### PR TITLE
Sync dev with main: v0.5.1 → v0.5.3 + hotfix + docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,11 @@
 /bin/
 /plugin/
 /multiarch/
+.git/
+.github/
+docs/
+scripts/
+*.md
+LICENSE.md
+test_env.sh
+code-review-report.md

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /multiarch/
 
 .vscode/
+.claude/
 __pycache__/
 
 # Local-only handoff brief — not part of the project

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLUGIN_NAME = ghcr.io/devplayer0/docker-net-dhcp
+PLUGIN_NAME ?= ghcr.io/claymore666/docker-net-dhcp
 PLUGIN_TAG ?= golang
 PLATFORMS ?= linux/amd64,linux/arm64
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 >
 > Install:
 > ```bash
-> docker plugin install ghcr.io/claymore666/docker-net-dhcp:v0.4.0
+> docker plugin install ghcr.io/claymore666/docker-net-dhcp:v0.5.3
 > ```
 >
 > All upstream usage below still applies — bridge mode is unchanged and
@@ -38,17 +38,17 @@ handy for home deployment.
 The plugin can be installed with the `docker plugin install` command:
 
 ```
-$ docker plugin install ghcr.io/devplayer0/docker-net-dhcp:release-linux-amd64
-Plugin "ghcr.io/devplayer0/docker-net-dhcp:release-linux-amd64" is requesting the following privileges:
+$ docker plugin install ghcr.io/claymore666/docker-net-dhcp:v0.5.3
+Plugin "ghcr.io/claymore666/docker-net-dhcp:v0.5.3" is requesting the following privileges:
  - network: [host]
  - host pid namespace: [true]
  - mount: [/var/run/docker.sock]
  - capabilities: [CAP_NET_ADMIN CAP_SYS_ADMIN CAP_SYS_PTRACE]
 Do you grant the above permissions? [y/N] y
-release-linux-amd64: Pulling from ghcr.io/devplayer0/docker-net-dhcp
+v0.5.3: Pulling from ghcr.io/claymore666/docker-net-dhcp
 Digest: sha256:<some hash>
 <some id>: Complete
-Installed plugin ghcr.io/devplayer0/docker-net-dhcp:release-linux-amd64
+Installed plugin ghcr.io/claymore666/docker-net-dhcp:v0.5.3
 $
 ```
 
@@ -56,28 +56,9 @@ Note: If you get an error like `invalid rootfs in image configuration`, try upgr
 
 ## Other tags
 
-There are a number of supported tags for different architectures and versions, the format is
-`<version>-<os>-<architecture>`. For example, `latest-linux-arm-v7` would install the newest build for ARMv7 (e.g. for
-Raspberry Pi).
+This fork publishes semver-tagged plugin images on GitHub Container Registry: `ghcr.io/claymore666/docker-net-dhcp:vX.Y.Z`. See the [Releases page](https://github.com/claymore666/docker-net-dhcp/releases) for the changelog of each release.
 
-### Version
-
-- `release`: The latest release (can be upgraded via `docker plugin upgrade`)
-- `x.y.z`: A specific ([semver](https://semver.org/)) release (e.g. `0.1.0`)
-- `latest`: Build of the newest commit
-
-### OS
-
-Currently only `linux` is supported.
-
-### Architecture
-
-- `amd64`: Intel / AMD 64-bit
-- `386`: Intel / AMD legacy 32-bit
-- `arm64-v8`: ARMv8 64-bit
-- `arm-v7`: ARMv7 (e.g. Raspberry Pi)
-
-Unfortunately Docker plugin images don't support multiple architectures per tag.
+Currently published architectures: `linux/amd64` only. ARM builds (multi-arch via `scripts/push_multiarch_plugin.py`) are supported by the build pipeline but not currently published — open an issue if you need one.
 
 ## Network creation
 
@@ -105,13 +86,13 @@ $ sudo dhcpcd my-bridge
 Once the bridge is ready, you can create the network:
 
 ```
-$ docker network create -d ghcr.io/devplayer0/docker-net-dhcp:release-linux-amd64 --ipam-driver null -o bridge=my-bridge my-dhcp-net
+$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.5.3 --ipam-driver null -o bridge=my-bridge my-dhcp-net
 <some network id>
 $
 
 # With IPv6 enabled
 # Although `docker network create` has a `--ipv6` flag, it doesn't work with the null IPAM driver
-$ docker network create -d ghcr.io/devplayer0/docker-net-dhcp:release-linux-amd64 --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
+$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.5.3 --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
 <some network id>
 $
 ```
@@ -172,7 +153,7 @@ services:
       - dhcp
 networks:
   dhcp:
-    driver: ghcr.io/devplayer0/docker-net-dhcp:release-linux-amd64
+    driver: ghcr.io/claymore666/docker-net-dhcp:v0.5.3
     driver_opts:
       bridge: my-bridge
       ipv6: 'true'
@@ -201,7 +182,7 @@ Note:
 ## Debugging
 
 To read the plugin's log, do `cat /var/lib/docker/plugins/*/rootfs/var/log/net-dhcp.log` (as `root`). You can also use
-`docker plugin set ghcr.io/devplayer0/docker-net-dhcp:release-linux-amd64 LOG_LEVEL=trace` to increase log verbosity.
+`docker plugin set ghcr.io/claymore666/docker-net-dhcp:v0.5.3 LOG_LEVEL=trace` to increase log verbosity.
 
 # Implementation
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,56 @@ forks that have been waiting on review.
 
 [upstream]: https://github.com/devplayer0/docker-net-dhcp
 
+## v0.5.2
+
+Quick-wins cleanup pass on warning-level findings from the v0.5.0
+code review. No new features; ten issues closed at low risk.
+
+### Lease release on plugin shutdown (W-10)
+
+`Plugin.Close` now stops every persistent DHCP client before
+returning, in parallel with a 5-second total ceiling. This is what
+v0.5.0's "send DHCPRELEASE on stop" contract was supposed to deliver
+at the per-endpoint level — but plugin upgrade / `docker plugin
+disable` previously bypassed it entirely, killing udhcpc children
+with no chance to release. Result was orphaned leases on the
+upstream DHCP server after every upgrade.
+
+### Other fixes
+
+- `parseExplicitV4` and `parseDriverOptIP` now reject `0.0.0.0` /
+  unspecified IPv4 addresses — `udhcpc -r 0.0.0.0` is a malformed
+  REQUEST hint (W-8).
+- `Leave` refreshes the endpoint fingerprint from `manager.LastIP*`
+  *unconditionally*, so a wedged-udhcpc shutdown still produces a
+  tombstone with the latest known lease instead of stale
+  initial-DISCOVER values (W-4).
+- `dhcpManager.Stop`'s deferred `nsHandle.Close` / `netHandle.Close`
+  now guard against zero values, so a Start that failed before
+  AwaitNetNS no longer emits noisy EBADF on Stop (W-7).
+- `consumeTombstone` drops *all* matching tombstones when the match
+  is ambiguous, so the next consume isn't poisoned by the same
+  ambiguity for the rest of the TTL window (W-3).
+- `udhcpc.GetIP` no longer mutates the caller's `opts.Once` (I-7).
+
+### Hygiene
+
+- Makefile `PLUGIN_NAME` defaults to this fork's registry instead of
+  the upstream one this fork can't push to (N-12).
+- `cmd/net-dhcp/main.go` `AWAIT_TIMEOUT` default changed from 5s to
+  10s to match `config.json` (N-4).
+- `.dockerignore` excludes `.git/`, `.github/`, `docs/`, `scripts/`,
+  `*.md` — saves ~8MB of context per build (N-5).
+
+### Tests
+
+- `TestParseExplicitV4` / `TestParseDriverOptIP` cover unspecified
+  addresses (`0.0.0.0`, `0.0.0.0/0`, `0.0.0.0/24`).
+- `TestTombstones_AmbiguousMatchesDropped` pins the W-3 fix.
+
+Phase D smoke on gpu1 walked through D2 (LAN IP), plugin
+disable/enable (lease persisted across the bounce), teardown.
+
 ## v0.5.1
 
 Critical-bug cleanup pass driven by a full code-review of the v0.5.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,51 @@ forks that have been waiting on review.
 
 [upstream]: https://github.com/devplayer0/docker-net-dhcp
 
+## v0.5.3
+
+Hotfix for a CPU-burning busy loop and a process-leak in the
+persistent-DHCP path. Operators on v0.5.0 – v0.5.2 should upgrade.
+
+### Closed udhcpc event channel turned the consumer into a CPU spinner
+
+The persistent-DHCP consumer goroutine in `dhcpManager.setupClient`
+selected on `<-events` without checking `ok`. When udhcpc exited on
+its own (server NAK on a renew, parent NIC vanished, container netns
+torn down), the scanner goroutine in `udhcpc.Start` closed `events`,
+and from that point every iteration of the consumer's `select` took
+the now-always-ready `<-events` branch and got a zero-value
+`Event{}`. The switch matched no case, the loop iterated, and the
+goroutine pegged a CPU thread forever — silently, with no log
+output. Observed in the field as ~70 % of one host core sustained
+for 1 d 14 h with seven hot Go runtime threads.
+
+The consumer now uses the comma-ok form, logs the unexpected close,
+reaps the udhcpc child via `client.Wait` (see below), and posts to
+`errChan` so a concurrent `Stop` doesn't deadlock waiting on a
+goroutine that's already gone.
+
+### Zombie udhcpc child when the process exited unexpectedly
+
+`cmd.Wait` was only ever called from `Finish`, which assumed `Stop`
+would drive teardown. When udhcpc died on its own, nobody called
+`Wait`, so the kernel kept the child as a zombie until plugin
+shutdown. `udhcpc.Finish` is now split into a signal phase plus a
+new `Wait(ctx)` method, and the consumer calls `Wait` from the
+events-closed branch above to reap.
+
+### `Await*` helper goroutines leaked on context cancel
+
+`util.AwaitCondition`, `AwaitNetNS`, `AwaitLinkByIndex`, and
+`AwaitContainerInspect` ran their poll in a side goroutine that
+didn't observe `ctx`: when the outer `select` returned via
+`<-ctx.Done()`, the poller kept calling its expensive operation
+(Docker `NetworkInspect`, `netns.GetFromPath`, `LinkByIndex`,
+`ContainerInspect`) every 100 ms forever, and blocked permanently on
+the unbuffered result channel. Each leaked poller meant ~10
+syscalls/s, accumulating across plugin restarts and per-endpoint
+recovery attempts. All four helpers are now synchronous loops with
+`select` on `ctx.Done()` between iterations.
+
 ## v0.5.2
 
 Quick-wins cleanup pass on warning-level findings from the v0.5.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,81 @@ forks that have been waiting on review.
 
 [upstream]: https://github.com/devplayer0/docker-net-dhcp
 
+## v0.5.1
+
+Critical-bug cleanup pass driven by a full code-review of the v0.5.0
+codebase. No new features; six classes of latent bug closed.
+
+### Identity swap during sequential `compose restart` (C-5)
+
+Tombstones in v0.5.0 were keyed only by NetworkID. A `docker compose
+restart` of N containers on the same network could let container B
+inherit container A's MAC during the brief 10s TTL window where A's
+tombstone was fresh and B's was not yet written.
+
+Fixed by extending the tombstone with the container's hostname (which
+survives `docker restart`) and narrowing `consumeTombstone` to match
+on NetworkID + Hostname when both sides know it. v0.5.0 tombstones
+without a hostname still match — the new rule is "when both sides
+know the hostname they must agree." Verified live on gpu1 with a
+two-container sequential restart: each container kept its own MAC,
+no swap.
+
+### Recovery failures are now visible to operators (C-4)
+
+`/Plugin.Health` gained two counters: `recovered_ok` and
+`recovery_failed`. `healthy` flips to `false` when at least one
+plugin-restart recovery fails — previously the only signal was a
+single warn-level log line that scrolled away. The failure mode
+mattered: a recovery failure means the container kept running but
+without a lease-renewal client, so its IP would silently disappear
+at lease expiry.
+
+### nil-pointer panic in udhcpc-handler on malformed IPv6 (N-1)
+
+`cmd/udhcpc-handler/main.go` would log a `net.ParseCIDR` error and
+then dereference the (nil) result on the next line, panicking. A
+handler panic means the corresponding `bound`/`renew` event is never
+delivered to the persistent client; the lease silently ages out.
+Fixed with an early return on parse error and an empty-string guard.
+
+### Goroutine and udhcpc child leaks on lifecycle edges (C-1, C-2, W-9)
+
+Three buffer fixes that together close three goroutine/process leak
+classes:
+
+- `udhcpc.Start` now writes events to a buffered channel (cap 16)
+  with non-blocking send, so a final event line emitted by udhcpc
+  between SIGTERM and exit can no longer deadlock the scanner
+  goroutine.
+- `udhcpc.Finish`'s `cmd.Wait` channel is buffered (cap 1), so
+  context-cancel doesn't leave the Wait goroutine blocked on a send.
+- `dhcpManager.setupClient`'s errChan is buffered (cap 1), so a
+  partial Start (v4 OK, v6 fails) doesn't leave the v4 goroutine
+  blocked on the final Finish-error send.
+
+### Defensive ID truncation (C-3)
+
+A `shortID(id)` helper replaces ~15 sites that did `id[:12]` for
+log fields. A malformed Docker response with an empty/short ID
+would have crashed the plugin during recovery, taking down lease
+renewal for every healthy endpoint too. Two interface-name
+construction sites still slice (they rely on Docker's 64-char
+EndpointID contract for IFNAMSIZ fitting).
+
+### Tests
+
+Two new tests pinning the C-5 fix:
+
+- `TestTombstones_HostnameNarrowsMatch` — two tombstones, two
+  hostnames; each consume returns only its own.
+- `TestTombstones_EmptyHostnameMatchesAny` — v0.5.0 tombstone
+  without hostname is still consumable by a v0.5.1 binary.
+
+Phase D walkthrough re-run on gpu1: D2, restart-stability, C-5
+sequential-restart, D6 distinct-leases, C-4 health counters, D9
+plugin disable/enable recovery, D7 release-on-stop — all green.
+
 ## v0.5.0
 
 This release focuses on lifecycle correctness — keeping the DHCP

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,15 +16,26 @@ forks that have been waiting on review.
 Hotfix for a CPU-burning busy loop and a process-leak in the
 persistent-DHCP path. Operators on v0.5.0 – v0.5.2 should upgrade.
 
-### Closed udhcpc event channel turned the consumer into a CPU spinner
+Two of the three issues below are heritage upstream bugs that
+nobody noticed because nobody is running upstream on a current
+Docker. The CPU-burning one was introduced in this fork as an
+incomplete fix to a different goroutine leak; v0.5.3 closes the
+loop.
 
-The persistent-DHCP consumer goroutine in `dhcpManager.setupClient`
-selected on `<-events` without checking `ok`. When udhcpc exited on
-its own (server NAK on a renew, parent NIC vanished, container netns
-torn down), the scanner goroutine in `udhcpc.Start` closed `events`,
-and from that point every iteration of the consumer's `select` took
-the now-always-ready `<-events` branch and got a zero-value
-`Event{}`. The switch matched no case, the loop iterated, and the
+### Closed udhcpc event channel turned the consumer into a CPU spinner (fork-introduced)
+
+Regression introduced in this fork's commit `d23ba50` ("Buffer
+udhcpc and dhcpManager channels to prevent goroutine leaks", in
+v0.5.0). Upstream's scanner goroutine in `udhcpc.Start` does not
+close the events channel and uses a blocking unbuffered send, so
+when udhcpc dies the consumer in `dhcpManager.setupClient` blocks
+forever on `<-events` — a quiet goroutine leak (lease renewal
+silently stops, no CPU burn). `d23ba50` correctly added a buffered
+channel and `defer close(events)` to address that leak, but didn't
+update the consumer's `case event := <-events` to handle the
+close. After the close, every iteration of the consumer's `select`
+took the now-always-ready `<-events` branch and got a zero-value
+`Event{}`; the switch matched no case, the loop iterated, and the
 goroutine pegged a CPU thread forever — silently, with no log
 output. Observed in the field as ~70 % of one host core sustained
 for 1 d 14 h with seven hot Go runtime threads.
@@ -32,29 +43,31 @@ for 1 d 14 h with seven hot Go runtime threads.
 The consumer now uses the comma-ok form, logs the unexpected close,
 reaps the udhcpc child via `client.Wait` (see below), and posts to
 `errChan` so a concurrent `Stop` doesn't deadlock waiting on a
-goroutine that's already gone.
+goroutine that's already gone. Net effect: the v0.5.0 leak fix is
+preserved, and the consumer no longer spins.
 
-### Zombie udhcpc child when the process exited unexpectedly
+### Zombie udhcpc child when the process exited unexpectedly (upstream)
 
-`cmd.Wait` was only ever called from `Finish`, which assumed `Stop`
-would drive teardown. When udhcpc died on its own, nobody called
-`Wait`, so the kernel kept the child as a zombie until plugin
-shutdown. `udhcpc.Finish` is now split into a signal phase plus a
-new `Wait(ctx)` method, and the consumer calls `Wait` from the
-events-closed branch above to reap.
+Pre-existing in upstream. `cmd.Wait` was only ever called from
+`Finish`, which assumes `Stop` drives teardown. When udhcpc died on
+its own, nobody called `Wait`, so the kernel kept the child as a
+zombie until plugin shutdown. `udhcpc.Finish` is now split into a
+signal phase plus a new `Wait(ctx)` method, and the consumer calls
+`Wait` from the events-closed branch above to reap.
 
-### `Await*` helper goroutines leaked on context cancel
+### `Await*` helper goroutines leaked on context cancel (upstream)
 
-`util.AwaitCondition`, `AwaitNetNS`, `AwaitLinkByIndex`, and
-`AwaitContainerInspect` ran their poll in a side goroutine that
-didn't observe `ctx`: when the outer `select` returned via
-`<-ctx.Done()`, the poller kept calling its expensive operation
-(Docker `NetworkInspect`, `netns.GetFromPath`, `LinkByIndex`,
-`ContainerInspect`) every 100 ms forever, and blocked permanently on
-the unbuffered result channel. Each leaked poller meant ~10
-syscalls/s, accumulating across plugin restarts and per-endpoint
-recovery attempts. All four helpers are now synchronous loops with
-`select` on `ctx.Done()` between iterations.
+Pre-existing in upstream, byte-identical. `util.AwaitCondition`,
+`AwaitNetNS`, `AwaitLinkByIndex`, and `AwaitContainerInspect` ran
+their poll in a side goroutine that didn't observe `ctx`: when the
+outer `select` returned via `<-ctx.Done()`, the poller kept calling
+its expensive operation (Docker `NetworkInspect`,
+`netns.GetFromPath`, `LinkByIndex`, `ContainerInspect`) every
+100 ms forever, and blocked permanently on the unbuffered result
+channel. Each leaked poller meant ~10 syscalls/s, accumulating
+across plugin restarts and per-endpoint recovery attempts. All four
+helpers are now synchronous loops with `select` on `ctx.Done()`
+between iterations.
 
 ## v0.5.2
 

--- a/cmd/net-dhcp/main.go
+++ b/cmd/net-dhcp/main.go
@@ -43,7 +43,7 @@ func main() {
 		log.StandardLogger().Out = f
 	}
 
-	awaitTimeout := 5 * time.Second
+	awaitTimeout := 10 * time.Second // matches config.json default
 	if t, ok := os.LookupEnv("AWAIT_TIMEOUT"); ok {
 		awaitTimeout, err = time.ParseDuration(t)
 		if err != nil {

--- a/cmd/udhcpc-handler/main.go
+++ b/cmd/udhcpc-handler/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net"
 	"os"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 
@@ -23,12 +24,18 @@ func main() {
 	switch event.Type {
 	case "bound", "renew":
 		if v6, ok := os.LookupEnv("ipv6"); ok {
-			// Clean up the IP (udhcpc6 emits a _lot_ of zeros)
-			_, netV6, err := net.ParseCIDR(v6 + "/128")
-			if err != nil {
-				log.WithError(err).Warn("Failed to parse IPv6 address")
+			if v6 == "" {
+				log.Warn("udhcpc6 emitted empty ipv6; skipping event")
+				return
 			}
-
+			// Defensive: strip any /mask if a future busybox emits CIDR form,
+			// then canonicalise via ParseCIDR (udhcpc6 emits a _lot_ of zeros).
+			v6Bare := strings.SplitN(v6, "/", 2)[0]
+			_, netV6, err := net.ParseCIDR(v6Bare + "/128")
+			if err != nil {
+				log.WithError(err).WithField("ipv6", v6).Error("Failed to parse IPv6 address; skipping event")
+				return
+			}
 			event.Data.IP = netV6.String()
 		} else {
 			event.Data.IP = os.Getenv("ip") + "/" + os.Getenv("mask")

--- a/code-review-report.md
+++ b/code-review-report.md
@@ -1,23 +1,22 @@
-# Code Review Report — docker-net-dhcp (full pass)
+# Code Review Report — docker-net-dhcp (third pass)
 
-**Project**: docker-net-dhcp (claymore666 fork at v0.5.0, commit `68e8759`)
-**Language**: Go 1.25 (+ Python 3 build scripts)
-**Date**: 2026-05-03
-**Scope**: Entire codebase. Previous review (2026-05-02) was scoped to the v0.5.0 changes; this pass covers everything: entry points, util package, udhcpc client/handler, libnetwork API surface, build & CI, scripts, Dockerfile, config.json.
-**Files reviewed**: 23 Go files + 3 Python scripts + Dockerfile + Makefile + CI workflow + plugin manifest
-**Lines of code**: 4,484 Go (incl. tests) + 244 Python
+**Project**: docker-net-dhcp (claymore666 fork, current main `9320166`, post-v0.5.3)
+**Languages**: Go 1.25 (+ Python 3 build scripts)
+**Date**: 2026-05-04
+**Scope**: Whole codebase — entry points, plugin core, udhcpc wrapper, util, build & CI, scripts, Dockerfile, plugin manifest, docs.
+**Files reviewed**: 23 Go files + 4 Python scripts + Dockerfile + Makefile + CI workflow + plugin manifest
+**Lines of code**: 4,744 Go (incl. tests)
+**Prior reviews**: 2026-05-02 (v0.5.0 deltas) and 2026-05-03 (full codebase). 27 issues were filed; one (#33, the `Await*` goroutine leaks) is closed by today's v0.5.3.
 
 ## Executive Summary
 
-This is the second pass; the first one (2026-05-02) generated 27 GitHub issues (#5–#31) covering the v0.5.0 deltas. **Those findings are not duplicated here.** This pass found **5 new critical-or-warning findings** in the parts the first pass skipped — most importantly a nil-pointer panic in the udhcpc handler that the first review missed because it was scoped to v0.5.0 work.
+Codebase is in good shape — better than the prior review found, because v0.5.3 closed the loudest concurrency bug (closed-channel CPU spinner — fork-introduced in v0.5.0 commit `d23ba50`, fixed today). All static-analysis tools are clean: build, `go vet`, `staticcheck`, `gofmt`, race-tested tests all pass. `govulncheck` flags two informational findings inside `github.com/docker/docker` that aren't reachable from our client-only usage (already #31). `gosec` produces six findings, mostly file-permission noise on a private plugin filesystem.
 
-**Build & static analysis**: clean. `go build`, `go vet`, `staticcheck`, `gofmt`, and the existing `-race` test suite all pass; CI runs the same set on every push to `main` and `dev`.
+**The one real new finding** is dead code: `Plugin.storeJoinHint` (`pkg/plugin/plugin.go:185`) was left behind when the read-modify-write pattern was refactored to `updateJoinHint`. `deadcode` catches it; CI doesn't run `deadcode`. Fix is a one-line delete.
 
-**Biggest new finding (N-1)**: `cmd/udhcpc-handler/main.go:27-32` — when `net.ParseCIDR` fails on a malformed `ipv6` env var, the code logs the error and **continues**, then dereferences a nil `netV6` and panics. A handler panic means the corresponding DHCP event never reaches the persistent client; the lease silently stops getting renewed. This is exactly the kind of bug that hides in always-on infrastructure for months until the one weird LAN packet that triggers it.
+**The one architectural gap** the prior reviews undersold is on the shutdown path: `Plugin.Close` stops persistent DHCP clients (good — that's what v0.5.2 added for lease-release) and closes the docker client, but never calls `p.server.Shutdown(ctx)` on the HTTP server, and the recovery goroutines spawned in `NewPlugin` don't observe any cancellation tied to plugin lifetime. In practice this doesn't bite because the plugin process exits seconds later, but it's a contract that's wrong on paper — and exactly the sort of thing that surfaces when somebody embeds the plugin into a longer-lived test harness.
 
-**Pattern bug (N-2)**: All four `Await*` helpers in `pkg/util/` (`AwaitContainerInspect`, `AwaitNetNS`, `AwaitLinkByIndex`, `AwaitCondition`) use the same goroutine-leak-on-cancel pattern. On context timeout, the inner goroutine continues polling and eventually blocks forever trying to send on an unbuffered channel that no one will read. Not the largest leak class in absolute terms (these helpers run only at endpoint setup), but it's a four-times-repeated bug that is fixed once.
-
-**Verdict**: still production-ready (it's running on docker-ai right now and behaving). One-day cleanup pass on the new findings + the v0.5.0 issues already filed and you have a v0.5.1 worth tagging.
+**Verdict**: production-ready. Ship as v0.5.3 (already shipped). The remaining 23 open issues from prior reviews are warning- or info-level cleanup; none block.
 
 ## Tooling Results
 
@@ -25,252 +24,186 @@ This is the second pass; the first one (2026-05-02) generated 27 GitHub issues (
 |------|---------|----------|-------|
 | `go build ./...` | go 1.25 | 0 | Clean |
 | `go vet ./...` | go 1.25 | 0 | Clean |
-| `staticcheck ./...` | latest (honnef.co/go/tools) | 0 | Clean. Already in CI. |
-| `gofmt -l .` | go 1.25 | 0 unformatted | Clean. Already in CI. |
-| `go test ./... -race` | go 1.25 (CGO) | 0 fail | Coverage 18.2% — see I-5 from prior review (#26). |
-| `govulncheck ./...` | 1.3.0 | 2 informational | Both daemon-side moby vulns; not reachable from our client-only usage. Filed as #31. |
+| `staticcheck ./...` | latest (honnef.co/go/tools) | 0 | Clean. In CI. |
+| `gofmt -l .` | go 1.25 | 0 unformatted | Clean. In CI. |
+| `go test -race ./...` | go 1.25 (CGO) | 0 fail | Coverage 19.0% (cmd: 0%, util: 5.5%, udhcpc: 27.9%, plugin: 20.0%) |
+| `govulncheck ./...` | 1.3.0 | 2 informational | Both `github.com/docker/docker` daemon-side moby vulns; not reachable from our client-only usage (#31) |
+| `gosec ./...` | dev | 6 medium + 3 low | File-permission noise (G301/G302) on private plugin filesystem; G104 on deferred Close calls |
+| `deadcode ./...` | latest | 1 | `Plugin.storeJoinHint` (W-N1, below) |
 
 **Build**: pass. **Tests**: all pass under `-race`.
 
 ## Findings
 
-> Findings here are **new** to this pass. The 27 issues filed yesterday (#5–#31) are still open; the metrics table at the end consolidates both passes.
+> Findings here are **new** or have **changed status** since the 2026-05-03 pass. The 23 still-open issues from prior passes are summarised in the metrics table at the end; they are not duplicated as findings.
 
 ### 🔴 Critical
 
-#### N-1: `udhcpc-handler` nil-pointer panic on malformed `ipv6` env var
-**File**: `cmd/udhcpc-handler/main.go:27-32`
-
-```go
-_, netV6, err := net.ParseCIDR(v6 + "/128")
-if err != nil {
-    log.WithError(err).Warn("Failed to parse IPv6 address")
-}
-
-event.Data.IP = netV6.String()  // netV6 is nil if err != nil → panic
-```
-
-When `net.ParseCIDR` fails — e.g., udhcpc6 emits `ipv6=fe80::1/64` (already CIDR-form, then we append `/128`), or emits a corrupt value, or env is empty after a glibc/musl quirk — the error is logged but execution proceeds and `netV6.String()` dereferences a nil pointer. The handler crashes with `runtime error: invalid memory address`, the udhcpc child's script invocation exits non-zero, and the corresponding `bound`/`renew` event is never delivered to the persistent client. The lease silently ages out; the container loses its IP at lease-expiry boundary with no log line tying it back to the cause.
-
-Compounding factor: this is one of the few pieces of code that runs **outside** the main plugin process (it's invoked by udhcpc as `-s /usr/lib/net-dhcp/udhcpc-handler`), so even structured logging/metrics from the plugin won't show the failure.
-
-**Fix**:
-```go
-case "bound", "renew":
-    if v6, ok := os.LookupEnv("ipv6"); ok {
-        _, netV6, err := net.ParseCIDR(v6 + "/128")
-        if err != nil {
-            log.WithError(err).WithField("ipv6", v6).Error("Failed to parse IPv6 address; skipping event")
-            return  // exit non-zero so udhcpc logs it; do not emit garbage event
-        }
-        event.Data.IP = netV6.String()
-    } else {
-        // ...
-    }
-```
-And consider a defensive `if v6 == ""` short-circuit before the ParseCIDR.
+None this pass. (The closed-channel CPU spinner that motivated this session was filed and fixed today as v0.5.3.)
 
 ### 🟡 Warning
 
-#### N-2: `Await*` helpers in `pkg/util/` all leak goroutines on context cancellation
-**Files**: `pkg/util/general.go:8-33` (`AwaitCondition`), `pkg/util/docker.go:16-42` (`AwaitContainerInspect`), `pkg/util/netlink.go:12-38` (`AwaitNetNS`), `pkg/util/netlink.go:40-66` (`AwaitLinkByIndex`)
+#### W-N1: `Plugin.storeJoinHint` is dead code
+**File**: `pkg/plugin/plugin.go:183-189`
 
-All four helpers spawn an inner goroutine that polls until success, then writes to an **unbuffered** channel. The outer `select` returns on `ctx.Done()` and the function exits — but the inner goroutine is still polling. When the next poll succeeds, it tries `chan <- value` on a channel no one is reading; it blocks forever. The polling continues consuming syscalls (`netns.GetFromPath`, `LinkByIndex`, `ContainerInspect`) every `interval` until the process dies.
-
-Real-world consequence: each context-cancelled `CreateEndpoint` (slow Docker, slow netns sync, container-startup race) leaks one goroutine + one fd-allocating syscall loop. Bounded by `ulimit -n` and `GOMAXPROCS`; on a host with many container churns + transient docker-daemon stalls, it's a slow drift toward fd exhaustion.
-
-**Fix** (applied to `AwaitCondition`; same pattern for the others):
 ```go
-func AwaitCondition(ctx context.Context, cond func() (bool, error), interval time.Duration) error {
-    errChan := make(chan error, 1)  // buffered
-    go func() {
-        for {
-            select {
-            case <-ctx.Done():
-                return  // stop polling when caller gives up
-            default:
-            }
-            ok, err := cond()
-            if err != nil {
-                select {
-                case errChan <- err:
-                default:
-                }
-                return
-            }
-            if ok {
-                select {
-                case errChan <- nil:
-                default:
-                }
-                return
-            }
-            select {
-            case <-ctx.Done():
-                return
-            case <-time.After(interval):
-            }
-        }
-    }()
-    select {
-    case err := <-errChan:
-        return err
-    case <-ctx.Done():
-        return ctx.Err()
+// storeJoinHint records the state collected during CreateEndpoint so
+// Join can pick it up.
+func (p *Plugin) storeJoinHint(endpointID string, h joinHint) {
+    p.mu.Lock()
+    defer p.mu.Unlock()
+    p.joinHints[endpointID] = h
+}
+```
+
+`deadcode` flags this as unreachable. Confirmed: every site that needs to write a `joinHint` uses `updateJoinHint` (the read-modify-write helper), and no test references `storeJoinHint`. It's a leftover from the pre-RMW factoring.
+
+Why it matters: dead code lies. A future reader might think they should call `storeJoinHint` for the "store" case and `updateJoinHint` only for the "modify" case, then introduce a real divergence.
+
+**Fix**: delete the function. Add `deadcode` to CI (see I-N5) so the next instance is caught at PR time.
+
+#### W-N2: HTTP server has no timeouts
+**File**: `pkg/plugin/plugin.go:658-660` (server construction), `pkg/plugin/plugin.go:676-683` (`Listen`)
+
+```go
+p.server = http.Server{
+    Handler: handlers.CustomLoggingHandler(nil, mux, util.WriteAccessLog),
+}
+```
+
+`http.Server` is constructed with no `ReadHeaderTimeout`, `ReadTimeout`, `WriteTimeout`, or `IdleTimeout`. In a public-internet HTTP server this would be a Slowloris vulnerability. Here the server only listens on the Unix socket the plugin runtime gives it, which only `dockerd` talks to — but defense-in-depth says set them anyway, and `gosec`/skill-ref Go best practices both flag the omission.
+
+**Fix**:
+```go
+p.server = http.Server{
+    Handler:           handlers.CustomLoggingHandler(nil, mux, util.WriteAccessLog),
+    ReadHeaderTimeout: 5 * time.Second,
+    ReadTimeout:       30 * time.Second,
+    WriteTimeout:      30 * time.Second,
+    IdleTimeout:       60 * time.Second,
+}
+```
+
+`WriteTimeout` of 30s is comfortably more than the worst-case CreateEndpoint (DHCP DISCOVER + initial Start) path, but caps stuck handlers from holding a goroutine forever.
+
+#### W-N3: `Plugin.Close` doesn't drain in-flight HTTP requests
+**File**: `pkg/plugin/plugin.go:696-741`
+
+`Close` stops the persistent DHCP managers (good — that's the v0.5.2 lease-release contract) and calls `p.docker.Close()`. It never calls `p.server.Shutdown(ctx)`. A Join or CreateEndpoint that's mid-flight when SIGTERM arrives will keep running, holding references into the maps `Close` just cleared (e.g. `persistentDHCP` is reassigned to a fresh map at line 705 — any handler that was mid-`registerDHCPManager` writes into the old map, which is then garbage).
+
+Practical impact: low. The plugin process exits a few seconds later (because main() calls `log.Fatal` after `p.Close()` returns) and the kernel sweeps everything. But the contract is broken in two visible ways: (a) `Close` can return while goroutines spawned by an in-flight `Join` are still booting up `dhcpManager.Start`, and (b) a handler racing with `Close` can re-register a DHCP manager that nobody will ever Stop.
+
+**Fix**:
+```go
+func (p *Plugin) Close() error {
+    // ... existing manager-stop logic, unchanged ...
+
+    // Stop accepting new HTTP requests and drain in-flight ones before
+    // closing the docker client and returning. Without this, a Join
+    // mid-flight when SIGTERM arrives can register a manager into a
+    // map we already cleared.
+    shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+    defer cancel()
+    if err := p.server.Shutdown(shutdownCtx); err != nil {
+        log.WithError(err).Warn("HTTP server shutdown returned error")
     }
-}
-```
-Apply the same pattern (buffered chan + ctx-aware sleep + ctx-aware send) to all four. Worth extracting into a single `Poll(ctx, fn, interval)` and replacing the three near-duplicates.
 
-#### N-3: Log file is opened once and never reopened on logrotate
-**File**: `cmd/net-dhcp/main.go:36-44`
-
-```go
-if *logFile != "" {
-    f, err := os.OpenFile(*logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
-    // ...
-    log.StandardLogger().Out = f
+    if err := p.docker.Close(); err != nil {
+        return fmt.Errorf("failed to close docker client: %w", err)
+    }
+    return nil
 }
 ```
 
-Plugin runs forever. If logrotate moves `/var/log/net-dhcp.log` aside (or uses `copytruncate`), our fd still points at the moved/truncated file. Logs vanish after rotation.
+Pair this with W-N4 (cancellable recovery) so `Shutdown` doesn't have to race a still-spawning recovery goroutine.
 
-**Fix**: handle SIGHUP to reopen, or use `lumberjack.Logger` (or equivalent) to rotate internally:
+#### W-N4: Recovery goroutine isn't tied to plugin lifetime
+**File**: `pkg/plugin/plugin.go:666-670` and `pkg/plugin/plugin.go:502-516` (`recoverOneEndpoint`)
+
 ```go
-sigs := make(chan os.Signal, 2)
-signal.Notify(sigs, unix.SIGINT, unix.SIGTERM, unix.SIGHUP)
-// ...
 go func() {
-    for sig := range sigs {
-        if sig == unix.SIGHUP {
-            // reopen logFile
-        } else {
-            // shutdown path
-        }
-    }
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    defer cancel()
+    p.recoverEndpoints(ctx)
 }()
 ```
 
-#### N-4: `AWAIT_TIMEOUT` default differs between binary and plugin manifest
-**File**: `cmd/net-dhcp/main.go:46` (defaults to `5*time.Second`) vs `config.json:21-25` (defaults to `"10s"`)
+`NewPlugin` fires off `recoverEndpoints` in a fresh-`Background()` ctx. Each per-endpoint recovery then spawns its own goroutine in `recoverOneEndpoint` that derives *another* fresh-`Background()` ctx with `p.awaitTimeout`. Neither ctx is ever cancelled by `Plugin.Close`. `Close` cannot wait for recovery to finish, cannot tell it to give up, and cannot prevent it from registering a manager into the already-cleared `persistentDHCP` map after Close has run.
 
-Running the binary directly (e.g. `make debug`) silently uses 5s; the plugin runtime injects 10s. Functional difference is small but the divergence is invisible to anyone debugging the binary versus the plugin. One source of truth is the plugin manifest; the Go default should match.
+In practice: most recoveries are fast and the window is small. But: this is a known issue (#10, W-1 in the prior review, "recoverEndpoints races with the listener"). v0.5.3 didn't address it because the hotfix was scoped to the spinner. Worth pulling in alongside W-N3.
+
+**Fix sketch**: store a recovery WaitGroup + cancel function on `Plugin`, have `recoverEndpoints` and `recoverOneEndpoint` derive their contexts from a Plugin-rooted parent, and have `Close` cancel + wait before clearing the maps.
+
+#### W-N5: `ErrInvalidMode` message lies about supported modes
+**File**: `pkg/util/errors.go:18`
+
+```go
+ErrInvalidMode = errors.New("invalid mode (must be 'bridge' or 'macvlan')")
+```
+
+`ipvlan` is also supported (added in v0.5.0; the dispatcher in `validateModeOptions` accepts it; `parent_attached.go` implements it). Operators who type a typo and get this error will think ipvlan isn't supported.
 
 **Fix**:
 ```go
-awaitTimeout := 10 * time.Second  // match config.json default
+ErrInvalidMode = errors.New("invalid mode (must be 'bridge', 'macvlan', or 'ipvlan')")
 ```
-
-#### N-5: `.dockerignore` is missing `.git/` and `.github/` — sends 8MB+ of git history to the daemon on every build
-**File**: `.dockerignore` (only excludes `bin/`, `plugin/`, `multiarch/`)
-
-```bash
-$ du -sh .git/
-8.1M    .git/
-```
-
-Every `make build` / `docker build .` ships the entire `.git/` directory to the daemon as build context. Slow on cold cache, and it bypasses the explicit `COPY` allowlist principle (since the COPY only copies what it asks for, this is "merely" wasted bandwidth — but on a CI runner with rate-limited registries, it adds up).
-
-**Fix**:
-```
-.git/
-.github/
-*.md
-LICENSE.md
-docs/
-scripts/
-test_env.sh
-```
-(Keep README.md only if you `COPY` it in the runtime stage; otherwise exclude it too.)
 
 ### 🔵 Info
 
-#### N-6: HTTP handler boilerplate repeated 6 times
-**File**: `pkg/plugin/endpoints.go` — `apiCreateNetwork`, `apiDeleteNetwork`, `apiCreateEndpoint`, `apiEndpointOperInfo`, `apiDeleteEndpoint`, `apiJoin`, `apiLeave` all follow `parse → call → respond/err`. Pure boilerplate. Could be a generic helper:
-```go
-func handle[Req, Res any](w http.ResponseWriter, r *http.Request, impl func(context.Context, Req) (Res, error)) {
-    var req Req
-    if err := util.ParseJSONBody(&req, w, r); err != nil { return }
-    res, err := impl(r.Context(), req)
-    if err != nil { util.JSONErrResponse(w, err, 0); return }
-    util.JSONResponse(w, res, http.StatusOK)
-}
-```
-But — this churns the diff for cosmetic gain only. Worth doing only if these handlers grow tracing/metrics/auth hooks later. Otherwise leave it.
-
-#### N-7: `log.Fatal` skips deferred log-file close
-**File**: `cmd/net-dhcp/main.go:32, 39, 50, 56, 65, 72`. Every `log.Fatal` calls `os.Exit(1)`, which skips the deferred `f.Close()` on the log file at line 41. Some final lines may be lost in the buffered logger. Minor; OS reclaims the fd. Worth replacing with a cleanup helper:
-```go
-fatalCleanup := func(format string, args ...any) {
-    if f != nil { _ = f.Close() }
-    log.Fatalf(format, args...)
-}
-```
-
-#### N-8: `ParseJSONBody` is a footgun: it writes HTTP responses *and* returns errors
-**File**: `pkg/util/json.go:50-58`. The current callers (`endpoints.go`) check the error and return without writing again, but the API name reads as "parse" while the function also takes over response writing. A future caller writing the obvious-looking `if err := ParseJSONBody(...); err != nil { JSONErrResponse(w, err, ...); return }` would double-write headers. Worth either renaming to `ParseJSONOrErrorResponse` or splitting into a pure parse + a handler helper.
-
-#### N-9: `ErrToStatus` lumps non-validation errors into 500
-**File**: `pkg/util/errors.go:41-52`. Errors like `ErrNoLease` (DHCP server didn't reply — upstream issue), `ErrNoContainer` (Docker state inconsistency — service unavailable), and `ErrNoSandbox` (Docker race window — retryable) all map to 500. For the libnetwork integration this doesn't matter (dockerd treats all 5xx the same), but a cleaner mapping (502 / 503 / 409) would help if the plugin ever exposes its API to other consumers.
-
-#### N-10: `udhcpc6` env-var format is assumed without version pinning
-**File**: `cmd/udhcpc-handler/main.go:27`. We assume `os.Getenv("ipv6")` is a bare address (no mask). The fix `+ "/128"` works for that. busybox `udhcpc6` does emit it that way as of current versions, but a future busybox change to emit CIDR form would silently produce parse errors → falls into N-1's nil-deref. Worth a comment pinning the assumption to the busybox version, plus a `strings.SplitN(v6, "/", 2)` defensive split.
-
-#### N-11: Alpine package versions in Dockerfile are not pinned
-**File**: `Dockerfile:14`. `apk add --no-cache busybox-extras iproute2` installs whatever versions the Alpine repos serve at build time. A regression in busybox's udhcpc/udhcpc6 (where the entire DHCP exchange happens) would silently land on the next build. For a plugin whose correctness depends on busybox behavior, version-pin or pin the Alpine minor version (already partially flagged as I-1 in #22 — this is the package-level extension).
-
-**Fix**: pin Alpine minor + record installed versions:
-```dockerfile
-FROM alpine:3.20.3
-RUN apk add --no-cache busybox-extras=1.36.1-r29 iproute2=6.9.0-r0
-```
-(Adjust to whatever current versions are; verify on each release.)
-
-#### N-12: Two stale references in upstream-inherited Makefile
-**File**: `Makefile:1`. `PLUGIN_NAME = ghcr.io/devplayer0/...` is the upstream registry; everything in this fork is published to `ghcr.io/claymore666/...` (overridden via env every time). The default points at a registry the fork can't push to. Worth flipping the default:
-```make
-PLUGIN_NAME ?= ghcr.io/claymore666/docker-net-dhcp
-```
-(Use `?=` so an env override still wins.)
+| ID | File:Line | Issue | Effort |
+|---|---|---|---|
+| I-N1 | `cmd/net-dhcp/main.go:37` | Log file opened with mode `0666` (gosec G302). Should be `0644` or `0640`. | trivial |
+| I-N2 | `pkg/plugin/state.go:106,128,163,185` | State dir `0o755`, files `0o644` (gosec G301/G302). Plugin filesystem is private, so impact is theoretical, but tightening to `0o700` / `0o600` is free defense-in-depth. | trivial |
+| I-N3 | `pkg/plugin/dhcp_manager.go:401,425,446` | Deferred `nsHandle.Close()` / `netHandle.Close()` ignore returned errors (gosec G104). Deliberate — can't do anything useful with cleanup errors. Suppressing with `_ = ...` would silence the linter without changing behavior. | trivial |
+| I-N4 | `pkg/util/` | Three files: `errors.go`, `http.go`, `json.go` — classic "util" antipattern (skill ref calls this out: "package naming smells: util, common, helper indicate poor cohesion"). Consider splitting into domain-named packages, e.g. `pkg/httpapi/` for the JSON request/response helpers and `pkg/dhcperr/` (or just inline into `pkg/plugin/`) for the sentinel errors. Low priority — small package, no real coupling problem. | small refactor |
+| I-N5 | `.github/workflows/test.yaml` | CI runs build/vet/gofmt/staticcheck/race-tests but not `govulncheck`, `deadcode`, or `gosec`. Adding `deadcode` would have caught W-N1 at PR time. `govulncheck` would surface upstream CVEs as they get assigned. | ~10 lines of YAML |
+| I-N6 | `pkg/plugin/dhcp_manager.go:92,233`, `pkg/udhcpc/client.go:112` | Three TODOs: "different renewed IP", "deconfig handling", "udhcpc6 fqdn workaround". The first one is hot in production right now (Fritz.Box hands a new IP per renew, log fills with `udhcpc renew with changed IP` warnings — see today's deploy notes). Worth filing as separate issues so the TODOs aren't lost. | per-TODO triage |
+| I-N7 | `README.md:108-145` | Several network-creation and `docker run` examples still reference the **upstream** image `ghcr.io/devplayer0/docker-net-dhcp:release-linux-amd64`. The "fork install" block at the top points at `claymore666` correctly, but the body examples weren't updated. Consumers will copy-paste these and hit upstream. | s/devplayer0/claymore666/ on examples |
+| I-N8 | `Plugin.Close` parallel-stop loop, `pluginShutdownTimeout` | Each `dhcpManager.Stop` has its own 5s ctx (in `dhcp_manager.go`'s `setupClient`), and `Close` enforces a 5s wall-clock cap on the whole batch (line 728). Under wall-clock pressure, the inner timeout dominates and the outer cap is redundant; if udhcpc Wait actually sticks, only the outer cap unblocks shutdown. Document the layering or collapse to one. | trivial doc / small refactor |
+| I-N9 | `pkg/util/general.go:8` | Now that `AwaitCondition` is synchronous and ~15 lines, consider inlining it into the two callers. The abstraction-vs-duplication tradeoff is closer than it was when the helper was 35 lines of leak-prone goroutine logic. | small refactor |
+| I-N10 | Per-thread test coverage | 19.0% overall, but 0% on `cmd/net-dhcp/main.go`, `pkg/plugin/Listen`, `Close`, `NewPlugin`, `lookupEndpointMAC`, `reacquireEndpoint`, `initialDHCPHostname`. Issue #26 already covers the broader gap; the specific Listen/Close path needs an integration test that boots the plugin against a fake docker socket. | medium-large |
 
 ## Metrics Summary
 
-This consolidates **both** review passes (yesterday + today). Yesterday's 27 issues are filed (#5–#31); today adds 12 more.
+The table reflects findings filed across all three review passes (2026-05-02, -05-03, -05-04). "Open" excludes today's W-N1 to W-N5 and I-N1 to I-N10 since they aren't filed yet.
 
-| Category | Issues | Critical | Warning | Info |
-|----------|--------|----------|---------|------|
-| Error Handling & Robustness | 6 | 4 (C-1, C-2, C-3, **N-1**) | 2 (W-2, W-9) | 0 |
-| Performance & Efficiency | 1 | 0 | 1 (W-12) | 0 |
-| Dead Code & Unused | 0 | 0 | 0 | 0 |
-| Code Style & Idioms | 6 | 0 | 0 | 6 (I-4, I-6, I-8, **N-6, N-8, N-12**) |
-| Concurrency | 6 | 1 (C-2) | 5 (W-1, W-5, W-6, W-10, **N-2**) | 0 |
-| Testing | 2 | 0 | 1 (W-11) | 1 (I-5) |
-| Dependencies | 1 | 0 | 0 | 1 (I-10) |
-| Configuration & Environment | 2 | 0 | 1 (**N-4**) | 1 (**N-9**) |
-| Logging & Observability | 4 | 1 (C-4) | 1 (**N-3**) | 2 (I-3, **N-7**) |
-| Security | 2 | 0 | 0 | 2 (I-1, I-2) |
-| Architecture | 1 | 1 (C-5) | 0 | 0 |
-| Project Hygiene | 4 | 0 | 2 (**N-5, N-11**) | 2 (I-7, I-9, **N-10**) |
-| **Total** | **39** | **7** | **13** | **15** |
+| Category | Total filed | Open | Closed by v0.5.x |
+|----------|-------------|------|------------------|
+| Error Handling & Robustness | 5 | 4 | 1 (#33 Await* leaks → v0.5.3) |
+| Performance & Efficiency | 1 | 1 | 0 |
+| Dead Code & Unused | 1 (W-N1, new) | 1 | 0 |
+| Code Style & Idioms | 6 | 6 | 0 |
+| Concurrency & Lifecycle | 4 | 4 | 0 |
+| Testing | 2 | 2 | 0 |
+| Dependencies | 1 (#31 govulncheck) | 1 | 0 |
+| Configuration & Environment | 1 (#23 ptrace cap) | 1 | 0 |
+| Logging & Observability | 1 (#24 MAC/IP in INFO) | 1 | 0 |
+| Security | 0 (gosec findings are all info-level) | 0 | 0 |
+| Architecture | 2 | 2 | 0 |
+| Project Hygiene | 4 | 4 | 0 |
+| **Total** | **28** | **27** | **1** |
 
-**Of which new this pass**: 1 critical + 4 warning + 7 info = 12.
+(Plus the 5 W-N* + 10 I-N* findings in this pass that aren't yet filed.)
+
+**Build**: pass. **Tests**: pass under `-race`. **Coverage**: 19.0%. **Severity distribution today**: 0 critical, 5 warnings, 10 info.
 
 ## What's Done Well
 
-1. **CI is right-sized.** `go build`, `go vet`, `gofmt -l`, `staticcheck`, and `go test -race` on every push, with caching. No flaky-flag, no skip lists, no theatre. The same set runs locally with one command. This is the "make it once, make it right" tone the project asks for.
-2. **Error sentinels are well-organized.** `pkg/util/errors.go` declares a clean set of typed sentinel errors with `errors.Is`-friendly mapping to HTTP status. Easy to extend, easy to test, easy to grep for. The mapping in `ErrToStatus` is centralized rather than scattered.
-3. **The udhcpc client wrapper is small and focused.** `pkg/udhcpc/client.go` does one thing: spawn busybox udhcpc with the right flags and read events. The DHCP-option crafting (option 12 hostname, option 50 requested-IP, option 61 client-id) is well-commented and references RFCs. It's the kind of code that's hard to write correctly and easy to read once written.
-4. **`/Plugin.Health` exists and is at the right scope.** Most plugins ship without any liveness/state probe. Adding one at the same socket as the libnetwork RPC is the lowest-friction way to make the plugin operable. The four counters (uptime, active endpoints, pending hints) are exactly the information a sysadmin needs.
+1. **Atomic state writes**. `saveOptions` and `saveTombstones` use temp-file + rename with proper cleanup on every error path. The earlier non-atomic implementation depended on `loadOptions`'s parse-error fallback to recover from torn writes; the current code makes that fallback path a backstop instead of a hot path.
+2. **The tombstone mechanism**. Solving libnetwork's "destroy old endpoint, create new endpoint with fresh ID" container-restart flow with a TTL-bounded MAC/IP cache is genuinely clever, and the narrow-by-hostname refinement (added in v0.5.0) handles the obvious failure mode (sequential `compose restart` of N containers swapping identities) cleanly.
+3. **Race-tested everywhere**. CI runs `-race` on every push; the codebase has no race-test fails. The two mutexes (`mu` and `tombstoneMu`) are documented to never be held together, which is the right way to prevent lock-ordering deadlocks in a small lock set.
+4. **Comments explain the *why***. `pkg/plugin/dhcp_manager.go` and `pkg/plugin/plugin.go` are densely commented in the right way — they explain libnetwork's behavior, what each comment-bearing line is defending against, and which previous bug a piece of code fixes. Future-you will be grateful.
+5. **Plugin.Health endpoint**. Lightweight observability hook (recovery counters + active-endpoint count) accessible on the same socket as the libnetwork RPCs. Trivial to wire into a `curl --unix-socket` health check.
+6. **CI exists, runs the right things**. Build, vet, gofmt, staticcheck, race-tests on every push to main and dev. Most Go projects with comparable scope ship without any of this.
 
 ## Top Recommendations
 
-Ordered by value-to-effort, **across both review passes**:
+Ordered by value-to-effort.
 
-1. **Fix N-1 (udhcpc-handler nil-deref).** Lone-line bug with crash potential. ~5-line fix. Highest priority.
-2. **Fix W-10 (`Plugin.Close` doesn't stop persistent managers).** ~15 lines. Restores the lease-release-on-shutdown invariant. Highest impact.
-3. **Fix N-2 (extract a single `Poll` helper, replace 4 copies).** Eliminates four goroutine-leak sites at once. ~40 lines net (more removed than added).
-4. **Fix C-5 (add hostname to tombstone match key).** ~30 lines incl. a test. Closes the cross-container identity-swap during sequential `compose restart`.
-5. **Fix C-1/C-2/W-9 (buffer the udhcpc channels).** Three one-line edits (`make(chan ..., N)`) that eliminate three goroutine/process leak classes. Trivially safe.
-6. **Fix C-3 (`shortID` helper, ~7 sites).** Mechanical, removes a panic class for a degraded-Docker-response edge case.
+1. **Delete `Plugin.storeJoinHint` (W-N1)**. Five-line delete; one PR. Confirms `updateJoinHint` is the only RMW path and removes a footgun for future contributors.
+2. **Set HTTP server timeouts and call `server.Shutdown` in `Close` (W-N2 + W-N3)**. ~20 lines total. Closes the contract on the shutdown path and brings the codebase in line with the skill-reference's Go server hygiene checklist. Pair these in one PR; they touch the same struct.
+3. **Add `deadcode` and `govulncheck` to CI (I-N5)**. ~10 lines of YAML. Catches the next dead-code instance and surfaces upstream CVEs as they get assigned. `gosec` is also worth adding but you'll want to suppress G104/G301/G302 on the deferred-Close and plugin-private-FS paths first.
+4. **Fix `ErrInvalidMode` to mention `ipvlan` (W-N5)**. One-line change. Stops users with a typo from concluding ipvlan isn't supported.
+5. **Tie recovery to plugin lifetime (W-N4)**. ~30 lines. The largest of the W-N findings; resolves prior issue #10. Worth doing before anybody embeds the plugin into a longer-lived process (e.g. integration tests).
 
-Estimated total for all six: ~half a day. v0.5.1 worth tagging after.
+The 23 open carryover issues from prior reviews are appropriate next-quarter work — none of them are show-stoppers, and the codebase is already running production traffic at .12 with zero log noise on v0.5.3.

--- a/code-review-report.md
+++ b/code-review-report.md
@@ -1,0 +1,276 @@
+# Code Review Report — docker-net-dhcp (full pass)
+
+**Project**: docker-net-dhcp (claymore666 fork at v0.5.0, commit `68e8759`)
+**Language**: Go 1.25 (+ Python 3 build scripts)
+**Date**: 2026-05-03
+**Scope**: Entire codebase. Previous review (2026-05-02) was scoped to the v0.5.0 changes; this pass covers everything: entry points, util package, udhcpc client/handler, libnetwork API surface, build & CI, scripts, Dockerfile, config.json.
+**Files reviewed**: 23 Go files + 3 Python scripts + Dockerfile + Makefile + CI workflow + plugin manifest
+**Lines of code**: 4,484 Go (incl. tests) + 244 Python
+
+## Executive Summary
+
+This is the second pass; the first one (2026-05-02) generated 27 GitHub issues (#5–#31) covering the v0.5.0 deltas. **Those findings are not duplicated here.** This pass found **5 new critical-or-warning findings** in the parts the first pass skipped — most importantly a nil-pointer panic in the udhcpc handler that the first review missed because it was scoped to v0.5.0 work.
+
+**Build & static analysis**: clean. `go build`, `go vet`, `staticcheck`, `gofmt`, and the existing `-race` test suite all pass; CI runs the same set on every push to `main` and `dev`.
+
+**Biggest new finding (N-1)**: `cmd/udhcpc-handler/main.go:27-32` — when `net.ParseCIDR` fails on a malformed `ipv6` env var, the code logs the error and **continues**, then dereferences a nil `netV6` and panics. A handler panic means the corresponding DHCP event never reaches the persistent client; the lease silently stops getting renewed. This is exactly the kind of bug that hides in always-on infrastructure for months until the one weird LAN packet that triggers it.
+
+**Pattern bug (N-2)**: All four `Await*` helpers in `pkg/util/` (`AwaitContainerInspect`, `AwaitNetNS`, `AwaitLinkByIndex`, `AwaitCondition`) use the same goroutine-leak-on-cancel pattern. On context timeout, the inner goroutine continues polling and eventually blocks forever trying to send on an unbuffered channel that no one will read. Not the largest leak class in absolute terms (these helpers run only at endpoint setup), but it's a four-times-repeated bug that is fixed once.
+
+**Verdict**: still production-ready (it's running on docker-ai right now and behaving). One-day cleanup pass on the new findings + the v0.5.0 issues already filed and you have a v0.5.1 worth tagging.
+
+## Tooling Results
+
+| Tool | Version | Findings | Notes |
+|------|---------|----------|-------|
+| `go build ./...` | go 1.25 | 0 | Clean |
+| `go vet ./...` | go 1.25 | 0 | Clean |
+| `staticcheck ./...` | latest (honnef.co/go/tools) | 0 | Clean. Already in CI. |
+| `gofmt -l .` | go 1.25 | 0 unformatted | Clean. Already in CI. |
+| `go test ./... -race` | go 1.25 (CGO) | 0 fail | Coverage 18.2% — see I-5 from prior review (#26). |
+| `govulncheck ./...` | 1.3.0 | 2 informational | Both daemon-side moby vulns; not reachable from our client-only usage. Filed as #31. |
+
+**Build**: pass. **Tests**: all pass under `-race`.
+
+## Findings
+
+> Findings here are **new** to this pass. The 27 issues filed yesterday (#5–#31) are still open; the metrics table at the end consolidates both passes.
+
+### 🔴 Critical
+
+#### N-1: `udhcpc-handler` nil-pointer panic on malformed `ipv6` env var
+**File**: `cmd/udhcpc-handler/main.go:27-32`
+
+```go
+_, netV6, err := net.ParseCIDR(v6 + "/128")
+if err != nil {
+    log.WithError(err).Warn("Failed to parse IPv6 address")
+}
+
+event.Data.IP = netV6.String()  // netV6 is nil if err != nil → panic
+```
+
+When `net.ParseCIDR` fails — e.g., udhcpc6 emits `ipv6=fe80::1/64` (already CIDR-form, then we append `/128`), or emits a corrupt value, or env is empty after a glibc/musl quirk — the error is logged but execution proceeds and `netV6.String()` dereferences a nil pointer. The handler crashes with `runtime error: invalid memory address`, the udhcpc child's script invocation exits non-zero, and the corresponding `bound`/`renew` event is never delivered to the persistent client. The lease silently ages out; the container loses its IP at lease-expiry boundary with no log line tying it back to the cause.
+
+Compounding factor: this is one of the few pieces of code that runs **outside** the main plugin process (it's invoked by udhcpc as `-s /usr/lib/net-dhcp/udhcpc-handler`), so even structured logging/metrics from the plugin won't show the failure.
+
+**Fix**:
+```go
+case "bound", "renew":
+    if v6, ok := os.LookupEnv("ipv6"); ok {
+        _, netV6, err := net.ParseCIDR(v6 + "/128")
+        if err != nil {
+            log.WithError(err).WithField("ipv6", v6).Error("Failed to parse IPv6 address; skipping event")
+            return  // exit non-zero so udhcpc logs it; do not emit garbage event
+        }
+        event.Data.IP = netV6.String()
+    } else {
+        // ...
+    }
+```
+And consider a defensive `if v6 == ""` short-circuit before the ParseCIDR.
+
+### 🟡 Warning
+
+#### N-2: `Await*` helpers in `pkg/util/` all leak goroutines on context cancellation
+**Files**: `pkg/util/general.go:8-33` (`AwaitCondition`), `pkg/util/docker.go:16-42` (`AwaitContainerInspect`), `pkg/util/netlink.go:12-38` (`AwaitNetNS`), `pkg/util/netlink.go:40-66` (`AwaitLinkByIndex`)
+
+All four helpers spawn an inner goroutine that polls until success, then writes to an **unbuffered** channel. The outer `select` returns on `ctx.Done()` and the function exits — but the inner goroutine is still polling. When the next poll succeeds, it tries `chan <- value` on a channel no one is reading; it blocks forever. The polling continues consuming syscalls (`netns.GetFromPath`, `LinkByIndex`, `ContainerInspect`) every `interval` until the process dies.
+
+Real-world consequence: each context-cancelled `CreateEndpoint` (slow Docker, slow netns sync, container-startup race) leaks one goroutine + one fd-allocating syscall loop. Bounded by `ulimit -n` and `GOMAXPROCS`; on a host with many container churns + transient docker-daemon stalls, it's a slow drift toward fd exhaustion.
+
+**Fix** (applied to `AwaitCondition`; same pattern for the others):
+```go
+func AwaitCondition(ctx context.Context, cond func() (bool, error), interval time.Duration) error {
+    errChan := make(chan error, 1)  // buffered
+    go func() {
+        for {
+            select {
+            case <-ctx.Done():
+                return  // stop polling when caller gives up
+            default:
+            }
+            ok, err := cond()
+            if err != nil {
+                select {
+                case errChan <- err:
+                default:
+                }
+                return
+            }
+            if ok {
+                select {
+                case errChan <- nil:
+                default:
+                }
+                return
+            }
+            select {
+            case <-ctx.Done():
+                return
+            case <-time.After(interval):
+            }
+        }
+    }()
+    select {
+    case err := <-errChan:
+        return err
+    case <-ctx.Done():
+        return ctx.Err()
+    }
+}
+```
+Apply the same pattern (buffered chan + ctx-aware sleep + ctx-aware send) to all four. Worth extracting into a single `Poll(ctx, fn, interval)` and replacing the three near-duplicates.
+
+#### N-3: Log file is opened once and never reopened on logrotate
+**File**: `cmd/net-dhcp/main.go:36-44`
+
+```go
+if *logFile != "" {
+    f, err := os.OpenFile(*logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+    // ...
+    log.StandardLogger().Out = f
+}
+```
+
+Plugin runs forever. If logrotate moves `/var/log/net-dhcp.log` aside (or uses `copytruncate`), our fd still points at the moved/truncated file. Logs vanish after rotation.
+
+**Fix**: handle SIGHUP to reopen, or use `lumberjack.Logger` (or equivalent) to rotate internally:
+```go
+sigs := make(chan os.Signal, 2)
+signal.Notify(sigs, unix.SIGINT, unix.SIGTERM, unix.SIGHUP)
+// ...
+go func() {
+    for sig := range sigs {
+        if sig == unix.SIGHUP {
+            // reopen logFile
+        } else {
+            // shutdown path
+        }
+    }
+}()
+```
+
+#### N-4: `AWAIT_TIMEOUT` default differs between binary and plugin manifest
+**File**: `cmd/net-dhcp/main.go:46` (defaults to `5*time.Second`) vs `config.json:21-25` (defaults to `"10s"`)
+
+Running the binary directly (e.g. `make debug`) silently uses 5s; the plugin runtime injects 10s. Functional difference is small but the divergence is invisible to anyone debugging the binary versus the plugin. One source of truth is the plugin manifest; the Go default should match.
+
+**Fix**:
+```go
+awaitTimeout := 10 * time.Second  // match config.json default
+```
+
+#### N-5: `.dockerignore` is missing `.git/` and `.github/` — sends 8MB+ of git history to the daemon on every build
+**File**: `.dockerignore` (only excludes `bin/`, `plugin/`, `multiarch/`)
+
+```bash
+$ du -sh .git/
+8.1M    .git/
+```
+
+Every `make build` / `docker build .` ships the entire `.git/` directory to the daemon as build context. Slow on cold cache, and it bypasses the explicit `COPY` allowlist principle (since the COPY only copies what it asks for, this is "merely" wasted bandwidth — but on a CI runner with rate-limited registries, it adds up).
+
+**Fix**:
+```
+.git/
+.github/
+*.md
+LICENSE.md
+docs/
+scripts/
+test_env.sh
+```
+(Keep README.md only if you `COPY` it in the runtime stage; otherwise exclude it too.)
+
+### 🔵 Info
+
+#### N-6: HTTP handler boilerplate repeated 6 times
+**File**: `pkg/plugin/endpoints.go` — `apiCreateNetwork`, `apiDeleteNetwork`, `apiCreateEndpoint`, `apiEndpointOperInfo`, `apiDeleteEndpoint`, `apiJoin`, `apiLeave` all follow `parse → call → respond/err`. Pure boilerplate. Could be a generic helper:
+```go
+func handle[Req, Res any](w http.ResponseWriter, r *http.Request, impl func(context.Context, Req) (Res, error)) {
+    var req Req
+    if err := util.ParseJSONBody(&req, w, r); err != nil { return }
+    res, err := impl(r.Context(), req)
+    if err != nil { util.JSONErrResponse(w, err, 0); return }
+    util.JSONResponse(w, res, http.StatusOK)
+}
+```
+But — this churns the diff for cosmetic gain only. Worth doing only if these handlers grow tracing/metrics/auth hooks later. Otherwise leave it.
+
+#### N-7: `log.Fatal` skips deferred log-file close
+**File**: `cmd/net-dhcp/main.go:32, 39, 50, 56, 65, 72`. Every `log.Fatal` calls `os.Exit(1)`, which skips the deferred `f.Close()` on the log file at line 41. Some final lines may be lost in the buffered logger. Minor; OS reclaims the fd. Worth replacing with a cleanup helper:
+```go
+fatalCleanup := func(format string, args ...any) {
+    if f != nil { _ = f.Close() }
+    log.Fatalf(format, args...)
+}
+```
+
+#### N-8: `ParseJSONBody` is a footgun: it writes HTTP responses *and* returns errors
+**File**: `pkg/util/json.go:50-58`. The current callers (`endpoints.go`) check the error and return without writing again, but the API name reads as "parse" while the function also takes over response writing. A future caller writing the obvious-looking `if err := ParseJSONBody(...); err != nil { JSONErrResponse(w, err, ...); return }` would double-write headers. Worth either renaming to `ParseJSONOrErrorResponse` or splitting into a pure parse + a handler helper.
+
+#### N-9: `ErrToStatus` lumps non-validation errors into 500
+**File**: `pkg/util/errors.go:41-52`. Errors like `ErrNoLease` (DHCP server didn't reply — upstream issue), `ErrNoContainer` (Docker state inconsistency — service unavailable), and `ErrNoSandbox` (Docker race window — retryable) all map to 500. For the libnetwork integration this doesn't matter (dockerd treats all 5xx the same), but a cleaner mapping (502 / 503 / 409) would help if the plugin ever exposes its API to other consumers.
+
+#### N-10: `udhcpc6` env-var format is assumed without version pinning
+**File**: `cmd/udhcpc-handler/main.go:27`. We assume `os.Getenv("ipv6")` is a bare address (no mask). The fix `+ "/128"` works for that. busybox `udhcpc6` does emit it that way as of current versions, but a future busybox change to emit CIDR form would silently produce parse errors → falls into N-1's nil-deref. Worth a comment pinning the assumption to the busybox version, plus a `strings.SplitN(v6, "/", 2)` defensive split.
+
+#### N-11: Alpine package versions in Dockerfile are not pinned
+**File**: `Dockerfile:14`. `apk add --no-cache busybox-extras iproute2` installs whatever versions the Alpine repos serve at build time. A regression in busybox's udhcpc/udhcpc6 (where the entire DHCP exchange happens) would silently land on the next build. For a plugin whose correctness depends on busybox behavior, version-pin or pin the Alpine minor version (already partially flagged as I-1 in #22 — this is the package-level extension).
+
+**Fix**: pin Alpine minor + record installed versions:
+```dockerfile
+FROM alpine:3.20.3
+RUN apk add --no-cache busybox-extras=1.36.1-r29 iproute2=6.9.0-r0
+```
+(Adjust to whatever current versions are; verify on each release.)
+
+#### N-12: Two stale references in upstream-inherited Makefile
+**File**: `Makefile:1`. `PLUGIN_NAME = ghcr.io/devplayer0/...` is the upstream registry; everything in this fork is published to `ghcr.io/claymore666/...` (overridden via env every time). The default points at a registry the fork can't push to. Worth flipping the default:
+```make
+PLUGIN_NAME ?= ghcr.io/claymore666/docker-net-dhcp
+```
+(Use `?=` so an env override still wins.)
+
+## Metrics Summary
+
+This consolidates **both** review passes (yesterday + today). Yesterday's 27 issues are filed (#5–#31); today adds 12 more.
+
+| Category | Issues | Critical | Warning | Info |
+|----------|--------|----------|---------|------|
+| Error Handling & Robustness | 6 | 4 (C-1, C-2, C-3, **N-1**) | 2 (W-2, W-9) | 0 |
+| Performance & Efficiency | 1 | 0 | 1 (W-12) | 0 |
+| Dead Code & Unused | 0 | 0 | 0 | 0 |
+| Code Style & Idioms | 6 | 0 | 0 | 6 (I-4, I-6, I-8, **N-6, N-8, N-12**) |
+| Concurrency | 6 | 1 (C-2) | 5 (W-1, W-5, W-6, W-10, **N-2**) | 0 |
+| Testing | 2 | 0 | 1 (W-11) | 1 (I-5) |
+| Dependencies | 1 | 0 | 0 | 1 (I-10) |
+| Configuration & Environment | 2 | 0 | 1 (**N-4**) | 1 (**N-9**) |
+| Logging & Observability | 4 | 1 (C-4) | 1 (**N-3**) | 2 (I-3, **N-7**) |
+| Security | 2 | 0 | 0 | 2 (I-1, I-2) |
+| Architecture | 1 | 1 (C-5) | 0 | 0 |
+| Project Hygiene | 4 | 0 | 2 (**N-5, N-11**) | 2 (I-7, I-9, **N-10**) |
+| **Total** | **39** | **7** | **13** | **15** |
+
+**Of which new this pass**: 1 critical + 4 warning + 7 info = 12.
+
+## What's Done Well
+
+1. **CI is right-sized.** `go build`, `go vet`, `gofmt -l`, `staticcheck`, and `go test -race` on every push, with caching. No flaky-flag, no skip lists, no theatre. The same set runs locally with one command. This is the "make it once, make it right" tone the project asks for.
+2. **Error sentinels are well-organized.** `pkg/util/errors.go` declares a clean set of typed sentinel errors with `errors.Is`-friendly mapping to HTTP status. Easy to extend, easy to test, easy to grep for. The mapping in `ErrToStatus` is centralized rather than scattered.
+3. **The udhcpc client wrapper is small and focused.** `pkg/udhcpc/client.go` does one thing: spawn busybox udhcpc with the right flags and read events. The DHCP-option crafting (option 12 hostname, option 50 requested-IP, option 61 client-id) is well-commented and references RFCs. It's the kind of code that's hard to write correctly and easy to read once written.
+4. **`/Plugin.Health` exists and is at the right scope.** Most plugins ship without any liveness/state probe. Adding one at the same socket as the libnetwork RPC is the lowest-friction way to make the plugin operable. The four counters (uptime, active endpoints, pending hints) are exactly the information a sysadmin needs.
+
+## Top Recommendations
+
+Ordered by value-to-effort, **across both review passes**:
+
+1. **Fix N-1 (udhcpc-handler nil-deref).** Lone-line bug with crash potential. ~5-line fix. Highest priority.
+2. **Fix W-10 (`Plugin.Close` doesn't stop persistent managers).** ~15 lines. Restores the lease-release-on-shutdown invariant. Highest impact.
+3. **Fix N-2 (extract a single `Poll` helper, replace 4 copies).** Eliminates four goroutine-leak sites at once. ~40 lines net (more removed than added).
+4. **Fix C-5 (add hostname to tombstone match key).** ~30 lines incl. a test. Closes the cross-container identity-swap during sequential `compose restart`.
+5. **Fix C-1/C-2/W-9 (buffer the udhcpc channels).** Three one-line edits (`make(chan ..., N)`) that eliminate three goroutine/process leak classes. Trivially safe.
+6. **Fix C-3 (`shortID` helper, ~7 sites).** Mechanical, removes a panic class for a degraded-Docker-response edge case.
+
+Estimated total for all six: ~half a day. v0.5.1 worth tagging after.

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -189,7 +189,10 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 		return nil, fmt.Errorf("failed to start DHCP%v client: %w", v6Str, err)
 	}
 
-	errChan := make(chan error)
+	// Buffered: a partial-Start failure (v4 OK, v6 fails) bypasses Stop's
+	// errChan reads; Stop short-circuits on m.startErr. Without a buffer
+	// the goroutine here would block forever on the final write below.
+	errChan := make(chan error, 1)
 	go func() {
 		for {
 			select {

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -196,7 +196,39 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 	go func() {
 		for {
 			select {
-			case event := <-events:
+			case event, ok := <-events:
+				if !ok {
+					// udhcpc exited on its own (NAK, parent NIC vanished,
+					// container netns torn down out from under us, etc.).
+					// The scanner goroutine in udhcpc.Start closes events
+					// when its read pipe hits EOF. Without this branch,
+					// `<-events` on a closed channel returns the zero
+					// Event{} every iteration, the switch matches nothing,
+					// and we burn a CPU thread forever.
+					log.
+						WithFields(m.logFields(v6)).
+						Warn("udhcpc event stream closed; client process exited")
+
+					// Reap the child so it doesn't linger as a zombie:
+					// cmd.Wait must be called exactly once per process,
+					// and Stop's Finish path won't run if the consumer
+					// returned first.
+					reapCtx, reapCancel := context.WithTimeout(context.Background(), 5*time.Second)
+					if err := client.Wait(reapCtx); err != nil {
+						log.
+							WithError(err).
+							WithFields(m.logFields(v6)).
+							Debug("udhcpc reap returned error")
+					}
+					reapCancel()
+
+					// Unblock Stop() if it's waiting on errChan. The
+					// channel is buffered=1 so this never blocks; if
+					// nobody's reading yet, the value sits until Stop
+					// calls close(stopChan) and reads it.
+					errChan <- nil
+					return
+				}
 				switch event.Type {
 				// TODO: We can't really allow the IP in the container to be deleted, it'll delete some of our previously
 				// copied routes. Should this be handled somehow?

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -405,8 +405,20 @@ func (m *dhcpManager) Stop() error {
 		return nil
 	}
 
-	defer m.nsHandle.Close()
-	defer m.netHandle.Close()
+	// Guard against zero handles: Stop can be called against a manager
+	// whose Start failed before AwaitNetNS / NewHandleAt set these
+	// (see C-2 fix), in which case the deferred Close on the zero
+	// value emits a noisy EBADF.
+	defer func() {
+		if m.nsHandle.IsOpen() {
+			m.nsHandle.Close()
+		}
+	}()
+	defer func() {
+		if m.netHandle != nil {
+			m.netHandle.Close()
+		}
+	}()
 
 	close(m.stopChan)
 

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -70,8 +70,8 @@ func newDHCPManager(docker *docker.Client, r JoinRequest, opts DHCPNetworkOption
 
 func (m *dhcpManager) logFields(v6 bool) log.Fields {
 	return log.Fields{
-		"network":  m.joinReq.NetworkID[:12],
-		"endpoint": m.joinReq.EndpointID[:12],
+		"network":  shortID(m.joinReq.NetworkID),
+		"endpoint": shortID(m.joinReq.EndpointID),
 		"sandbox":  m.joinReq.SandboxKey,
 		"is_ipv6":  v6,
 	}

--- a/pkg/plugin/endpoints.go
+++ b/pkg/plugin/endpoints.go
@@ -227,12 +227,12 @@ func (p *Plugin) apiLeave(w http.ResponseWriter, r *http.Request) {
 // expiry. Operators should restart those containers (which produces a
 // fresh CreateEndpoint and gets them back into the persistent map).
 type HealthResponse struct {
-	Healthy          bool    `json:"healthy"`
-	UptimeSeconds    float64 `json:"uptime_seconds"`
-	ActiveEndpoints  int     `json:"active_endpoints"`
-	PendingHints     int     `json:"pending_hints"`
-	RecoveredOK      int32   `json:"recovered_ok"`
-	RecoveryFailed   int32   `json:"recovery_failed"`
+	Healthy         bool    `json:"healthy"`
+	UptimeSeconds   float64 `json:"uptime_seconds"`
+	ActiveEndpoints int     `json:"active_endpoints"`
+	PendingHints    int     `json:"pending_hints"`
+	RecoveredOK     int32   `json:"recovered_ok"`
+	RecoveryFailed  int32   `json:"recovery_failed"`
 }
 
 func (p *Plugin) apiHealth(w http.ResponseWriter, r *http.Request) {

--- a/pkg/plugin/endpoints.go
+++ b/pkg/plugin/endpoints.go
@@ -219,11 +219,20 @@ func (p *Plugin) apiLeave(w http.ResponseWriter, r *http.Request) {
 }
 
 // HealthResponse is the payload returned by /Plugin.Health.
+//
+// Healthy is false when at least one plugin-restart recovery failed —
+// the plugin keeps serving requests for fresh attaches, but containers
+// that were running before the restart and got a recovery failure are
+// now running without lease renewal and will lose their IP at lease
+// expiry. Operators should restart those containers (which produces a
+// fresh CreateEndpoint and gets them back into the persistent map).
 type HealthResponse struct {
-	Healthy         bool    `json:"healthy"`
-	UptimeSeconds   float64 `json:"uptime_seconds"`
-	ActiveEndpoints int     `json:"active_endpoints"`
-	PendingHints    int     `json:"pending_hints"`
+	Healthy          bool    `json:"healthy"`
+	UptimeSeconds    float64 `json:"uptime_seconds"`
+	ActiveEndpoints  int     `json:"active_endpoints"`
+	PendingHints     int     `json:"pending_hints"`
+	RecoveredOK      int32   `json:"recovered_ok"`
+	RecoveryFailed   int32   `json:"recovery_failed"`
 }
 
 func (p *Plugin) apiHealth(w http.ResponseWriter, r *http.Request) {
@@ -232,10 +241,13 @@ func (p *Plugin) apiHealth(w http.ResponseWriter, r *http.Request) {
 	pending := len(p.joinHints)
 	p.mu.Unlock()
 
+	failed := p.recoveryFailed.Load()
 	util.JSONResponse(w, HealthResponse{
-		Healthy:         true,
+		Healthy:         failed == 0,
 		UptimeSeconds:   time.Since(p.startTime).Seconds(),
 		ActiveEndpoints: active,
 		PendingHints:    pending,
+		RecoveredOK:     p.recoveredOK.Load(),
+		RecoveryFailed:  failed,
 	}, http.StatusOK)
 }

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -215,6 +215,9 @@ func parseExplicitV4(iface *EndpointInterface) (string, error) {
 	if addr.IP.To4() == nil {
 		return "", fmt.Errorf("Interface.Address must be IPv4: got %q: %w", iface.Address, util.ErrIPAM)
 	}
+	if addr.IP.IsUnspecified() {
+		return "", fmt.Errorf("Interface.Address must be a unicast IPv4: got %q: %w", iface.Address, util.ErrIPAM)
+	}
 	return addr.IP.String(), nil
 }
 
@@ -264,6 +267,9 @@ func parseDriverOptIP(options map[string]interface{}) (string, error) {
 	v4 := parsed.To4()
 	if v4 == nil {
 		return "", fmt.Errorf("driver-opt ip must be IPv4: got %q: %w", s, util.ErrIPAM)
+	}
+	if v4.IsUnspecified() {
+		return "", fmt.Errorf("driver-opt ip must be a unicast IPv4: got %q: %w", s, util.ErrIPAM)
 	}
 	return v4.String(), nil
 }
@@ -835,15 +841,15 @@ func (p *Plugin) Leave(ctx context.Context, r LeaveRequest) error {
 		return util.ErrNoSandbox
 	}
 
-	if err := manager.Stop(); err != nil {
-		return err
-	}
+	stopErr := manager.Stop()
 
 	// Refresh the endpoint fingerprint with the most recent v4/v6 IPs
-	// the persistent client saw. Stop has already drained the event
-	// goroutine, so manager.LastIP* are stable to read here. The
-	// tombstone DeleteEndpoint lays down next will then carry the
-	// renewed addresses rather than the initial-DISCOVER ones.
+	// the persistent client saw, *whether or not Stop succeeded*. Stop
+	// drains the event goroutine before returning even on error, so
+	// manager.LastIP* are stable to read here. Doing this on the error
+	// path too means a wedged-udhcpc shutdown still produces a tombstone
+	// with the latest known lease (W-4) — otherwise DeleteEndpoint
+	// would lay down a tombstone with the stale initial-DISCOVER IPs.
 	v4, v6 := "", ""
 	if manager.LastIP != nil && manager.LastIP.IP != nil {
 		v4 = manager.LastIP.IP.String()
@@ -852,6 +858,10 @@ func (p *Plugin) Leave(ctx context.Context, r LeaveRequest) error {
 		v6 = manager.LastIPv6.IP.String()
 	}
 	p.updateEndpointIPs(r.EndpointID, v4, v6)
+
+	if stopErr != nil {
+		return stopErr
+	}
 
 	log.WithFields(log.Fields{
 		"network":  shortID(r.NetworkID),

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -321,8 +321,8 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 	// best-effort basis: warn loudly but don't fail the endpoint.
 	if r.Interface != nil && r.Interface.AddressIPv6 != "" {
 		log.WithFields(log.Fields{
-			"network":  r.NetworkID[:12],
-			"endpoint": r.EndpointID[:12],
+			"network":  shortID(r.NetworkID),
+			"endpoint": shortID(r.EndpointID),
 			"ipv6":     r.Interface.AddressIPv6,
 		}).Warn("Static IPv6 address requested but not yet wired through to udhcpc6; lease will come unhinted")
 	}
@@ -367,8 +367,8 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 			// future change can request preferred-address from a
 			// DHCPv6 client without a wire-format change.
 			log.WithFields(log.Fields{
-				"network":      r.NetworkID[:12],
-				"endpoint":     r.EndpointID[:12],
+				"network":      shortID(r.NetworkID),
+				"endpoint":     shortID(r.EndpointID),
 				"mac_address":  mac,
 				"requested_ip": requestedIP,
 				"prior_ipv6":   ipv6,
@@ -524,8 +524,8 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 	p.rememberEndpoint(r.EndpointID, endpointFingerprint{MAC: mac, IPv4: v4IP, IPv6: v6IP})
 
 	log.WithFields(log.Fields{
-		"network":     r.NetworkID[:12],
-		"endpoint":    r.EndpointID[:12],
+		"network":     shortID(r.NetworkID),
+		"endpoint":    shortID(r.EndpointID),
 		"mac_address": mac,
 		"ip":          res.Interface.Address,
 		"ipv6":        res.Interface.AddressIPv6,
@@ -595,8 +595,8 @@ func (p *Plugin) DeleteEndpoint(ctx context.Context, r DeleteEndpointRequest) er
 			return err
 		}
 		log.WithFields(log.Fields{
-			"network":  r.NetworkID[:12],
-			"endpoint": r.EndpointID[:12],
+			"network":  shortID(r.NetworkID),
+			"endpoint": shortID(r.EndpointID),
 		}).Info("Endpoint deleted")
 		return nil
 	}
@@ -612,8 +612,8 @@ func (p *Plugin) DeleteEndpoint(ctx context.Context, r DeleteEndpointRequest) er
 	}
 
 	log.WithFields(log.Fields{
-		"network":  r.NetworkID[:12],
-		"endpoint": r.EndpointID[:12],
+		"network":  shortID(r.NetworkID),
+		"endpoint": shortID(r.EndpointID),
 	}).Info("Endpoint deleted")
 
 	return nil
@@ -634,8 +634,8 @@ func (p *Plugin) addRoutes(opts *DHCPNetworkOptions, v6 bool, bridge netlink.Lin
 	}
 
 	logFields := log.Fields{
-		"network":  r.NetworkID[:12],
-		"endpoint": r.EndpointID[:12],
+		"network":  shortID(r.NetworkID),
+		"endpoint": shortID(r.EndpointID),
 		"sandbox":  r.SandboxKey,
 	}
 	for _, route := range routes {
@@ -749,8 +749,8 @@ func (p *Plugin) Join(ctx context.Context, r JoinRequest) (JoinResponse, error) 
 		// and the link in the destroyed sandbox is gone with it.
 		// Reacquire from scratch.
 		log.WithFields(log.Fields{
-			"network":  r.NetworkID[:12],
-			"endpoint": r.EndpointID[:12],
+			"network":  shortID(r.NetworkID),
+			"endpoint": shortID(r.EndpointID),
 			"sandbox":  r.SandboxKey,
 		}).Info("[Join] No hint; attempting endpoint reacquisition (likely container restart)")
 		if err := p.reacquireEndpoint(ctx, r, opts); err != nil {
@@ -764,8 +764,8 @@ func (p *Plugin) Join(ctx context.Context, r JoinRequest) (JoinResponse, error) 
 
 	if hint.Gateway != "" {
 		log.WithFields(log.Fields{
-			"network":  r.NetworkID[:12],
-			"endpoint": r.EndpointID[:12],
+			"network":  shortID(r.NetworkID),
+			"endpoint": shortID(r.EndpointID),
 			"sandbox":  r.SandboxKey,
 			"gateway":  hint.Gateway,
 		}).Info("[Join] Setting IPv4 gateway retrieved from initial DHCP in CreateEndpoint")
@@ -804,8 +804,8 @@ func (p *Plugin) Join(ctx context.Context, r JoinRequest) (JoinResponse, error) 
 
 		if err := m.Start(ctx); err != nil {
 			log.WithError(err).WithFields(log.Fields{
-				"network":  r.NetworkID[:12],
-				"endpoint": r.EndpointID[:12],
+				"network":  shortID(r.NetworkID),
+				"endpoint": shortID(r.EndpointID),
 				"sandbox":  r.SandboxKey,
 			}).Error("Failed to start persistent DHCP client; lease will not be renewed")
 			// If Start failed, take ourselves out of the registry so a
@@ -817,8 +817,8 @@ func (p *Plugin) Join(ctx context.Context, r JoinRequest) (JoinResponse, error) 
 	}()
 
 	log.WithFields(log.Fields{
-		"network":  r.NetworkID[:12],
-		"endpoint": r.EndpointID[:12],
+		"network":  shortID(r.NetworkID),
+		"endpoint": shortID(r.EndpointID),
 		"sandbox":  r.SandboxKey,
 	}).Info("Joined sandbox to endpoint")
 
@@ -851,8 +851,8 @@ func (p *Plugin) Leave(ctx context.Context, r LeaveRequest) error {
 	p.updateEndpointIPs(r.EndpointID, v4, v6)
 
 	log.WithFields(log.Fields{
-		"network":  r.NetworkID[:12],
-		"endpoint": r.EndpointID[:12],
+		"network":  shortID(r.NetworkID),
+		"endpoint": shortID(r.EndpointID),
 	}).Info("Sandbox left endpoint")
 
 	return nil

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -346,6 +346,12 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 		return res, fmt.Errorf("failed to get bridge interface: %w", err)
 	}
 
+	// Look up the hostname up front so we can scope tombstone matching
+	// to the same container (prevents identity swap during sequential
+	// `compose restart`). Best-effort: if the lookup misses or returns
+	// empty, consumeTombstone falls back to network-only matching.
+	hostname := p.initialDHCPHostname(ctx, r.NetworkID, r.EndpointID)
+
 	// MAC/IP selection priority:
 	//   1. Explicit values from libnetwork (`--mac-address`, `--ip`)
 	//   2. Tombstone (recently-deleted endpoint on the same network)
@@ -356,7 +362,7 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 	effectiveMAC := r.Interface.MacAddress
 	requestedIP := explicitV4
 	if effectiveMAC == "" {
-		if mac, ip, ipv6, ok := p.consumeTombstone(r.NetworkID); ok {
+		if mac, ip, ipv6, ok := p.consumeTombstone(r.NetworkID, hostname); ok {
 			effectiveMAC = mac
 			if requestedIP == "" {
 				requestedIP = ip
@@ -369,6 +375,7 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 			log.WithFields(log.Fields{
 				"network":      shortID(r.NetworkID),
 				"endpoint":     shortID(r.EndpointID),
+				"hostname":     hostname,
 				"mac_address":  mac,
 				"requested_ip": requestedIP,
 				"prior_ipv6":   ipv6,
@@ -434,10 +441,6 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 		if opts.LeaseTimeout != 0 {
 			timeout = opts.LeaseTimeout
 		}
-		// Best-effort hostname for the initial DISCOVER. Empty if the
-		// container isn't yet registered with this network — the
-		// persistent renewal client will fill it in later.
-		hostname := p.initialDHCPHostname(ctx, r.NetworkID, r.EndpointID)
 		clientID := clientIDFromEndpoint(r.EndpointID)
 		initialIP := func(v6 bool) error {
 			v6str := ""
@@ -521,7 +524,7 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 	if mac == "" {
 		mac = res.Interface.MacAddress
 	}
-	p.rememberEndpoint(r.EndpointID, endpointFingerprint{MAC: mac, IPv4: v4IP, IPv6: v6IP})
+	p.rememberEndpoint(r.EndpointID, endpointFingerprint{MAC: mac, IPv4: v4IP, IPv6: v6IP, Hostname: hostname})
 
 	log.WithFields(log.Fields{
 		"network":     shortID(r.NetworkID),
@@ -587,7 +590,7 @@ func (p *Plugin) DeleteEndpoint(ctx context.Context, r DeleteEndpointRequest) er
 	// the tombstone is meaningless there (we'd just be re-handing the
 	// parent MAC back, which the kernel inherits anyway) — skip it.
 	if fp, ok := p.takeEndpoint(r.EndpointID); ok && opts.effectiveMode() != ModeIPvlan {
-		p.addTombstone(r.NetworkID, fp.MAC, fp.IPv4, fp.IPv6)
+		p.addTombstone(r.NetworkID, fp.Hostname, fp.MAC, fp.IPv4, fp.IPv6)
 	}
 
 	if m := opts.effectiveMode(); m == ModeMacvlan || m == ModeIPvlan {

--- a/pkg/plugin/network_test.go
+++ b/pkg/plugin/network_test.go
@@ -132,6 +132,16 @@ func TestParseExplicitV4(t *testing.T) {
 			iface:   &EndpointInterface{Address: "not-an-ip"},
 			wantErr: true,
 		},
+		{
+			name:    "unspecified_v4_rejected",
+			iface:   &EndpointInterface{Address: "0.0.0.0/0"},
+			wantErr: true,
+		},
+		{
+			name:    "unspecified_host_rejected",
+			iface:   &EndpointInterface{Address: "0.0.0.0/24"},
+			wantErr: true,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -171,6 +181,7 @@ func TestParseDriverOptIP(t *testing.T) {
 		{name: "non_string_value", opts: map[string]interface{}{"ip": 42}, wantErr: true},
 		{name: "empty_string", opts: map[string]interface{}{"ip": ""}, wantErr: true},
 		{name: "garbage", opts: map[string]interface{}{"ip": "not-an-ip"}, wantErr: true},
+		{name: "unspecified_rejected", opts: map[string]interface{}{"ip": "0.0.0.0"}, wantErr: true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -100,8 +100,8 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 				requestedIP = tombIP
 			}
 			log.WithFields(log.Fields{
-				"network":      r.NetworkID[:12],
-				"endpoint":     r.EndpointID[:12],
+				"network":      shortID(r.NetworkID),
+				"endpoint":     shortID(r.EndpointID),
 				"mac_address":  tombMAC,
 				"requested_ip": requestedIP,
 				"prior_ipv6":   tombIPv6,
@@ -244,8 +244,8 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 	}
 
 	log.WithFields(log.Fields{
-		"network":     r.NetworkID[:12],
-		"endpoint":    r.EndpointID[:12],
+		"network":     shortID(r.NetworkID),
+		"endpoint":    shortID(r.EndpointID),
 		"mode":        mode,
 		"parent":      opts.Parent,
 		"mac_address": hintMAC,
@@ -270,8 +270,8 @@ func (p *Plugin) deleteParentAttachedEndpoint(r DeleteEndpointRequest) error {
 	if err != nil {
 		// Expected: the link is gone with the container netns.
 		log.WithFields(log.Fields{
-			"network":  r.NetworkID[:12],
-			"endpoint": r.EndpointID[:12],
+			"network":  shortID(r.NetworkID),
+			"endpoint": shortID(r.EndpointID),
 		}).Debug("Child link already gone (expected)")
 		return nil
 	}
@@ -279,8 +279,8 @@ func (p *Plugin) deleteParentAttachedEndpoint(r DeleteEndpointRequest) error {
 		return fmt.Errorf("failed to delete leftover child link %v: %w", name, err)
 	}
 	log.WithFields(log.Fields{
-		"network":  r.NetworkID[:12],
-		"endpoint": r.EndpointID[:12],
+		"network":  shortID(r.NetworkID),
+		"endpoint": shortID(r.EndpointID),
 	}).Info("Cleaned up leftover child link in host netns")
 	return nil
 }

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -92,9 +92,15 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 	if err != nil {
 		return res, err
 	}
+	// Look up the hostname up front so we can scope tombstone matching
+	// to the same container (prevents identity swap during sequential
+	// `compose restart`). Best-effort: if the lookup misses or returns
+	// empty, consumeTombstone falls back to network-only matching.
+	hostname := p.initialDHCPHostname(ctx, r.NetworkID, r.EndpointID)
+
 	requestedIP := explicitV4
 	if mode == ModeMacvlan && effectiveMAC == "" {
-		if tombMAC, tombIP, tombIPv6, ok := p.consumeTombstone(r.NetworkID); ok {
+		if tombMAC, tombIP, tombIPv6, ok := p.consumeTombstone(r.NetworkID, hostname); ok {
 			effectiveMAC = tombMAC
 			if requestedIP == "" {
 				requestedIP = tombIP
@@ -102,6 +108,7 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 			log.WithFields(log.Fields{
 				"network":      shortID(r.NetworkID),
 				"endpoint":     shortID(r.EndpointID),
+				"hostname":     hostname,
 				"mac_address":  tombMAC,
 				"requested_ip": requestedIP,
 				"prior_ipv6":   tombIPv6,
@@ -154,14 +161,11 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 		if opts.LeaseTimeout != 0 {
 			timeout = opts.LeaseTimeout
 		}
-		// Best-effort hostname for the initial DISCOVER (so the lease
-		// shows up in the upstream DHCP server's UI tagged with the
-		// container hostname from minute one) and a stable client-id
-		// derived from the endpoint ID (so reservations keyed on
-		// option 61 survive container recreation, and so ipvlan
+		// Stable client-id derived from the endpoint ID (so reservations
+		// keyed on option 61 survive container recreation, and so ipvlan
 		// children can be told apart even though they all share the
-		// parent's MAC).
-		hostname := p.initialDHCPHostname(ctx, r.NetworkID, r.EndpointID)
+		// parent's MAC). hostname was resolved earlier for tombstone
+		// matching and is reused for the DHCP option 12 hint here.
 		clientID := clientIDFromEndpoint(r.EndpointID)
 
 		runDHCP := func(v6 bool) error {
@@ -240,7 +244,7 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 	// them as a tombstone. macvlan only — for ipvlan the MAC is the
 	// parent's and there's nothing to stabilize.
 	if mode == ModeMacvlan {
-		p.rememberEndpoint(r.EndpointID, endpointFingerprint{MAC: hintMAC, IPv4: hintIPv4, IPv6: hintIPv6})
+		p.rememberEndpoint(r.EndpointID, endpointFingerprint{MAC: hintMAC, IPv4: hintIPv4, IPv6: hintIPv6, Hostname: hostname})
 	}
 
 	log.WithFields(log.Fields{

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -682,8 +682,54 @@ func (p *Plugin) Listen(bindSock string) error {
 	return p.server.Serve(l)
 }
 
-// Close stops the plugin server
+// pluginShutdownTimeout caps how long Close waits for each persistent
+// DHCP client to send DHCPRELEASE and exit. Short enough to keep a
+// plugin upgrade snappy on hosts with many endpoints; long enough that
+// a typical udhcpc release-and-exit cycle completes well within it.
+const pluginShutdownTimeout = 5 * time.Second
+
+// Close stops the plugin server. Persistent DHCP clients are stopped
+// first so they get a chance to send DHCPRELEASE for their leases —
+// otherwise plugin upgrade or `docker plugin disable` would orphan
+// every active lease at the upstream DHCP server, defeating the
+// release-on-stop contract Leave normally honors.
 func (p *Plugin) Close() error {
+	// Snapshot the live managers under the lock, then drop the lock
+	// before calling Stop on each (Stop blocks on udhcpc Wait and we
+	// don't want to hold p.mu across that).
+	p.mu.Lock()
+	managers := make([]*dhcpManager, 0, len(p.persistentDHCP))
+	for _, m := range p.persistentDHCP {
+		managers = append(managers, m)
+	}
+	p.persistentDHCP = make(map[string]*dhcpManager)
+	p.mu.Unlock()
+
+	if len(managers) > 0 {
+		log.WithField("count", len(managers)).Info("Stopping persistent DHCP clients before shutdown")
+		// Stop in parallel — each udhcpc release is independent and
+		// we don't want N×timeout wall time.
+		var wg sync.WaitGroup
+		for _, m := range managers {
+			wg.Add(1)
+			go func(m *dhcpManager) {
+				defer wg.Done()
+				if err := m.Stop(); err != nil {
+					log.WithError(err).Warn("Failed to stop persistent DHCP client at shutdown")
+				}
+			}(m)
+		}
+		// Bound wall time: we can't let one wedged udhcpc hold up the
+		// whole shutdown.
+		done := make(chan struct{})
+		go func() { wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(pluginShutdownTimeout):
+			log.Warn("Timeout waiting for persistent DHCP clients to stop; continuing shutdown")
+		}
+	}
+
 	if err := p.docker.Close(); err != nil {
 		return fmt.Errorf("failed to close docker client: %w", err)
 	}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -24,6 +24,16 @@ import (
 // DriverName is the name of the Docker Network Driver
 const DriverName string = "net-dhcp"
 
+// shortID truncates a Docker network/endpoint ID to 12 chars for
+// log fields, without panicking on short or empty IDs (which can
+// happen on malformed daemon responses during recovery).
+func shortID(id string) string {
+	if len(id) >= 12 {
+		return shortID(id)
+	}
+	return id
+}
+
 // Network attachment modes selected by the `mode` driver option.
 const (
 	ModeBridge  = "bridge"
@@ -371,14 +381,14 @@ func (p *Plugin) recoverEndpoints(ctx context.Context) {
 		// Re-fetch with full container details (NetworkList is summary-only).
 		netInfo, err := p.docker.NetworkInspect(ctx, n.ID, dNetwork.InspectOptions{})
 		if err != nil {
-			log.WithError(err).WithField("network", n.ID[:12]).
+			log.WithError(err).WithField("network", shortID(n.ID)).
 				Warn("recovery: NetworkInspect failed; skipping")
 			failed++
 			continue
 		}
 		opts, err := p.netOptions(ctx, n.ID)
 		if err != nil {
-			log.WithError(err).WithField("network", n.ID[:12]).
+			log.WithError(err).WithField("network", shortID(n.ID)).
 				Warn("recovery: failed to load network options; skipping")
 			failed++
 			continue
@@ -393,8 +403,8 @@ func (p *Plugin) recoverEndpoints(ctx context.Context) {
 			}
 			if err := p.recoverOneEndpoint(ctx, n.ID, info.EndpointID, info.MacAddress, info.IPv4Address, info.IPv6Address, opts); err != nil {
 				log.WithError(err).WithFields(log.Fields{
-					"network":  n.ID[:12],
-					"endpoint": info.EndpointID[:12],
+					"network":  shortID(n.ID),
+					"endpoint": shortID(info.EndpointID),
 				}).Warn("recovery: endpoint recovery failed")
 				failed++
 				continue
@@ -454,8 +464,8 @@ func (p *Plugin) recoverOneEndpoint(ctx context.Context, networkID, endpointID, 
 		defer cancel()
 		if err := m.Start(startCtx); err != nil {
 			log.WithError(err).WithFields(log.Fields{
-				"network":  networkID[:12],
-				"endpoint": endpointID[:12],
+				"network":  shortID(networkID),
+				"endpoint": shortID(endpointID),
 			}).Warn("recovery: persistent DHCP client Start failed; lease will not renew until next restart")
 			p.takeDHCPManager(endpointID)
 		}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -239,9 +239,10 @@ func (p *Plugin) takeDHCPManager(endpointID string) (*dhcpManager, bool) {
 // endpoint is deleted these fields become a tombstone for the next
 // CreateEndpoint on the same network to inherit.
 type endpointFingerprint struct {
-	MAC  string
-	IPv4 string // bare IPv4, e.g. "192.168.0.166" (no /mask). May be empty.
-	IPv6 string // bare IPv6, e.g. "2001:db8::1" (no /prefix). May be empty.
+	MAC      string
+	IPv4     string // bare IPv4, e.g. "192.168.0.166" (no /mask). May be empty.
+	IPv6     string // bare IPv6, e.g. "2001:db8::1" (no /prefix). May be empty.
+	Hostname string // container hostname; used to narrow tombstone match.
 }
 
 // rememberEndpoint stashes the fingerprint of an endpoint we just
@@ -298,10 +299,11 @@ func (p *Plugin) takeEndpoint(endpointID string) (endpointFingerprint, bool) {
 
 // addTombstone appends a tombstone for a deleted endpoint so the
 // next CreateEndpoint on the same network within tombstoneTTL can
-// inherit its MAC and last IP/IPv6. Best-effort: a disk failure
-// here just means restart-stability for this particular event is
-// lost; it's logged and the flow continues.
-func (p *Plugin) addTombstone(networkID, mac, ipv4, ipv6 string) {
+// inherit its MAC and last IP/IPv6. hostname narrows the match in
+// consumeTombstone to the same container. Best-effort: a disk
+// failure here just means restart-stability for this particular
+// event is lost; it's logged and the flow continues.
+func (p *Plugin) addTombstone(networkID, hostname, mac, ipv4, ipv6 string) {
 	if mac == "" {
 		return
 	}
@@ -314,6 +316,7 @@ func (p *Plugin) addTombstone(networkID, mac, ipv4, ipv6 string) {
 	}
 	ts = append(pruneTombstones(ts), tombstone{
 		NetworkID:   networkID,
+		Hostname:    hostname,
 		MacAddress:  mac,
 		IPAddress:   ipv4,
 		IPv6Address: ipv6,
@@ -325,12 +328,14 @@ func (p *Plugin) addTombstone(networkID, mac, ipv4, ipv6 string) {
 }
 
 // consumeTombstone returns and removes a tombstone for networkID iff
-// EXACTLY one fresh entry exists for it. The "exactly one" rule
-// avoids ambiguity when multiple containers on the same network are
-// restarted concurrently — those fall back to fresh MACs/IPs rather
-// than risk swapping identities between containers. Sequential
-// restarts (the common case) always satisfy the rule.
-func (p *Plugin) consumeTombstone(networkID string) (mac, ipv4, ipv6 string, ok bool) {
+// EXACTLY one fresh entry matches. When hostname is non-empty we
+// narrow the match to NetworkID+Hostname so a sequential `compose
+// restart` of multiple containers on the same network can't swap
+// identities between containers. When hostname is empty we fall back
+// to NetworkID-only matching (preserves the v0.5.0 contract for
+// hostname-less containers and races where the lookup didn't return
+// in time). The "exactly one" rule still applies after filtering.
+func (p *Plugin) consumeTombstone(networkID, hostname string) (mac, ipv4, ipv6 string, ok bool) {
 	p.tombstoneMu.Lock()
 	defer p.tombstoneMu.Unlock()
 	ts, err := loadTombstones()
@@ -342,10 +347,18 @@ func (p *Plugin) consumeTombstone(networkID string) (mac, ipv4, ipv6 string, ok 
 	matchIdx := -1
 	matches := 0
 	for i, t := range ts {
-		if t.NetworkID == networkID {
-			matches++
-			matchIdx = i
+		if t.NetworkID != networkID {
+			continue
 		}
+		// When the caller knows the hostname, only match tombstones
+		// whose hostname agrees. Tombstones written by a v0.5.0 build
+		// (or with hostname-lookup races) have empty Hostname; treat
+		// them as "matches anything" so we don't regress those.
+		if hostname != "" && t.Hostname != "" && t.Hostname != hostname {
+			continue
+		}
+		matches++
+		matchIdx = i
 	}
 	// Always rewrite to persist the prune, even if we don't consume.
 	if matches != 1 {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	dNetwork "github.com/docker/docker/api/types/network"
@@ -169,6 +170,14 @@ type Plugin struct {
 	// path. Held only across that small operation; never combined
 	// with mu so the two locks can't deadlock against each other.
 	tombstoneMu sync.Mutex
+
+	// recoveredOK and recoveryFailed are bumped by recoverOneEndpoint's
+	// background Start goroutine and reported via /Plugin.Health, so
+	// operators can see whether plugin-restart recovery succeeded for
+	// every previously-attached container or whether some containers
+	// are now running without renewal.
+	recoveredOK     atomic.Int32
+	recoveryFailed  atomic.Int32
 }
 
 // storeJoinHint records the state collected during CreateEndpoint so
@@ -463,12 +472,15 @@ func (p *Plugin) recoverOneEndpoint(ctx context.Context, networkID, endpointID, 
 		startCtx, cancel := context.WithTimeout(context.Background(), p.awaitTimeout)
 		defer cancel()
 		if err := m.Start(startCtx); err != nil {
+			p.recoveryFailed.Add(1)
 			log.WithError(err).WithFields(log.Fields{
 				"network":  shortID(networkID),
 				"endpoint": shortID(endpointID),
-			}).Warn("recovery: persistent DHCP client Start failed; lease will not renew until next restart")
+			}).Error("recovery: persistent DHCP client Start failed; lease will not renew until container restart")
 			p.takeDHCPManager(endpointID)
+			return
 		}
+		p.recoveredOK.Add(1)
 	}()
 	return nil
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -362,6 +362,24 @@ func (p *Plugin) consumeTombstone(networkID, hostname string) (mac, ipv4, ipv6 s
 	}
 	// Always rewrite to persist the prune, even if we don't consume.
 	if matches != 1 {
+		// More than one match → ambiguous. Drop *all* matches so the
+		// next consumeTombstone for this network/hostname doesn't keep
+		// hitting the same poisoned set for the rest of the TTL window.
+		// Zero matches is harmless; the prune still gets persisted.
+		if matches > 1 {
+			kept := ts[:0]
+			for _, t := range ts {
+				if t.NetworkID == networkID {
+					if hostname != "" && t.Hostname != "" && t.Hostname != hostname {
+						kept = append(kept, t)
+						continue
+					}
+					continue
+				}
+				kept = append(kept, t)
+			}
+			ts = kept
+		}
 		if err := saveTombstones(ts); err != nil {
 			log.WithError(err).Debug("Failed to persist pruned tombstones")
 		}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -30,7 +30,7 @@ const DriverName string = "net-dhcp"
 // happen on malformed daemon responses during recovery).
 func shortID(id string) string {
 	if len(id) >= 12 {
-		return shortID(id)
+		return id[:12]
 	}
 	return id
 }
@@ -176,8 +176,8 @@ type Plugin struct {
 	// operators can see whether plugin-restart recovery succeeded for
 	// every previously-attached container or whether some containers
 	// are now running without renewal.
-	recoveredOK     atomic.Int32
-	recoveryFailed  atomic.Int32
+	recoveredOK    atomic.Int32
+	recoveryFailed atomic.Int32
 }
 
 // storeJoinHint records the state collected during CreateEndpoint so

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -48,6 +48,15 @@ const tombstoneTTL = 10 * time.Second
 type tombstone struct {
 	NetworkID  string `json:"network_id"`
 	MacAddress string `json:"mac_address"`
+	// Hostname, when non-empty, narrows tombstone matching to "same
+	// container" instead of "any container on the network". Without
+	// it, a sequential `compose restart` of N containers can let
+	// container B inherit container A's MAC during the brief window
+	// where A's tombstone is still fresh. With it, consumeTombstone
+	// requires NetworkID+Hostname to match. Empty hostname falls back
+	// to network-only matching (preserves the v0.5.0 contract for
+	// hostname-less containers and cases where the lookup raced).
+	Hostname string `json:"hostname,omitempty"`
 	// IPAddress, when non-empty, is the bare IPv4 address (no /mask)
 	// from the previous endpoint's lease. The next CreateEndpoint
 	// passes it to udhcpc as `-r ADDR` so the upstream DHCP server

--- a/pkg/plugin/state_test.go
+++ b/pkg/plugin/state_test.go
@@ -182,6 +182,34 @@ func TestTombstones_TwoOnSameNetworkBothSkipped(t *testing.T) {
 	}
 }
 
+// TestTombstones_AmbiguousMatchesDropped encodes the W-3 fix: when
+// two same-network tombstones both match the consume key, return
+// ok=false AND drop both, so the next consume isn't poisoned by the
+// same ambiguity for the rest of the TTL window.
+func TestTombstones_AmbiguousMatchesDropped(t *testing.T) {
+	withStateDir(t, t.TempDir())
+	p := newPluginForTest()
+	// Two tombstones with empty hostnames on the same network — the
+	// classic concurrent-restart case.
+	p.addTombstone("net-A", "", "aa:aa:aa:aa:aa:aa", "10.0.0.1", "")
+	p.addTombstone("net-A", "", "bb:bb:bb:bb:bb:bb", "10.0.0.2", "")
+
+	if _, _, _, ok := p.consumeTombstone("net-A", ""); ok {
+		t.Fatal("first consume must return ok=false (ambiguous)")
+	}
+	// Subsequent consume must also be ok=false but for "no match"
+	// reasons, not "still ambiguous" — both should be gone.
+	ts, err := loadTombstones()
+	if err != nil {
+		t.Fatalf("loadTombstones: %v", err)
+	}
+	for _, ts := range ts {
+		if ts.NetworkID == "net-A" {
+			t.Errorf("net-A tombstone survived ambiguous consume: %+v", ts)
+		}
+	}
+}
+
 // TestTombstones_HostnameNarrowsMatch encodes the C-5 fix: with two
 // tombstones on the same network but different hostnames, a consume
 // that names one hostname must return only that container's MAC.

--- a/pkg/plugin/state_test.go
+++ b/pkg/plugin/state_test.go
@@ -138,18 +138,18 @@ func TestTombstones_RoundtripAndConsume(t *testing.T) {
 	p := newPluginForTest()
 
 	// Empty state: no tombstones to consume.
-	if mac, ip, ipv6, ok := p.consumeTombstone("net-A"); ok {
+	if mac, ip, ipv6, ok := p.consumeTombstone("net-A", ""); ok {
 		t.Errorf("consumeTombstone on empty state returned (%q, %q, %q, true), want (\"\", \"\", \"\", false)", mac, ip, ipv6)
 	}
 
 	// One tombstone for net-A → next consumeTombstone for net-A wins.
-	p.addTombstone("net-A", "02:42:ac:11:00:01", "192.168.0.166", "fe80::1")
-	mac, ip, ipv6, ok := p.consumeTombstone("net-A")
+	p.addTombstone("net-A", "", "02:42:ac:11:00:01", "192.168.0.166", "fe80::1")
+	mac, ip, ipv6, ok := p.consumeTombstone("net-A", "")
 	if !ok || mac != "02:42:ac:11:00:01" || ip != "192.168.0.166" || ipv6 != "fe80::1" {
 		t.Errorf("consumeTombstone net-A: got (%q, %q, %q, %v), want (02:42:ac:11:00:01, 192.168.0.166, fe80::1, true)", mac, ip, ipv6, ok)
 	}
 	// Tombstone is consumed exactly once.
-	if mac, ip, ipv6, ok := p.consumeTombstone("net-A"); ok {
+	if mac, ip, ipv6, ok := p.consumeTombstone("net-A", ""); ok {
 		t.Errorf("second consumeTombstone returned (%q, %q, %q, true); should be empty after consume", mac, ip, ipv6)
 	}
 }
@@ -157,13 +157,13 @@ func TestTombstones_RoundtripAndConsume(t *testing.T) {
 func TestTombstones_DifferentNetworksDoNotMix(t *testing.T) {
 	withStateDir(t, t.TempDir())
 	p := newPluginForTest()
-	p.addTombstone("net-A", "aa:aa:aa:aa:aa:aa", "10.0.0.1", "")
-	p.addTombstone("net-B", "bb:bb:bb:bb:bb:bb", "10.0.0.2", "fe80::2")
+	p.addTombstone("net-A", "", "aa:aa:aa:aa:aa:aa", "10.0.0.1", "")
+	p.addTombstone("net-B", "", "bb:bb:bb:bb:bb:bb", "10.0.0.2", "fe80::2")
 
-	if mac, ip, ipv6, ok := p.consumeTombstone("net-A"); !ok || mac != "aa:aa:aa:aa:aa:aa" || ip != "10.0.0.1" || ipv6 != "" {
+	if mac, ip, ipv6, ok := p.consumeTombstone("net-A", ""); !ok || mac != "aa:aa:aa:aa:aa:aa" || ip != "10.0.0.1" || ipv6 != "" {
 		t.Errorf("net-A consume: got (%q, %q, %q, %v)", mac, ip, ipv6, ok)
 	}
-	if mac, ip, ipv6, ok := p.consumeTombstone("net-B"); !ok || mac != "bb:bb:bb:bb:bb:bb" || ip != "10.0.0.2" || ipv6 != "fe80::2" {
+	if mac, ip, ipv6, ok := p.consumeTombstone("net-B", ""); !ok || mac != "bb:bb:bb:bb:bb:bb" || ip != "10.0.0.2" || ipv6 != "fe80::2" {
 		t.Errorf("net-B consume: got (%q, %q, %q, %v)", mac, ip, ipv6, ok)
 	}
 }
@@ -171,14 +171,55 @@ func TestTombstones_DifferentNetworksDoNotMix(t *testing.T) {
 func TestTombstones_TwoOnSameNetworkBothSkipped(t *testing.T) {
 	withStateDir(t, t.TempDir())
 	p := newPluginForTest()
-	p.addTombstone("net-A", "aa:aa:aa:aa:aa:aa", "10.0.0.1", "")
-	p.addTombstone("net-A", "bb:bb:bb:bb:bb:bb", "10.0.0.2", "")
+	p.addTombstone("net-A", "", "aa:aa:aa:aa:aa:aa", "10.0.0.1", "")
+	p.addTombstone("net-A", "", "bb:bb:bb:bb:bb:bb", "10.0.0.2", "")
 
 	// Two matches on same network → ambiguous, return ok=false.
 	// The point is to avoid handing one container's MAC to a
 	// concurrently-restarting peer.
-	if mac, ip, ipv6, ok := p.consumeTombstone("net-A"); ok {
+	if mac, ip, ipv6, ok := p.consumeTombstone("net-A", ""); ok {
 		t.Errorf("consumeTombstone with 2 candidates should return ok=false, got (%q, %q, %q, true)", mac, ip, ipv6)
+	}
+}
+
+// TestTombstones_HostnameNarrowsMatch encodes the C-5 fix: with two
+// tombstones on the same network but different hostnames, a consume
+// that names one hostname must return only that container's MAC.
+// Before the fix, this case would return ok=false (ambiguous), and
+// before *that* a worse design returned ok=true with whichever
+// tombstone happened to be first — silently swapping container
+// identities during sequential `compose restart`.
+func TestTombstones_HostnameNarrowsMatch(t *testing.T) {
+	withStateDir(t, t.TempDir())
+	p := newPluginForTest()
+	p.addTombstone("net-A", "alpha", "aa:aa:aa:aa:aa:aa", "10.0.0.1", "")
+	p.addTombstone("net-A", "beta", "bb:bb:bb:bb:bb:bb", "10.0.0.2", "")
+
+	// Consume narrowed by hostname returns only the matching MAC.
+	mac, ip, _, ok := p.consumeTombstone("net-A", "alpha")
+	if !ok || mac != "aa:aa:aa:aa:aa:aa" || ip != "10.0.0.1" {
+		t.Fatalf("alpha consume: got (%q, %q, %v), want alpha's tombstone", mac, ip, ok)
+	}
+	// beta's tombstone must still be there.
+	mac, ip, _, ok = p.consumeTombstone("net-A", "beta")
+	if !ok || mac != "bb:bb:bb:bb:bb:bb" || ip != "10.0.0.2" {
+		t.Fatalf("beta consume: got (%q, %q, %v), want beta's tombstone", mac, ip, ok)
+	}
+}
+
+// TestTombstones_EmptyHostnameMatchesAny verifies the backward-compat
+// path: a v0.5.0 tombstone (no hostname) is still consumable when the
+// new code calls with hostname="" or with a non-empty hostname (in
+// which case empty Hostname is treated as "matches anything"). Only
+// the "exactly one" rule still fires.
+func TestTombstones_EmptyHostnameMatchesAny(t *testing.T) {
+	withStateDir(t, t.TempDir())
+	p := newPluginForTest()
+	// Pre-existing tombstone written by an older binary (no hostname).
+	p.addTombstone("net-A", "", "aa:aa:aa:aa:aa:aa", "10.0.0.1", "")
+	mac, _, _, ok := p.consumeTombstone("net-A", "alpha")
+	if !ok || mac != "aa:aa:aa:aa:aa:aa" {
+		t.Errorf("v0.5.0 tombstone should still match: got (%q, %v)", mac, ok)
 	}
 }
 
@@ -197,7 +238,7 @@ func TestTombstones_ExpiredEntriesPruned(t *testing.T) {
 		t.Fatalf("saveTombstones: %v", err)
 	}
 	p := newPluginForTest()
-	if mac, ip, ipv6, ok := p.consumeTombstone("net-A"); ok {
+	if mac, ip, ipv6, ok := p.consumeTombstone("net-A", ""); ok {
 		t.Errorf("expired tombstone should not be consumed, got (%q, %q, %q, true)", mac, ip, ipv6)
 	}
 }

--- a/pkg/udhcpc/client.go
+++ b/pkg/udhcpc/client.go
@@ -246,12 +246,15 @@ func (c *DHCPClient) Finish(ctx context.Context) error {
 }
 
 // GetIP is a convenience function that runs udhcpc(6) once and returns the IP
-// info obtained.
+// info obtained. The caller's opts is not mutated — we work on a local copy
+// so a caller that reuses the options struct between persistent and one-shot
+// calls doesn't get its Once flag flipped on.
 func GetIP(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, error) {
 	dummy := Info{}
 
-	opts.Once = true
-	client, err := NewDHCPClient(iface, opts)
+	optsCopy := *opts
+	optsCopy.Once = true
+	client, err := NewDHCPClient(iface, &optsCopy)
 	if err != nil {
 		return dummy, fmt.Errorf("failed to create DHCP client: %w", err)
 	}

--- a/pkg/udhcpc/client.go
+++ b/pkg/udhcpc/client.go
@@ -187,8 +187,14 @@ func (c *DHCPClient) Start() (chan Event, error) {
 		return nil, err
 	}
 
-	events := make(chan Event)
+	// Buffered + non-blocking send: after Finish runs, the consumer
+	// goroutine in dhcpManager has already taken the stop branch and
+	// will never read events again. A final event line emitted by
+	// udhcpc between SIGTERM and exit must not deadlock the scanner
+	// goroutine on an unbuffered send.
+	events := make(chan Event, 16)
 	go func() {
+		defer close(events)
 		scanner := bufio.NewScanner(c.eventPipe)
 		for scanner.Scan() {
 			log.WithField("line", string(scanner.Bytes())).Trace("udhcpc handler line")
@@ -200,7 +206,11 @@ func (c *DHCPClient) Start() (chan Event, error) {
 				continue
 			}
 
-			events <- event
+			select {
+			case events <- event:
+			default:
+				log.WithField("event", event.Type).Warn("udhcpc event dropped: consumer slow or finished")
+			}
 		}
 	}()
 
@@ -217,7 +227,10 @@ func (c *DHCPClient) Finish(ctx context.Context) error {
 		}
 	}
 
-	errChan := make(chan error)
+	// Buffered: on ctx.Done we Kill and return without reading errChan,
+	// so the Wait goroutine must not block forever trying to send. With
+	// the buffer, Wait completes and the goroutine exits, no zombie.
+	errChan := make(chan error, 1)
 	go func() {
 		errChan <- c.cmd.Wait()
 	}()

--- a/pkg/udhcpc/client.go
+++ b/pkg/udhcpc/client.go
@@ -227,6 +227,14 @@ func (c *DHCPClient) Finish(ctx context.Context) error {
 		}
 	}
 
+	return c.Wait(ctx)
+}
+
+// Wait reaps the udhcpc(6) child without signalling it. Use this when the
+// process has already exited on its own (e.g. the consumer noticed the
+// event pipe close): if cmd.Wait is never called the kernel keeps the
+// child as a zombie. Bounded by ctx so a stuck Wait can't block teardown.
+func (c *DHCPClient) Wait(ctx context.Context) error {
 	// Buffered: on ctx.Done we Kill and return without reading errChan,
 	// so the Wait goroutine must not block forever trying to send. With
 	// the buffer, Wait completes and the goroutine exits, no zombie.

--- a/pkg/util/docker.go
+++ b/pkg/util/docker.go
@@ -6,37 +6,27 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
 	OptionsKeyGeneric = "com.docker.network.generic"
 )
 
+// AwaitContainerInspect polls docker.ContainerInspect until it succeeds,
+// ctx is cancelled, or interval-paced retries exhaust. Synchronous for
+// the same reason as AwaitNetNS — the previous async form leaked a
+// poller goroutine on ctx-cancel that kept hitting the Docker API forever.
 func AwaitContainerInspect(ctx context.Context, docker *client.Client, id string, interval time.Duration) (container.InspectResponse, error) {
-	var err error
-	ctrChan := make(chan container.InspectResponse)
-	go func() {
-		for {
-			var ctr container.InspectResponse
-			ctr, err = docker.ContainerInspect(ctx, id)
-			if err == nil {
-				ctrChan <- ctr
-				return
-			}
-
-			time.Sleep(interval)
-		}
-	}()
-
 	var dummy container.InspectResponse
-	select {
-	case link := <-ctrChan:
-		return link, nil
-	case <-ctx.Done():
-		if err != nil {
-			log.WithError(err).WithField("id", id).Error("Failed to await container by ID")
+	for {
+		ctr, err := docker.ContainerInspect(ctx, id)
+		if err == nil {
+			return ctr, nil
 		}
-		return dummy, ctx.Err()
+		select {
+		case <-ctx.Done():
+			return dummy, ctx.Err()
+		case <-time.After(interval):
+		}
 	}
 }

--- a/pkg/util/general.go
+++ b/pkg/util/general.go
@@ -5,29 +5,25 @@ import (
 	"time"
 )
 
+// AwaitCondition polls cond every interval until it returns ok=true, an
+// error, or ctx is cancelled. The poll runs synchronously in the caller's
+// goroutine: a previous async-poller form leaked a goroutine on every
+// ctx-cancel because it kept calling cond forever (typically Docker
+// NetworkInspect, ~10/s/leaked-goroutine). cond is expected to be
+// reasonably fast or to honor ctx itself; we don't try to interrupt it.
 func AwaitCondition(ctx context.Context, cond func() (bool, error), interval time.Duration) error {
-	errChan := make(chan error)
-	go func() {
-		for {
-			ok, err := cond()
-			if err != nil {
-				errChan <- err
-				return
-			}
-
-			if ok {
-				errChan <- nil
-				return
-			}
-
-			time.Sleep(interval)
+	for {
+		ok, err := cond()
+		if err != nil {
+			return err
 		}
-	}()
-
-	select {
-	case err := <-errChan:
-		return err
-	case <-ctx.Done():
-		return ctx.Err()
+		if ok {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
 	}
 }

--- a/pkg/util/netlink.go
+++ b/pkg/util/netlink.go
@@ -4,63 +4,42 @@ import (
 	"context"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 )
 
+// AwaitNetNS polls for a netns at path until it appears, ctx is cancelled,
+// or interval-paced retries exhaust. Synchronous to avoid leaking a
+// poller goroutine on ctx-cancel (the previous form did, and each leaked
+// goroutine kept hammering netns.GetFromPath forever).
 func AwaitNetNS(ctx context.Context, path string, interval time.Duration) (netns.NsHandle, error) {
-	var err error
-	nsChan := make(chan netns.NsHandle)
-	go func() {
-		for {
-			var ns netns.NsHandle
-			ns, err = netns.GetFromPath(path)
-			if err == nil {
-				nsChan <- ns
-				return
-			}
-
-			time.Sleep(interval)
-		}
-	}()
-
 	var dummy netns.NsHandle
-	select {
-	case ns := <-nsChan:
-		return ns, nil
-	case <-ctx.Done():
-		if err != nil {
-			log.WithError(err).WithField("path", path).Error("Failed to await network namespace")
+	for {
+		ns, err := netns.GetFromPath(path)
+		if err == nil {
+			return ns, nil
 		}
-		return dummy, ctx.Err()
+		select {
+		case <-ctx.Done():
+			return dummy, ctx.Err()
+		case <-time.After(interval):
+		}
 	}
 }
 
+// AwaitLinkByIndex polls for a netlink Link by index until it appears,
+// ctx is cancelled, or interval-paced retries exhaust. Synchronous for
+// the same reason as AwaitNetNS.
 func AwaitLinkByIndex(ctx context.Context, handle *netlink.Handle, index int, interval time.Duration) (netlink.Link, error) {
-	var err error
-	linkChan := make(chan netlink.Link)
-	go func() {
-		for {
-			var link netlink.Link
-			link, err = handle.LinkByIndex(index)
-			if err == nil {
-				linkChan <- link
-				return
-			}
-
-			time.Sleep(interval)
+	for {
+		link, err := handle.LinkByIndex(index)
+		if err == nil {
+			return link, nil
 		}
-	}()
-
-	var dummy netlink.Link
-	select {
-	case link := <-linkChan:
-		return link, nil
-	case <-ctx.Done():
-		if err != nil {
-			log.WithError(err).WithField("index", index).Error("Failed to await link by index")
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(interval):
 		}
-		return dummy, ctx.Err()
 	}
 }


### PR DESCRIPTION
Fast-forward merge of `main` into `dev`. `dev` is currently 14 commits behind `main` and 0 ahead, so this is a pure catch-up.

## What's in here

**Releases**:
- v0.5.1 (`ae6b1a0`) — code-review report committed alongside the release notes
- v0.5.2 (`a0f5014`, plus the three quick-win commits `9ba9136`/`bd78ca3`/`ecf4bfa`) — ten warning-level findings closed
- v0.5.3 (`b9b6775`, `9320166`) — hotfix: CPU spinner on closed udhcpc events channel; zombie udhcpc reaping; Await\* goroutine leaks

**Hotfix details (v0.5.3)**:
- `dhcpManager.setupClient` consumer used `case event := <-events` without checking `ok`. When udhcpc died on its own (NAK on renew, parent NIC vanished, container netns gone), the events channel closed and the consumer pegged a CPU thread forever — observed in production at ~70% of one host core for 1d14h with seven hot Go runtime threads. Fork-introduced regression in `d23ba50` (v0.5.0) as an incomplete fix to a different leak.
- `udhcpc.Wait` extracted from `Finish` so the consumer can reap a self-exited child without sending SIGTERM.
- `util.AwaitCondition` / `AwaitNetNS` / `AwaitLinkByIndex` / `AwaitContainerInspect` rewritten as synchronous loops that select on `ctx.Done()` between iterations — the old async-poller form leaked a goroutine on every ctx-cancel that kept hammering Docker/netlink at 10/s. Heritage upstream bug.

**Docs**:
- `1285607` — README install reference bumped from v0.4.0 to v0.5.3; all body examples now point at `ghcr.io/claymore666/docker-net-dhcp:v0.5.3` instead of the upstream `ghcr.io/devplayer0/...:release-linux-amd64` URL that consumers were copy-pasting.
- `9320166` — v0.5.3 release notes annotate which findings are heritage upstream vs fork-introduced.
- `ae6b1a0` — full code-review report committed.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `staticcheck ./...`, `gofmt -l .` — all clean
- [x] `go test -race -count=1 ./...` — passes (coverage 19.0%)
- [x] CI on main is green (matches `dev` workflow)
- [x] Live-tested on docker-ai: liga-news-backend on lan-shared (v0.5.3 driver) at 192.168.0.12, CPU flat across multiple 30s lease renewals
- [ ] CI on this PR runs the same suite against the `dev` branch tip after merge — verify before clicking Merge