### PR TITLE
Eliminate three concurrency hazards (W-1, W-5, W-11)

### DIFF
--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 	"time"
 
 	dNetwork "github.com/docker/docker/api/types/network"
@@ -31,8 +32,15 @@ type dhcpManager struct {
 	joinReq JoinRequest
 	opts    DHCPNetworkOptions
 
-	LastIP   *netlink.Addr
-	LastIPv6 *netlink.Addr
+	// ipMu guards lastIP / lastIPv6. Writes happen from the udhcpc
+	// event goroutine (renew); reads happen from Leave after Stop has
+	// drained that goroutine. The drain establishes happens-before in
+	// practice, but the race detector doesn't always see the channel
+	// pairing through `select`, and a future change to stop priority
+	// could turn this into a real race. Cheap to make explicit.
+	ipMu     sync.Mutex
+	lastIP   *netlink.Addr
+	lastIPv6 *netlink.Addr
 	// MacAddress is set in macvlan mode so we can re-find the link inside
 	// the container netns after Docker has moved and renamed it. Empty in
 	// bridge mode.
@@ -77,10 +85,29 @@ func (m *dhcpManager) logFields(v6 bool) log.Fields {
 	}
 }
 
-func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
-	lastIP := m.LastIP
+// lastIPs returns the most recently observed v4/v6 leases under ipMu.
+func (m *dhcpManager) lastIPs() (*netlink.Addr, *netlink.Addr) {
+	m.ipMu.Lock()
+	defer m.ipMu.Unlock()
+	return m.lastIP, m.lastIPv6
+}
+
+// setLastIP records a freshly-bound address under ipMu.
+func (m *dhcpManager) setLastIP(v6 bool, addr *netlink.Addr) {
+	m.ipMu.Lock()
+	defer m.ipMu.Unlock()
 	if v6 {
-		lastIP = m.LastIPv6
+		m.lastIPv6 = addr
+	} else {
+		m.lastIP = addr
+	}
+}
+
+func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
+	v4, v6Last := m.lastIPs()
+	lastIP := v4
+	if v6 {
+		lastIP = v6Last
 	}
 
 	ip, err := netlink.ParseAddr(info.IP)
@@ -102,11 +129,7 @@ func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
 	// Without this the manager keeps reporting whatever the very
 	// first CreateEndpoint DISCOVER produced, even if udhcpc has
 	// moved to a different lease since.
-	if v6 {
-		m.LastIPv6 = ip
-	} else {
-		m.LastIP = ip
-	}
+	m.setLastIP(v6, ip)
 
 	// Skip gateway-from-DHCP renewal handling when the operator pinned a
 	// gateway override on the network — leave their override in place.
@@ -163,13 +186,15 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 	// On plugin-restart recovery the persistent client should ask the
 	// DHCP server for the IP the container is already using, instead
 	// of doing a fresh DISCOVER that might return something different.
-	// In the normal CreateEndpoint -> Join path m.LastIP / m.LastIPv6
+	// In the normal CreateEndpoint -> Join path lastIP / lastIPv6
 	// already point at the IP we just acquired; passing it as -r is a
 	// no-op (server still ACKs the same address). On recovery it's
 	// what makes the lease "sticky".
 	requestedIP := ""
-	if !v6 && m.LastIP != nil && m.LastIP.IP != nil {
-		requestedIP = m.LastIP.IP.String()
+	if !v6 {
+		if v4Addr, _ := m.lastIPs(); v4Addr != nil && v4Addr.IP != nil {
+			requestedIP = v4Addr.IP.String()
+		}
 	}
 	client, err := udhcpc.NewDHCPClient(m.ctrLink.Attrs().Name, &udhcpc.DHCPClientOptions{
 		Hostname:    m.hostname,

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -802,8 +802,8 @@ func (p *Plugin) Join(ctx context.Context, r JoinRequest) (JoinResponse, error) 
 	// (success or failure), so it's safe to call against a manager whose
 	// Start is still in flight.
 	m := newDHCPManager(p.docker, r, opts)
-	m.LastIP = hint.IPv4
-	m.LastIPv6 = hint.IPv6
+	m.setLastIP(false, hint.IPv4)
+	m.setLastIP(true, hint.IPv6)
 	m.MacAddress = hint.MacAddress
 	p.registerDHCPManager(r.EndpointID, m)
 
@@ -846,16 +846,19 @@ func (p *Plugin) Leave(ctx context.Context, r LeaveRequest) error {
 	// Refresh the endpoint fingerprint with the most recent v4/v6 IPs
 	// the persistent client saw, *whether or not Stop succeeded*. Stop
 	// drains the event goroutine before returning even on error, so
-	// manager.LastIP* are stable to read here. Doing this on the error
-	// path too means a wedged-udhcpc shutdown still produces a tombstone
-	// with the latest known lease (W-4) — otherwise DeleteEndpoint
-	// would lay down a tombstone with the stale initial-DISCOVER IPs.
+	// the read here is sequenced after every renew that's going to
+	// happen — but go through ipMu anyway so the race detector doesn't
+	// have to reason through `select`. Doing this on the error path too
+	// means a wedged-udhcpc shutdown still produces a tombstone with
+	// the latest known lease (W-4) — otherwise DeleteEndpoint would
+	// lay down a tombstone with the stale initial-DISCOVER IPs.
+	v4Addr, v6Addr := manager.lastIPs()
 	v4, v6 := "", ""
-	if manager.LastIP != nil && manager.LastIP.IP != nil {
-		v4 = manager.LastIP.IP.String()
+	if v4Addr != nil && v4Addr.IP != nil {
+		v4 = v4Addr.IP.String()
 	}
-	if manager.LastIPv6 != nil && manager.LastIPv6.IP != nil {
-		v6 = manager.LastIPv6.IP.String()
+	if v6Addr != nil && v6Addr.IP != nil {
+		v6 = v6Addr.IP.String()
 	}
 	p.updateEndpointIPs(r.EndpointID, v4, v6)
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -494,8 +494,8 @@ func (p *Plugin) recoverOneEndpoint(ctx context.Context, networkID, endpointID, 
 		EndpointID: endpointID,
 	}
 	m := newDHCPManager(p.docker, fakeJoin, opts)
-	m.LastIP = ipv4
-	m.LastIPv6 = ipv6
+	m.setLastIP(false, ipv4)
+	m.setLastIP(true, ipv6)
 	m.MacAddress = mac
 	p.registerDHCPManager(endpointID, m)
 
@@ -659,15 +659,18 @@ func NewPlugin(awaitTimeout time.Duration) (*Plugin, error) {
 		Handler: handlers.CustomLoggingHandler(nil, mux, util.WriteAccessLog),
 	}
 
-	// Kick off endpoint recovery in the background. We don't block
-	// plugin startup on it: libnetwork RPCs for fresh networks should
-	// be served immediately. Recovery serialises against those via the
-	// Plugin mutex on the maps.
-	go func() {
+	// Run endpoint recovery synchronously before NewPlugin returns
+	// (and thus before Listen accepts the first RPC). Doing it on a
+	// background goroutine — the previous behaviour — opened a window
+	// where a fresh CreateEndpoint could race recovery's Start for the
+	// same endpoint: the map check is mutex-protected, but Start runs
+	// outside the mutex. Recovery is bounded at 30s, which is acceptable
+	// plugin-enable latency.
+	{
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
 		p.recoverEndpoints(ctx)
-	}()
+		cancel()
+	}
 
 	return &p, nil
 }

--- a/pkg/plugin/state_test.go
+++ b/pkg/plugin/state_test.go
@@ -2,8 +2,10 @@ package plugin
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -248,6 +250,41 @@ func TestTombstones_EmptyHostnameMatchesAny(t *testing.T) {
 	mac, _, _, ok := p.consumeTombstone("net-A", "alpha")
 	if !ok || mac != "aa:aa:aa:aa:aa:aa" {
 		t.Errorf("v0.5.0 tombstone should still match: got (%q, %v)", mac, ok)
+	}
+}
+
+// TestTombstones_ConcurrentAddDoesNotLose asserts that N parallel
+// addTombstone calls all land on disk. tombstoneMu serializes the
+// read-modify-write today; a refactor that drops the mutex would
+// silently lose entries because each writer's load+marshal loses
+// concurrent peers' updates. Run with -race for the full guarantee.
+func TestTombstones_ConcurrentAddDoesNotLose(t *testing.T) {
+	withStateDir(t, t.TempDir())
+	p := newPluginForTest()
+
+	const N = 50
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func(i int) {
+			defer wg.Done()
+			p.addTombstone(
+				fmt.Sprintf("net-%d", i),
+				"",
+				fmt.Sprintf("aa:bb:cc:dd:%02x:%02x", i>>8, i&0xff),
+				fmt.Sprintf("10.0.0.%d", (i%254)+1),
+				"",
+			)
+		}(i)
+	}
+	wg.Wait()
+
+	ts, err := loadTombstones()
+	if err != nil {
+		t.Fatalf("loadTombstones: %v", err)
+	}
+	if len(ts) != N {
+		t.Errorf("lost tombstones under concurrent adds: got %d, want %d", len(ts), N)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **#10 (W-1)**: Run `recoverEndpoints` synchronously in `NewPlugin` before `Listen` accepts the first RPC. The previous goroutine spawn opened a race window where a fresh `CreateEndpoint` could collide with recovery's `Start` for the same endpoint — the registry check was mutex-protected, but `Start` ran outside the mutex. Bounded at 30s.
- **#14 (W-5)**: Serialize `dhcpManager.lastIP` / `lastIPv6` through `ipMu`. `renew()` in the udhcpc event goroutine and `Leave()` at teardown were touching the same pointer without sync. The channel drain in `Stop` establishes happens-before in practice, but the race detector can't always see it through `select`, and a future change to stop priority would turn this into a real race.
- **#20 (W-11)**: Add `TestTombstones_ConcurrentAddDoesNotLose`. 50 parallel `addTombstone` calls must all land on disk; `tombstoneMu` makes this hold today, and the test is a regression gate against a future refactor that drops the mutex.

Closes #10, #14, #20.

## Test plan

- [x] go build ./... clean
- [x] go vet ./... clean
- [x] go test -race -count=1 ./... passes (new test included)
- [x] staticcheck ./... clean
- [ ] CI green (test + staticcheck) on this branch
- [ ] Integration smoke on gpu1-docker after merge to dev