### PR TITLE
Tombstone-write failures + DeleteNetwork manager prune

### DIFF
--- a/pkg/plugin/endpoints.go
+++ b/pkg/plugin/endpoints.go
@@ -227,12 +227,13 @@ func (p *Plugin) apiLeave(w http.ResponseWriter, r *http.Request) {
 // expiry. Operators should restart those containers (which produces a
 // fresh CreateEndpoint and gets them back into the persistent map).
 type HealthResponse struct {
-	Healthy         bool    `json:"healthy"`
-	UptimeSeconds   float64 `json:"uptime_seconds"`
-	ActiveEndpoints int     `json:"active_endpoints"`
-	PendingHints    int     `json:"pending_hints"`
-	RecoveredOK     int32   `json:"recovered_ok"`
-	RecoveryFailed  int32   `json:"recovery_failed"`
+	Healthy                bool    `json:"healthy"`
+	UptimeSeconds          float64 `json:"uptime_seconds"`
+	ActiveEndpoints        int     `json:"active_endpoints"`
+	PendingHints           int     `json:"pending_hints"`
+	RecoveredOK            int32   `json:"recovered_ok"`
+	RecoveryFailed         int32   `json:"recovery_failed"`
+	TombstoneWriteFailures int32   `json:"tombstone_write_failures"`
 }
 
 func (p *Plugin) apiHealth(w http.ResponseWriter, r *http.Request) {
@@ -242,12 +243,18 @@ func (p *Plugin) apiHealth(w http.ResponseWriter, r *http.Request) {
 	p.mu.Unlock()
 
 	failed := p.recoveryFailed.Load()
+	tsFails := p.tombstoneWriteFailures.Load()
 	util.JSONResponse(w, HealthResponse{
-		Healthy:         failed == 0,
-		UptimeSeconds:   time.Since(p.startTime).Seconds(),
-		ActiveEndpoints: active,
-		PendingHints:    pending,
-		RecoveredOK:     p.recoveredOK.Load(),
-		RecoveryFailed:  failed,
+		// Healthy is false on any condition that means an operator
+		// should look: a recovery failure means a running container has
+		// no renewal goroutine; a tombstone-write failure means the
+		// next restart of some container will pick a new MAC/IP.
+		Healthy:                failed == 0 && tsFails == 0,
+		UptimeSeconds:          time.Since(p.startTime).Seconds(),
+		ActiveEndpoints:        active,
+		PendingHints:           pending,
+		RecoveredOK:            p.recoveredOK.Load(),
+		RecoveryFailed:         failed,
+		TombstoneWriteFailures: tsFails,
 	}, http.StatusOK)
 }

--- a/pkg/plugin/endpoints_test.go
+++ b/pkg/plugin/endpoints_test.go
@@ -46,4 +46,37 @@ func TestApiHealth(t *testing.T) {
 	if got.UptimeSeconds < 2.5 || got.UptimeSeconds > 60 {
 		t.Errorf("uptime should be ~3s after seeding, got %v", got.UptimeSeconds)
 	}
+	if got.TombstoneWriteFailures != 0 {
+		t.Errorf("expected 0 tombstone write failures, got %d", got.TombstoneWriteFailures)
+	}
+}
+
+// TestApiHealth_TombstoneWriteFailureUnhealthy verifies that a non-zero
+// tombstoneWriteFailures counter flips the response to unhealthy. The
+// counter is bumped from addTombstone's saveTombstones error path; we
+// just write to it directly here since the surface we care about is
+// what /Plugin.Health reports, not the disk-write path that already
+// has its own coverage.
+func TestApiHealth_TombstoneWriteFailureUnhealthy(t *testing.T) {
+	p := &Plugin{
+		startTime:      time.Now(),
+		joinHints:      make(map[string]joinHint),
+		persistentDHCP: make(map[string]*dhcpManager),
+	}
+	p.tombstoneWriteFailures.Add(2)
+
+	req := httptest.NewRequest(http.MethodGet, "/Plugin.Health", nil)
+	rec := httptest.NewRecorder()
+	p.apiHealth(rec, req)
+
+	var got HealthResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Healthy {
+		t.Error("tombstone write failures must mark plugin unhealthy")
+	}
+	if got.TombstoneWriteFailures != 2 {
+		t.Errorf("expected 2 tombstone failures reported, got %d", got.TombstoneWriteFailures)
+	}
 }

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sync"
 
 	dNetwork "github.com/docker/docker/api/types/network"
 	"github.com/mitchellh/mapstructure"
@@ -177,12 +178,40 @@ func (p *Plugin) CreateNetwork(r CreateNetworkRequest) error {
 	return nil
 }
 
-// DeleteNetwork "deletes" a DHCP network (does nothing, the bridge is managed by the user)
+// DeleteNetwork "deletes" a DHCP network (the bridge is managed by the
+// user). We also evict any persistent DHCP managers attached to this
+// network: libnetwork doesn't issue Leave for endpoints in stopped
+// containers when the network is removed, so without this prune they
+// linger as ghost entries in /Plugin.Health.active_endpoints. Stop is
+// safe to call against a manager whose underlying netns is gone — it
+// just unblocks the udhcpc-events loop and returns; udhcpc itself may
+// have already self-exited because its netns vanished.
 func (p *Plugin) DeleteNetwork(r DeleteNetworkRequest) error {
 	if err := deleteOptions(r.NetworkID); err != nil {
 		log.WithError(err).WithField("network", r.NetworkID).
 			Warn("Failed to remove persisted options; harmless leftover")
 	}
+
+	orphaned := p.takeDHCPManagersForNetwork(r.NetworkID)
+	if len(orphaned) > 0 {
+		log.WithFields(log.Fields{
+			"network": r.NetworkID,
+			"count":   len(orphaned),
+		}).Info("Stopping orphaned DHCP managers on network removal")
+		var wg sync.WaitGroup
+		for _, m := range orphaned {
+			wg.Add(1)
+			go func(m *dhcpManager) {
+				defer wg.Done()
+				if err := m.Stop(); err != nil {
+					log.WithError(err).WithField("network", r.NetworkID).
+						Warn("Orphaned manager stop returned error; manager already removed from registry")
+				}
+			}(m)
+		}
+		wg.Wait()
+	}
+
 	log.WithField("network", r.NetworkID).Info("Network deleted")
 	return nil
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -178,6 +178,13 @@ type Plugin struct {
 	// are now running without renewal.
 	recoveredOK    atomic.Int32
 	recoveryFailed atomic.Int32
+
+	// tombstoneWriteFailures counts saveTombstones failures (disk full,
+	// EROFS) from addTombstone. Reported on /Plugin.Health so operators
+	// can detect a degraded restart-stability window — every failure
+	// here means one container that won't get its previous MAC/IP back
+	// on restart until the disk recovers.
+	tombstoneWriteFailures atomic.Int32
 }
 
 // storeJoinHint records the state collected during CreateEndpoint so
@@ -232,6 +239,27 @@ func (p *Plugin) takeDHCPManager(endpointID string) (*dhcpManager, bool) {
 		delete(p.persistentDHCP, endpointID)
 	}
 	return m, ok
+}
+
+// takeDHCPManagersForNetwork atomically retrieves and removes every
+// DHCP manager whose JoinRequest belongs to networkID. Used by
+// DeleteNetwork to evict managers that libnetwork didn't issue a Leave
+// for — typically the recovery-then-network-removed path: the plugin
+// recovered an endpoint into its registry, the network was deleted
+// while the container's netns was already gone, and no Leave RPC ever
+// arrived. Without this prune, /Plugin.Health's active_endpoints
+// count drifts upward across network upgrade cycles.
+func (p *Plugin) takeDHCPManagersForNetwork(networkID string) []*dhcpManager {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var out []*dhcpManager
+	for id, m := range p.persistentDHCP {
+		if m.joinReq.NetworkID == networkID {
+			out = append(out, m)
+			delete(p.persistentDHCP, id)
+		}
+	}
+	return out
 }
 
 // endpointFingerprint is the stable identity of a live endpoint we
@@ -323,6 +351,7 @@ func (p *Plugin) addTombstone(networkID, hostname, mac, ipv4, ipv6 string) {
 		DeletedAt:   time.Now(),
 	})
 	if err := saveTombstones(ts); err != nil {
+		p.tombstoneWriteFailures.Add(1)
 		log.WithError(err).Warn("Failed to persist tombstone; container restart may pick a new MAC/IP")
 	}
 }

--- a/pkg/plugin/race_test.go
+++ b/pkg/plugin/race_test.go
@@ -121,3 +121,54 @@ func TestPlugin_JoinHintFlow(t *testing.T) {
 		t.Error("takeDHCPManager must remove the entry it returns")
 	}
 }
+
+// TestTakeDHCPManagersForNetwork_PrunesByNetwork covers the #44 fix:
+// DeleteNetwork must evict every manager attached to the disappearing
+// network, leaving managers on other networks untouched. It's the
+// underlying primitive — DeleteNetwork's HTTP path also calls Stop on
+// each, but Stop's blocking semantics are exercised separately in
+// integration testing.
+func TestTakeDHCPManagersForNetwork_PrunesByNetwork(t *testing.T) {
+	p := &Plugin{
+		joinHints:      make(map[string]joinHint),
+		persistentDHCP: make(map[string]*dhcpManager),
+	}
+	mkMgr := func(networkID string) *dhcpManager {
+		return &dhcpManager{joinReq: JoinRequest{NetworkID: networkID}}
+	}
+	mA1 := mkMgr("net-A")
+	mA2 := mkMgr("net-A")
+	mB1 := mkMgr("net-B")
+	p.registerDHCPManager("ep-A1", mA1)
+	p.registerDHCPManager("ep-A2", mA2)
+	p.registerDHCPManager("ep-B1", mB1)
+
+	got := p.takeDHCPManagersForNetwork("net-A")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 managers evicted for net-A, got %d", len(got))
+	}
+	// Order isn't guaranteed (map iteration); verify by set membership.
+	have := map[*dhcpManager]bool{got[0]: true, got[1]: true}
+	if !have[mA1] || !have[mA2] {
+		t.Errorf("evicted set missing one of mA1/mA2: %+v", got)
+	}
+	if have[mB1] {
+		t.Error("net-B manager was wrongly evicted")
+	}
+
+	// Registry should now hold only the unrelated manager.
+	if _, ok := p.takeDHCPManager("ep-A1"); ok {
+		t.Error("ep-A1 should already be gone")
+	}
+	if _, ok := p.takeDHCPManager("ep-A2"); ok {
+		t.Error("ep-A2 should already be gone")
+	}
+	if m, ok := p.takeDHCPManager("ep-B1"); !ok || m != mB1 {
+		t.Errorf("ep-B1 should still be there: ok=%v m=%v", ok, m)
+	}
+
+	// Calling again on the now-empty network is a clean no-op.
+	if got := p.takeDHCPManagersForNetwork("net-A"); len(got) != 0 {
+		t.Errorf("expected empty result on second call, got %d managers", len(got))
+	}
+}


### PR DESCRIPTION
## Summary

- **#11 (W-2)**: `addTombstone` now bumps a `tombstoneWriteFailures` counter on `saveTombstones` failure, and `/Plugin.Health` exposes it. `Healthy` goes false on any non-zero count, so a disk-full / EROFS window that breaks restart-stability is visible to operators immediately.
- **#44**: `DeleteNetwork` evicts every `dhcpManager` whose `JoinRequest` belongs to the deleted network. libnetwork doesn't issue `Leave` for endpoints in stopped containers when the network is removed, so without this prune the registry accumulates ghost entries — observed on docker-ai 2026-05-03 (`active_endpoints=2` with one container actually attached). `takeDHCPManagersForNetwork` is the prune primitive (unit-tested); `DeleteNetwork` Stop()s the evicted managers in parallel.

Closes #11, #44.

## Test plan

- [x] go build ./... clean
- [x] go vet ./... clean
- [x] go test -race -count=1 ./... passes (new tests included)
- [x] staticcheck ./... clean
- [ ] CI green on this branch
- [ ] After merge to dev: integration smoke on gpu1-docker — verify /Plugin.Health.active_endpoints drops to 0 after `docker network rm` of a network with attached managers