### PR TITLE
Tighter Docker poll timeout + SIGHUP log reopen + compose merge docs

### DIFF
--- a/cmd/net-dhcp/main.go
+++ b/cmd/net-dhcp/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 	"os/signal"
+	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -33,14 +34,56 @@ func main() {
 	}
 	log.SetLevel(level)
 
-	if *logFile != "" {
+	// logFileMu guards the SIGHUP reopen path. Without it, a HUP
+	// arriving while logrus is mid-write could swap Out from under
+	// the writer; the lock makes "current fd is the one we just
+	// installed" hold.
+	var logFileMu sync.Mutex
+	var currentLogFd *os.File
+	openLogFile := func() error {
 		f, err := os.OpenFile(*logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 		if err != nil {
+			return err
+		}
+		logFileMu.Lock()
+		old := currentLogFd
+		currentLogFd = f
+		log.StandardLogger().Out = f
+		logFileMu.Unlock()
+		if old != nil {
+			_ = old.Close()
+		}
+		return nil
+	}
+
+	if *logFile != "" {
+		if err := openLogFile(); err != nil {
 			log.WithError(err).Fatal("Failed to open log file for writing")
 		}
-		defer func() { _ = f.Close() }()
+		defer func() {
+			logFileMu.Lock()
+			defer logFileMu.Unlock()
+			if currentLogFd != nil {
+				_ = currentLogFd.Close()
+			}
+		}()
 
-		log.StandardLogger().Out = f
+		// SIGHUP reopens the log file so logrotate (move-then-signal,
+		// or copytruncate followed by HUP) doesn't leave us writing
+		// into a unlinked or truncated fd. logrotate's `postrotate`
+		// is the conventional place to send HUP; this handler matches
+		// the common daemon behaviour.
+		hup := make(chan os.Signal, 1)
+		signal.Notify(hup, unix.SIGHUP)
+		go func() {
+			for range hup {
+				if err := openLogFile(); err != nil {
+					log.WithError(err).Warn("Failed to reopen log file on SIGHUP")
+				} else {
+					log.Info("Reopened log file on SIGHUP")
+				}
+			}
+		}()
 	}
 
 	awaitTimeout := 10 * time.Second // matches config.json default

--- a/cmd/net-dhcp/main.go
+++ b/cmd/net-dhcp/main.go
@@ -22,6 +22,31 @@ var (
 func main() {
 	flag.Parse()
 
+	// logFileMu guards the SIGHUP reopen path. Without it, a HUP
+	// arriving while logrus is mid-write could swap Out from under
+	// the writer; the lock makes "current fd is the one we just
+	// installed" hold. closeLogFile / fatalCleanup also reach for it.
+	var logFileMu sync.Mutex
+	var currentLogFd *os.File
+	closeLogFile := func() {
+		logFileMu.Lock()
+		defer logFileMu.Unlock()
+		if currentLogFd != nil {
+			_ = currentLogFd.Close()
+			currentLogFd = nil
+		}
+	}
+	// fatalCleanup mirrors log.WithError(err).Fatal but flushes and
+	// closes the log file first, so the final error line reaches disk.
+	// log.Fatal calls os.Exit(1) directly, which skips deferred Closes
+	// — without this helper the last logged line can be lost in the
+	// stdio buffer under -logfile.
+	fatalCleanup := func(err error, msg string) {
+		log.WithError(err).Error(msg)
+		closeLogFile()
+		os.Exit(1)
+	}
+
 	if *logLevel == "" {
 		if *logLevel = os.Getenv("LOG_LEVEL"); *logLevel == "" {
 			*logLevel = "info"
@@ -30,16 +55,10 @@ func main() {
 
 	level, err := log.ParseLevel(*logLevel)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to parse log level")
+		fatalCleanup(err, "Failed to parse log level")
 	}
 	log.SetLevel(level)
 
-	// logFileMu guards the SIGHUP reopen path. Without it, a HUP
-	// arriving while logrus is mid-write could swap Out from under
-	// the writer; the lock makes "current fd is the one we just
-	// installed" hold.
-	var logFileMu sync.Mutex
-	var currentLogFd *os.File
 	openLogFile := func() error {
 		f, err := os.OpenFile(*logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 		if err != nil {
@@ -58,15 +77,9 @@ func main() {
 
 	if *logFile != "" {
 		if err := openLogFile(); err != nil {
-			log.WithError(err).Fatal("Failed to open log file for writing")
+			fatalCleanup(err, "Failed to open log file for writing")
 		}
-		defer func() {
-			logFileMu.Lock()
-			defer logFileMu.Unlock()
-			if currentLogFd != nil {
-				_ = currentLogFd.Close()
-			}
-		}()
+		defer closeLogFile()
 
 		// SIGHUP reopens the log file so logrotate (move-then-signal,
 		// or copytruncate followed by HUP) doesn't leave us writing
@@ -90,13 +103,13 @@ func main() {
 	if t, ok := os.LookupEnv("AWAIT_TIMEOUT"); ok {
 		awaitTimeout, err = time.ParseDuration(t)
 		if err != nil {
-			log.WithError(err).Fatal("Failed to parse await timeout")
+			fatalCleanup(err, "Failed to parse await timeout")
 		}
 	}
 
 	p, err := plugin.NewPlugin(awaitTimeout)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to create plugin")
+		fatalCleanup(err, "Failed to create plugin")
 	}
 
 	sigs := make(chan os.Signal, 1)
@@ -105,13 +118,13 @@ func main() {
 	go func() {
 		log.Info("Starting server...")
 		if err := p.Listen(*bindSock); err != nil {
-			log.WithError(err).Fatal("Failed to start plugin")
+			fatalCleanup(err, "Failed to start plugin")
 		}
 	}()
 
 	<-sigs
 	log.Info("Shutting down...")
 	if err := p.Close(); err != nil {
-		log.WithError(err).Fatal("Failed to stop plugin")
+		fatalCleanup(err, "Failed to stop plugin")
 	}
 }

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -168,6 +168,55 @@ DHCP server has a free lease in its pool.
 **`docker plugin install` reports "invalid rootfs"** — your Docker daemon
 is too old. Plugin requires Docker 23+.
 
+**Compose silently doesn't attach the container to the DHCP network.**
+Compose merges base and override files at the top-level `networks:` map
+*key by key*, not file by file. A common deployment shape with this
+plugin is "use built-in macvlan in dev, switch to an external pre-created
+DHCP network in prod" — written as:
+
+```yaml
+# docker-compose.yml (base)
+networks:
+  lan:
+    driver: macvlan
+    driver_opts:
+      parent: ${LAN_INTERFACE:-eth0}
+    ipam:
+      config:
+        - subnet: 192.168.0.0/24
+          gateway: 192.168.0.1
+          ip_range: 192.168.0.200/30
+
+# docker-compose.prod.yml (override)
+networks:
+  lan:
+    external: true
+    name: lan-shared
+```
+
+Compose merges these into a hybrid: `external: true` AND `driver: macvlan`
+AND `ipam.config: [...]`. At runtime Compose silently skips attaching
+your service to `lan` because the merged result doesn't match either
+contract (pure-external attach vs internal-create). The container comes
+up attached only to the other networks listed in `services.<name>.networks`.
+
+Diagnostic: run `docker compose -f docker-compose.yml -f docker-compose.prod.yml config`
+and check the merged `networks.lan` block. If you see `external: true`
+alongside `driver` or `ipam`, you've hit this trap.
+
+Fixes (consumer-side; the plugin can't influence Compose's merge logic):
+
+- **Best**: don't define `lan` in the base file at all. Move the dev
+  definition into `docker-compose.dev.yml` and the prod override into
+  `docker-compose.prod.yml`. Each file then *replaces* `lan` entirely.
+- **Acceptable**: keep base, but in the override redefine `lan` with
+  every key the base sets to `null` to wipe them: `driver: null`,
+  `driver_opts: null`, `ipam: null`, `external: true`, `name: lan-shared`.
+  Brittle — each new key in base needs a matching null in override.
+- **Workaround for stuck operators**: `docker network connect lan-shared
+  <container>` after `docker compose up`. One-shot fix; doesn't survive
+  recreate.
+
 ## Static IP requests
 
 Plugin networks use `--ipam-driver=null`, which means `docker run --ip=`

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -582,9 +582,20 @@ func (p *Plugin) initialDHCPHostname(ctx context.Context, networkID, endpointID 
 	ctx, cancel := context.WithTimeout(ctx, initialDHCPHostnameLookupTimeout)
 	defer cancel()
 
+	// Each Docker call inside the poll body is bounded much tighter
+	// than the outer 2s budget so a single hung NetworkInspect /
+	// ContainerInspect doesn't burn the whole window. The Docker client
+	// itself has its own 2s per-request timeout (NewPlugin), but that's
+	// the same as our entire poll budget — without an inner cap, one
+	// stuck call effectively turns the 100ms retry interval into a 2s
+	// retry interval. Cap the inner ctx at the poll interval.
+	const dockerCallTimeout = 200 * time.Millisecond
+
 	var hostname string
 	_ = util.AwaitCondition(ctx, func() (bool, error) {
-		dockerNet, err := p.docker.NetworkInspect(ctx, networkID, dNetwork.InspectOptions{})
+		inner, innerCancel := context.WithTimeout(ctx, dockerCallTimeout)
+		defer innerCancel()
+		dockerNet, err := p.docker.NetworkInspect(inner, networkID, dNetwork.InspectOptions{})
 		if err != nil {
 			// Don't propagate the error — we want to keep retrying
 			// while the timeout has time. The caller treats an empty
@@ -600,7 +611,7 @@ func (p *Plugin) initialDHCPHostname(ctx context.Context, networkID, endpointID 
 			if strings.HasPrefix(ctrID, "ep-") {
 				return false, nil
 			}
-			ctr, err := p.docker.ContainerInspect(ctx, ctrID)
+			ctr, err := p.docker.ContainerInspect(inner, ctrID)
 			if err != nil {
 				return false, nil
 			}


### PR DESCRIPTION
## Summary

- **#21 (W-12)**: Cap each `NetworkInspect` / `ContainerInspect` call inside `initialDHCPHostname`'s poll body at 200 ms. The Docker client's own 2 s per-request timeout was the same as the entire poll budget, so one hung call effectively turned the 100 ms retry interval into a 2 s retry interval.
- **#34 (N-3)**: Handle `SIGHUP` in `cmd/net-dhcp/main.go` to close and reopen the log file. logrotate's move-and-signal / copytruncate flows otherwise leave the plugin writing into an unlinked or zero-length fd and logs vanish until the next plugin restart.
- **#45**: Add a `docs/parent-attached-modes.md` Troubleshooting section describing the Compose base+override merge trap that silently drops the `lan` network attachment. Fix is consumer-side; this stops operators from rediscovering it the way docker-ai did across two release deploys.

Closes #21, #34, #45.

## Test plan

- [x] go build ./... clean
- [x] go vet ./... clean
- [x] go test -race -count=1 ./... passes
- [x] staticcheck ./... clean
- [ ] CI green
- [ ] On gpu1-docker after merge to dev: send SIGHUP to the plugin process after `mv net-dhcp.log net-dhcp.log.1`, confirm new log file appears and writes resume there.