### PR TITLE
Pin Dockerfile + drop CAP_SYS_PTRACE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,15 @@ COPY pkg/ ./pkg/
 RUN mkdir bin/ && go build -o bin/ ./cmd/...
 
 
-FROM alpine:3.20
+FROM alpine:3.20.3@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
 
-RUN mkdir -p /run/docker/plugins /var/lib/net-dhcp && apk add --no-cache busybox-extras iproute2
+# Pin both the Alpine minor and the apk package versions: busybox supplies
+# udhcpc (the entire DHCP exchange), so a silent regression in busybox-extras
+# would land in plugin builds without warning. Bump together when refreshing.
+RUN mkdir -p /run/docker/plugins /var/lib/net-dhcp && \
+    apk add --no-cache \
+        busybox-extras=1.36.1-r31 \
+        iproute2=6.9.0-r0
 
 COPY --from=builder /usr/local/src/docker-net-dhcp/bin/net-dhcp /usr/sbin/
 COPY --from=builder /usr/local/src/docker-net-dhcp/bin/udhcpc-handler /usr/lib/net-dhcp/udhcpc-handler

--- a/config.json
+++ b/config.json
@@ -51,8 +51,7 @@
     "linux": {
         "capabilities": [
             "CAP_NET_ADMIN",
-            "CAP_SYS_ADMIN",
-            "CAP_SYS_PTRACE"
+            "CAP_SYS_ADMIN"
         ]
     }
 }


### PR DESCRIPTION
## Summary

- **#22 + #42 (I-1, N-11)**: Pin `alpine:3.20.3@sha256:d9e853e8…` and pin `busybox-extras=1.36.1-r31` + `iproute2=6.9.0-r0`. busybox supplies udhcpc, where the entire DHCP exchange runs — a silent regression there would land on the next build with no signal.
- **#23 (I-2)**: Drop `CAP_SYS_PTRACE`. `setns` and netlink operations only need `CAP_SYS_ADMIN`. PTRACE was inherited from upstream but isn't reachable from any code path here.

Closes #22, #23, #42.

## Test plan

- [x] go build ./... clean
- [x] go test ./... passes (no test-affecting changes)
- [ ] **Required before merge**: gpu1-docker smoke test must succeed with the cap-dropped plugin. If endpoint creation or recovery fails, revert the `config.json` hunk and reopen #23.