### PR TITLE
Release v0.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,15 @@ COPY pkg/ ./pkg/
 RUN mkdir bin/ && go build -o bin/ ./cmd/...
 
 
-FROM alpine:3.20
+FROM alpine:3.20.3@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
 
-RUN mkdir -p /run/docker/plugins /var/lib/net-dhcp && apk add --no-cache busybox-extras iproute2
+# Pin both the Alpine minor and the apk package versions: busybox supplies
+# udhcpc (the entire DHCP exchange), so a silent regression in busybox-extras
+# would land in plugin builds without warning. Bump together when refreshing.
+RUN mkdir -p /run/docker/plugins /var/lib/net-dhcp && \
+    apk add --no-cache \
+        busybox-extras=1.36.1-r31 \
+        iproute2=6.9.0-r0
 
 COPY --from=builder /usr/local/src/docker-net-dhcp/bin/net-dhcp /usr/sbin/
 COPY --from=builder /usr/local/src/docker-net-dhcp/bin/udhcpc-handler /usr/lib/net-dhcp/udhcpc-handler

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,21 @@ forks that have been waiting on review.
 
 [upstream]: https://github.com/devplayer0/docker-net-dhcp
 
+## Acknowledged findings (not applicable to this fork)
+
+The third-pass code review of v0.5.3 ran `govulncheck` and surfaced
+two informational findings on `github.com/docker/docker`:
+
+- **GO-2026-4887** — Moby AuthZ plugin bypass on oversized request bodies.
+- **GO-2026-4883** — Moby off-by-one in plugin privilege validation.
+
+Both are **daemon-side** vulnerabilities. This plugin uses
+`github.com/docker/docker` only as a client library — the call sites
+are `NetworkList`, `NetworkInspect`, and `ContainerInspect`. Neither
+vulnerable code path is reachable from the plugin process, so no
+action is required. Recorded here so future audits don't
+re-investigate. (Original report: third-pass code review, 2026-05-04.)
+
 ## v0.5.3
 
 Hotfix for a CPU-burning busy loop and a process-leak in the

--- a/cmd/net-dhcp/main.go
+++ b/cmd/net-dhcp/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 	"os/signal"
+	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -33,14 +34,56 @@ func main() {
 	}
 	log.SetLevel(level)
 
-	if *logFile != "" {
+	// logFileMu guards the SIGHUP reopen path. Without it, a HUP
+	// arriving while logrus is mid-write could swap Out from under
+	// the writer; the lock makes "current fd is the one we just
+	// installed" hold.
+	var logFileMu sync.Mutex
+	var currentLogFd *os.File
+	openLogFile := func() error {
 		f, err := os.OpenFile(*logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 		if err != nil {
+			return err
+		}
+		logFileMu.Lock()
+		old := currentLogFd
+		currentLogFd = f
+		log.StandardLogger().Out = f
+		logFileMu.Unlock()
+		if old != nil {
+			_ = old.Close()
+		}
+		return nil
+	}
+
+	if *logFile != "" {
+		if err := openLogFile(); err != nil {
 			log.WithError(err).Fatal("Failed to open log file for writing")
 		}
-		defer func() { _ = f.Close() }()
+		defer func() {
+			logFileMu.Lock()
+			defer logFileMu.Unlock()
+			if currentLogFd != nil {
+				_ = currentLogFd.Close()
+			}
+		}()
 
-		log.StandardLogger().Out = f
+		// SIGHUP reopens the log file so logrotate (move-then-signal,
+		// or copytruncate followed by HUP) doesn't leave us writing
+		// into a unlinked or truncated fd. logrotate's `postrotate`
+		// is the conventional place to send HUP; this handler matches
+		// the common daemon behaviour.
+		hup := make(chan os.Signal, 1)
+		signal.Notify(hup, unix.SIGHUP)
+		go func() {
+			for range hup {
+				if err := openLogFile(); err != nil {
+					log.WithError(err).Warn("Failed to reopen log file on SIGHUP")
+				} else {
+					log.Info("Reopened log file on SIGHUP")
+				}
+			}
+		}()
 	}
 
 	awaitTimeout := 10 * time.Second // matches config.json default

--- a/cmd/net-dhcp/main.go
+++ b/cmd/net-dhcp/main.go
@@ -22,6 +22,31 @@ var (
 func main() {
 	flag.Parse()
 
+	// logFileMu guards the SIGHUP reopen path. Without it, a HUP
+	// arriving while logrus is mid-write could swap Out from under
+	// the writer; the lock makes "current fd is the one we just
+	// installed" hold. closeLogFile / fatalCleanup also reach for it.
+	var logFileMu sync.Mutex
+	var currentLogFd *os.File
+	closeLogFile := func() {
+		logFileMu.Lock()
+		defer logFileMu.Unlock()
+		if currentLogFd != nil {
+			_ = currentLogFd.Close()
+			currentLogFd = nil
+		}
+	}
+	// fatalCleanup mirrors log.WithError(err).Fatal but flushes and
+	// closes the log file first, so the final error line reaches disk.
+	// log.Fatal calls os.Exit(1) directly, which skips deferred Closes
+	// — without this helper the last logged line can be lost in the
+	// stdio buffer under -logfile.
+	fatalCleanup := func(err error, msg string) {
+		log.WithError(err).Error(msg)
+		closeLogFile()
+		os.Exit(1)
+	}
+
 	if *logLevel == "" {
 		if *logLevel = os.Getenv("LOG_LEVEL"); *logLevel == "" {
 			*logLevel = "info"
@@ -30,16 +55,10 @@ func main() {
 
 	level, err := log.ParseLevel(*logLevel)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to parse log level")
+		fatalCleanup(err, "Failed to parse log level")
 	}
 	log.SetLevel(level)
 
-	// logFileMu guards the SIGHUP reopen path. Without it, a HUP
-	// arriving while logrus is mid-write could swap Out from under
-	// the writer; the lock makes "current fd is the one we just
-	// installed" hold.
-	var logFileMu sync.Mutex
-	var currentLogFd *os.File
 	openLogFile := func() error {
 		f, err := os.OpenFile(*logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 		if err != nil {
@@ -58,15 +77,9 @@ func main() {
 
 	if *logFile != "" {
 		if err := openLogFile(); err != nil {
-			log.WithError(err).Fatal("Failed to open log file for writing")
+			fatalCleanup(err, "Failed to open log file for writing")
 		}
-		defer func() {
-			logFileMu.Lock()
-			defer logFileMu.Unlock()
-			if currentLogFd != nil {
-				_ = currentLogFd.Close()
-			}
-		}()
+		defer closeLogFile()
 
 		// SIGHUP reopens the log file so logrotate (move-then-signal,
 		// or copytruncate followed by HUP) doesn't leave us writing
@@ -90,13 +103,13 @@ func main() {
 	if t, ok := os.LookupEnv("AWAIT_TIMEOUT"); ok {
 		awaitTimeout, err = time.ParseDuration(t)
 		if err != nil {
-			log.WithError(err).Fatal("Failed to parse await timeout")
+			fatalCleanup(err, "Failed to parse await timeout")
 		}
 	}
 
 	p, err := plugin.NewPlugin(awaitTimeout)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to create plugin")
+		fatalCleanup(err, "Failed to create plugin")
 	}
 
 	sigs := make(chan os.Signal, 1)
@@ -105,13 +118,13 @@ func main() {
 	go func() {
 		log.Info("Starting server...")
 		if err := p.Listen(*bindSock); err != nil {
-			log.WithError(err).Fatal("Failed to start plugin")
+			fatalCleanup(err, "Failed to start plugin")
 		}
 	}()
 
 	<-sigs
 	log.Info("Shutting down...")
 	if err := p.Close(); err != nil {
-		log.WithError(err).Fatal("Failed to stop plugin")
+		fatalCleanup(err, "Failed to stop plugin")
 	}
 }

--- a/config.json
+++ b/config.json
@@ -51,8 +51,7 @@
     "linux": {
         "capabilities": [
             "CAP_NET_ADMIN",
-            "CAP_SYS_ADMIN",
-            "CAP_SYS_PTRACE"
+            "CAP_SYS_ADMIN"
         ]
     }
 }

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -168,6 +168,55 @@ DHCP server has a free lease in its pool.
 **`docker plugin install` reports "invalid rootfs"** — your Docker daemon
 is too old. Plugin requires Docker 23+.
 
+**Compose silently doesn't attach the container to the DHCP network.**
+Compose merges base and override files at the top-level `networks:` map
+*key by key*, not file by file. A common deployment shape with this
+plugin is "use built-in macvlan in dev, switch to an external pre-created
+DHCP network in prod" — written as:
+
+```yaml
+# docker-compose.yml (base)
+networks:
+  lan:
+    driver: macvlan
+    driver_opts:
+      parent: ${LAN_INTERFACE:-eth0}
+    ipam:
+      config:
+        - subnet: 192.168.0.0/24
+          gateway: 192.168.0.1
+          ip_range: 192.168.0.200/30
+
+# docker-compose.prod.yml (override)
+networks:
+  lan:
+    external: true
+    name: lan-shared
+```
+
+Compose merges these into a hybrid: `external: true` AND `driver: macvlan`
+AND `ipam.config: [...]`. At runtime Compose silently skips attaching
+your service to `lan` because the merged result doesn't match either
+contract (pure-external attach vs internal-create). The container comes
+up attached only to the other networks listed in `services.<name>.networks`.
+
+Diagnostic: run `docker compose -f docker-compose.yml -f docker-compose.prod.yml config`
+and check the merged `networks.lan` block. If you see `external: true`
+alongside `driver` or `ipam`, you've hit this trap.
+
+Fixes (consumer-side; the plugin can't influence Compose's merge logic):
+
+- **Best**: don't define `lan` in the base file at all. Move the dev
+  definition into `docker-compose.dev.yml` and the prod override into
+  `docker-compose.prod.yml`. Each file then *replaces* `lan` entirely.
+- **Acceptable**: keep base, but in the override redefine `lan` with
+  every key the base sets to `null` to wipe them: `driver: null`,
+  `driver_opts: null`, `ipam: null`, `external: true`, `name: lan-shared`.
+  Brittle — each new key in base needs a matching null in override.
+- **Workaround for stuck operators**: `docker network connect lan-shared
+  <container>` after `docker compose up`. One-shot fix; doesn't survive
+  recreate.
+
 ## Static IP requests
 
 Plugin networks use `--ipam-driver=null`, which means `docker run --ip=`

--- a/pkg/plugin/api_handlers_test.go
+++ b/pkg/plugin/api_handlers_test.go
@@ -1,0 +1,387 @@
+package plugin
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestPlugin(t *testing.T) *Plugin {
+	t.Helper()
+	withStateDir(t, t.TempDir())
+	return &Plugin{
+		joinHints:            make(map[string]joinHint),
+		persistentDHCP:       make(map[string]*dhcpManager),
+		endpointFingerprints: make(map[string]endpointFingerprint),
+	}
+}
+
+func TestApiGetCapabilities(t *testing.T) {
+	p := newTestPlugin(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/NetworkDriver.GetCapabilities", nil)
+	p.apiGetCapabilities(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", rec.Code)
+	}
+	var got CapabilitiesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Scope != "local" {
+		t.Errorf("scope: got %q want local", got.Scope)
+	}
+	if got.ConnectivityScope != "global" {
+		t.Errorf("connectivity scope: got %q want global", got.ConnectivityScope)
+	}
+}
+
+// decodeErrBody decodes the application/problem+json body into the
+// jsonError shape (`{"Err": "..."}`). All wrappers use util.JSONErrResponse
+// which writes that schema.
+func decodeErrBody(t *testing.T, body []byte) string {
+	t.Helper()
+	var shape struct {
+		Err string `json:"Err"`
+	}
+	if err := json.Unmarshal(body, &shape); err != nil {
+		t.Fatalf("error body decode: %v (raw=%q)", err, string(body))
+	}
+	return shape.Err
+}
+
+// TestApiWrappers_BadJSON exercises the JSON-decode failure path of every
+// HTTP wrapper in one place. Each wrapper calls util.ParseJSONOrErrorResponse
+// first; a malformed body must short-circuit with a 400 application/problem+json
+// response and never invoke the underlying network method (which would need
+// netlink/docker and crash this unit test).
+func TestApiWrappers_BadJSON(t *testing.T) {
+	p := newTestPlugin(t)
+
+	cases := []struct {
+		name    string
+		handler func(http.ResponseWriter, *http.Request)
+	}{
+		{"CreateNetwork", p.apiCreateNetwork},
+		{"DeleteNetwork", p.apiDeleteNetwork},
+		{"CreateEndpoint", p.apiCreateEndpoint},
+		{"EndpointOperInfo", p.apiEndpointOperInfo},
+		{"DeleteEndpoint", p.apiDeleteEndpoint},
+		{"Join", p.apiJoin},
+		{"Leave", p.apiLeave},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("not-json"))
+			c.handler(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status: got %d want 400", rec.Code)
+			}
+			if ct := rec.Header().Get("Content-Type"); ct != "application/problem+json" {
+				t.Errorf("content-type: got %q want application/problem+json", ct)
+			}
+			if msg := decodeErrBody(t, rec.Body.Bytes()); !strings.Contains(msg, "failed to parse") {
+				t.Errorf("body: got %q want substring 'failed to parse'", msg)
+			}
+		})
+	}
+}
+
+func TestApiCreateNetwork_InvalidModeMaps400(t *testing.T) {
+	p := newTestPlugin(t)
+
+	body, err := json.Marshal(CreateNetworkRequest{
+		NetworkID: "net-invalid-mode",
+		Options: map[string]interface{}{
+			"com.docker.network.generic": map[string]interface{}{
+				"mode":   "wireguard",
+				"parent": "ens18",
+			},
+		},
+		IPv4Data: []*IPAMData{{AddressSpace: "null", Pool: "0.0.0.0/0"}},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	p.apiCreateNetwork(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400 (body=%s)", rec.Code, rec.Body.String())
+	}
+	msg := decodeErrBody(t, rec.Body.Bytes())
+	// errors.Is on the wire isn't possible, but the sentinel's literal text
+	// is what makes the response actionable for an operator.
+	if !strings.Contains(msg, "invalid mode") {
+		t.Errorf("body: got %q want substring 'invalid mode'", msg)
+	}
+}
+
+func TestApiCreateNetwork_BadIPAMMaps400(t *testing.T) {
+	p := newTestPlugin(t)
+
+	body, err := json.Marshal(CreateNetworkRequest{
+		NetworkID: "net-bad-ipam",
+		Options: map[string]interface{}{
+			"com.docker.network.generic": map[string]interface{}{"bridge": "br0"},
+		},
+		IPv4Data: []*IPAMData{{AddressSpace: "default", Pool: "10.0.0.0/8"}},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	p.apiCreateNetwork(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if msg := decodeErrBody(t, rec.Body.Bytes()); !strings.Contains(msg, "null IPAM") {
+		t.Errorf("body: got %q want substring 'null IPAM'", msg)
+	}
+}
+
+func TestApiCreateNetwork_BridgeMissingMaps400(t *testing.T) {
+	p := newTestPlugin(t)
+
+	body, err := json.Marshal(CreateNetworkRequest{
+		NetworkID: "net-no-bridge",
+		Options:   map[string]interface{}{"com.docker.network.generic": map[string]interface{}{}},
+		IPv4Data:  []*IPAMData{{AddressSpace: "null", Pool: "0.0.0.0/0"}},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	p.apiCreateNetwork(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400", rec.Code)
+	}
+	if msg := decodeErrBody(t, rec.Body.Bytes()); !strings.Contains(msg, "bridge required") {
+		t.Errorf("body: got %q want substring 'bridge required'", msg)
+	}
+}
+
+// TestApiDeleteNetwork_NoState verifies the success path of the only
+// HTTP wrapper whose underlying method is fully unit-testable: with no
+// state on disk and no DHCP managers, DeleteNetwork is a no-op that
+// returns 200 with a `{}` body.
+func TestApiDeleteNetwork_NoState(t *testing.T) {
+	p := newTestPlugin(t)
+
+	body, err := json.Marshal(DeleteNetworkRequest{NetworkID: "net-ghost"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	p.apiDeleteNetwork(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type: got %q want application/json", ct)
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != "{}" {
+		t.Errorf("body: got %q want {}", got)
+	}
+}
+
+// stoppableManager returns a dhcpManager whose Stop() short-circuits
+// because startedCh is closed AND startErr is set — that branch
+// returns nil immediately without touching netlink/handles.
+func stoppableManager(networkID string) *dhcpManager {
+	m := &dhcpManager{
+		joinReq:   JoinRequest{NetworkID: networkID},
+		startedCh: make(chan struct{}),
+		startErr:  errStubManager,
+	}
+	close(m.startedCh)
+	return m
+}
+
+var errStubManager = errors.New("stub manager (test-only)")
+
+// TestApiDeleteNetwork_DropsOrphanedManagers exercises the
+// takeDHCPManagersForNetwork prune introduced for the recovery-then-
+// network-removed lifecycle case (#44). Two managers belong to the
+// removed network, one to a peer; only the two get evicted.
+func TestApiDeleteNetwork_DropsOrphanedManagers(t *testing.T) {
+	p := newTestPlugin(t)
+
+	// Seed three managers across two networks. The stub managers'
+	// Stop() short-circuits via startErr so DeleteNetwork's wg.Wait
+	// completes without touching netlink.
+	p.persistentDHCP["ep-A1"] = stoppableManager("net-A")
+	p.persistentDHCP["ep-A2"] = stoppableManager("net-A")
+	p.persistentDHCP["ep-B1"] = stoppableManager("net-B")
+
+	body, err := json.Marshal(DeleteNetworkRequest{NetworkID: "net-A"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	p.apiDeleteNetwork(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	// net-A managers gone; net-B's survives.
+	if _, ok := p.persistentDHCP["ep-A1"]; ok {
+		t.Error("ep-A1 must be evicted by DeleteNetwork(net-A)")
+	}
+	if _, ok := p.persistentDHCP["ep-A2"]; ok {
+		t.Error("ep-A2 must be evicted by DeleteNetwork(net-A)")
+	}
+	if _, ok := p.persistentDHCP["ep-B1"]; !ok {
+		t.Error("ep-B1 belongs to net-B and must survive DeleteNetwork(net-A)")
+	}
+}
+
+// TestDecodeOpts_RejectsUnknownField verifies the mapstructure decoder
+// is configured with ErrorUnused: a typo'd option key fails fast at
+// decode time rather than being silently dropped, which is what makes
+// `docker network create -o moed=macvlan ...` (typo) surface as a 400
+// instead of falling through to default-mode behaviour.
+func TestDecodeOpts_RejectsUnknownField(t *testing.T) {
+	_, err := decodeOpts(map[string]interface{}{
+		"mode":      "macvlan",
+		"parent":    "ens18",
+		"unknownXX": "value",
+	})
+	if err == nil {
+		t.Fatal("expected error from unknown field, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknownXX") {
+		t.Errorf("err should name the offending field; got %v", err)
+	}
+}
+
+// TestDecodeOpts_DurationParsing verifies the StringToTimeDurationHookFunc
+// is wired so an operator can pass `-o lease_timeout=45s` and get a real
+// time.Duration on the receiving side.
+func TestDecodeOpts_DurationParsing(t *testing.T) {
+	opts, err := decodeOpts(map[string]interface{}{
+		"mode":          "macvlan",
+		"parent":        "ens18",
+		"lease_timeout": "45s",
+	})
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got := opts.LeaseTimeout.Seconds(); got != 45 {
+		t.Errorf("LeaseTimeout: got %v want 45s", opts.LeaseTimeout)
+	}
+}
+
+// TestDecodeOpts_BoolFromString verifies the WeaklyTypedInput coercion
+// path: docker passes string-typed driver options on the wire even when
+// the operator's intent was a bool, so the decoder must coerce
+// "true"/"false" rather than failing.
+func TestDecodeOpts_BoolFromString(t *testing.T) {
+	opts, err := decodeOpts(map[string]interface{}{
+		"mode":             "macvlan",
+		"parent":           "ens18",
+		"ignore_conflicts": "true",
+		"skip_routes":      "false",
+	})
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !opts.IgnoreConflicts {
+		t.Errorf("IgnoreConflicts: got false, want true")
+	}
+	if opts.SkipRoutes {
+		t.Errorf("SkipRoutes: got true, want false")
+	}
+}
+
+// TestDecodeOpts_NilInput is the empty-options path libnetwork hits when
+// `docker network create` was run without any `-o` flags. It must not
+// error — validateModeOptions later catches the missing-bridge case.
+func TestDecodeOpts_NilInput(t *testing.T) {
+	opts, err := decodeOpts(nil)
+	if err != nil {
+		t.Fatalf("decode(nil): %v", err)
+	}
+	if opts.Mode != "" || opts.Bridge != "" || opts.Parent != "" {
+		t.Errorf("zero options expected, got %+v", opts)
+	}
+}
+
+// TestApiCreateNetwork_DecodeOptsError covers the error path where the
+// driver-opts payload itself is shaped wrong (a non-map under the
+// generic key). decodeOpts returns a wrapped mapstructure error which
+// ErrToStatus doesn't recognize → 500. That's the correct shape: the
+// caller's request was structurally invalid in a way that bypasses
+// our sentinel set.
+func TestApiCreateNetwork_DecodeOptsError(t *testing.T) {
+	p := newTestPlugin(t)
+
+	// String under the generic key — decodeOpts can't decode that into
+	// the DHCPNetworkOptions struct.
+	body, err := json.Marshal(CreateNetworkRequest{
+		NetworkID: "net-bad-opts",
+		Options:   map[string]interface{}{"com.docker.network.generic": "not-a-map"},
+		IPv4Data:  []*IPAMData{{AddressSpace: "null", Pool: "0.0.0.0/0"}},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	p.apiCreateNetwork(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d want 500", rec.Code)
+	}
+	if msg := decodeErrBody(t, rec.Body.Bytes()); !strings.Contains(msg, "decode network options") {
+		t.Errorf("body: got %q want substring 'decode network options'", msg)
+	}
+}
+
+// TestApiCreateNetwork_BridgeAndParentRejected covers the
+// ErrModeMismatch branch — a 400 path that goes through validateModeOptions
+// rather than validateIPAMData / decodeOpts.
+func TestApiCreateNetwork_BridgeAndParentRejected(t *testing.T) {
+	p := newTestPlugin(t)
+
+	body, err := json.Marshal(CreateNetworkRequest{
+		NetworkID: "net-mode-mismatch",
+		Options: map[string]interface{}{
+			"com.docker.network.generic": map[string]interface{}{
+				"mode":   "macvlan",
+				"parent": "ens18",
+				"bridge": "br0",
+			},
+		},
+		IPv4Data: []*IPAMData{{AddressSpace: "null", Pool: "0.0.0.0/0"}},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	p.apiCreateNetwork(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if msg := decodeErrBody(t, rec.Body.Bytes()); !strings.Contains(msg, "option does not apply") {
+		t.Errorf("body: got %q want substring 'option does not apply'", msg)
+	}
+}
+

--- a/pkg/plugin/api_handlers_test.go
+++ b/pkg/plugin/api_handlers_test.go
@@ -384,4 +384,3 @@ func TestApiCreateNetwork_BridgeAndParentRejected(t *testing.T) {
 		t.Errorf("body: got %q want substring 'option does not apply'", msg)
 	}
 }
-

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 	"time"
 
 	dNetwork "github.com/docker/docker/api/types/network"
@@ -31,8 +32,15 @@ type dhcpManager struct {
 	joinReq JoinRequest
 	opts    DHCPNetworkOptions
 
-	LastIP   *netlink.Addr
-	LastIPv6 *netlink.Addr
+	// ipMu guards lastIP / lastIPv6. Writes happen from the udhcpc
+	// event goroutine (renew); reads happen from Leave after Stop has
+	// drained that goroutine. The drain establishes happens-before in
+	// practice, but the race detector doesn't always see the channel
+	// pairing through `select`, and a future change to stop priority
+	// could turn this into a real race. Cheap to make explicit.
+	ipMu     sync.Mutex
+	lastIP   *netlink.Addr
+	lastIPv6 *netlink.Addr
 	// MacAddress is set in macvlan mode so we can re-find the link inside
 	// the container netns after Docker has moved and renamed it. Empty in
 	// bridge mode.
@@ -77,10 +85,29 @@ func (m *dhcpManager) logFields(v6 bool) log.Fields {
 	}
 }
 
-func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
-	lastIP := m.LastIP
+// lastIPs returns the most recently observed v4/v6 leases under ipMu.
+func (m *dhcpManager) lastIPs() (*netlink.Addr, *netlink.Addr) {
+	m.ipMu.Lock()
+	defer m.ipMu.Unlock()
+	return m.lastIP, m.lastIPv6
+}
+
+// setLastIP records a freshly-bound address under ipMu.
+func (m *dhcpManager) setLastIP(v6 bool, addr *netlink.Addr) {
+	m.ipMu.Lock()
+	defer m.ipMu.Unlock()
 	if v6 {
-		lastIP = m.LastIPv6
+		m.lastIPv6 = addr
+	} else {
+		m.lastIP = addr
+	}
+}
+
+func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
+	v4, v6Last := m.lastIPs()
+	lastIP := v4
+	if v6 {
+		lastIP = v6Last
 	}
 
 	ip, err := netlink.ParseAddr(info.IP)
@@ -102,11 +129,7 @@ func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
 	// Without this the manager keeps reporting whatever the very
 	// first CreateEndpoint DISCOVER produced, even if udhcpc has
 	// moved to a different lease since.
-	if v6 {
-		m.LastIPv6 = ip
-	} else {
-		m.LastIP = ip
-	}
+	m.setLastIP(v6, ip)
 
 	// Skip gateway-from-DHCP renewal handling when the operator pinned a
 	// gateway override on the network — leave their override in place.
@@ -163,13 +186,15 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 	// On plugin-restart recovery the persistent client should ask the
 	// DHCP server for the IP the container is already using, instead
 	// of doing a fresh DISCOVER that might return something different.
-	// In the normal CreateEndpoint -> Join path m.LastIP / m.LastIPv6
+	// In the normal CreateEndpoint -> Join path lastIP / lastIPv6
 	// already point at the IP we just acquired; passing it as -r is a
 	// no-op (server still ACKs the same address). On recovery it's
 	// what makes the lease "sticky".
 	requestedIP := ""
-	if !v6 && m.LastIP != nil && m.LastIP.IP != nil {
-		requestedIP = m.LastIP.IP.String()
+	if !v6 {
+		if v4Addr, _ := m.lastIPs(); v4Addr != nil && v4Addr.IP != nil {
+			requestedIP = v4Addr.IP.String()
+		}
 	}
 	client, err := udhcpc.NewDHCPClient(m.ctrLink.Attrs().Name, &udhcpc.DHCPClientOptions{
 		Hostname:    m.hostname,

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -27,6 +27,19 @@ const linkAwaitTimeout = 30 * time.Second
 
 const pollTime = 100 * time.Millisecond
 
+// dhcpClientReapTimeout caps how long the udhcpc consumer waits to
+// reap a self-exited child process before giving up and letting it
+// linger as a zombie. The kernel's eventual reaping by init handles
+// the worst case; this just bounds wall time on the cleanup path.
+const dhcpClientReapTimeout = 5 * time.Second
+
+// dhcpClientFinishTimeout caps how long Stop waits for SIGTERM ->
+// DHCPRELEASE -> exit on the persistent udhcpc child. Long enough
+// for a DHCPRELEASE round-trip on a healthy LAN; short enough that
+// plugin shutdown / Leave isn't held hostage by an unresponsive
+// upstream DHCP server.
+const dhcpClientFinishTimeout = 5 * time.Second
+
 type dhcpManager struct {
 	docker  *docker.Client
 	joinReq JoinRequest
@@ -238,7 +251,7 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 					// cmd.Wait must be called exactly once per process,
 					// and Stop's Finish path won't run if the consumer
 					// returned first.
-					reapCtx, reapCancel := context.WithTimeout(context.Background(), 5*time.Second)
+					reapCtx, reapCancel := context.WithTimeout(context.Background(), dhcpClientReapTimeout)
 					if err := client.Wait(reapCtx); err != nil {
 						log.
 							WithError(err).
@@ -312,7 +325,7 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 					WithFields(m.logFields(v6)).
 					Info("Shutting down persistent DHCP client")
 
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				ctx, cancel := context.WithTimeout(context.Background(), dhcpClientFinishTimeout)
 				defer cancel()
 
 				errChan <- client.Finish(ctx)

--- a/pkg/plugin/endpoints.go
+++ b/pkg/plugin/endpoints.go
@@ -227,12 +227,13 @@ func (p *Plugin) apiLeave(w http.ResponseWriter, r *http.Request) {
 // expiry. Operators should restart those containers (which produces a
 // fresh CreateEndpoint and gets them back into the persistent map).
 type HealthResponse struct {
-	Healthy         bool    `json:"healthy"`
-	UptimeSeconds   float64 `json:"uptime_seconds"`
-	ActiveEndpoints int     `json:"active_endpoints"`
-	PendingHints    int     `json:"pending_hints"`
-	RecoveredOK     int32   `json:"recovered_ok"`
-	RecoveryFailed  int32   `json:"recovery_failed"`
+	Healthy                bool    `json:"healthy"`
+	UptimeSeconds          float64 `json:"uptime_seconds"`
+	ActiveEndpoints        int     `json:"active_endpoints"`
+	PendingHints           int     `json:"pending_hints"`
+	RecoveredOK            int32   `json:"recovered_ok"`
+	RecoveryFailed         int32   `json:"recovery_failed"`
+	TombstoneWriteFailures int32   `json:"tombstone_write_failures"`
 }
 
 func (p *Plugin) apiHealth(w http.ResponseWriter, r *http.Request) {
@@ -242,12 +243,18 @@ func (p *Plugin) apiHealth(w http.ResponseWriter, r *http.Request) {
 	p.mu.Unlock()
 
 	failed := p.recoveryFailed.Load()
+	tsFails := p.tombstoneWriteFailures.Load()
 	util.JSONResponse(w, HealthResponse{
-		Healthy:         failed == 0,
-		UptimeSeconds:   time.Since(p.startTime).Seconds(),
-		ActiveEndpoints: active,
-		PendingHints:    pending,
-		RecoveredOK:     p.recoveredOK.Load(),
-		RecoveryFailed:  failed,
+		// Healthy is false on any condition that means an operator
+		// should look: a recovery failure means a running container has
+		// no renewal goroutine; a tombstone-write failure means the
+		// next restart of some container will pick a new MAC/IP.
+		Healthy:                failed == 0 && tsFails == 0,
+		UptimeSeconds:          time.Since(p.startTime).Seconds(),
+		ActiveEndpoints:        active,
+		PendingHints:           pending,
+		RecoveredOK:            p.recoveredOK.Load(),
+		RecoveryFailed:         failed,
+		TombstoneWriteFailures: tsFails,
 	}, http.StatusOK)
 }

--- a/pkg/plugin/endpoints.go
+++ b/pkg/plugin/endpoints.go
@@ -40,7 +40,7 @@ type CreateNetworkRequest struct {
 
 func (p *Plugin) apiCreateNetwork(w http.ResponseWriter, r *http.Request) {
 	var req CreateNetworkRequest
-	if err := util.ParseJSONBody(&req, w, r); err != nil {
+	if err := util.ParseJSONOrErrorResponse(&req, w, r); err != nil {
 		return
 	}
 
@@ -59,7 +59,7 @@ type DeleteNetworkRequest struct {
 
 func (p *Plugin) apiDeleteNetwork(w http.ResponseWriter, r *http.Request) {
 	var req DeleteNetworkRequest
-	if err := util.ParseJSONBody(&req, w, r); err != nil {
+	if err := util.ParseJSONOrErrorResponse(&req, w, r); err != nil {
 		return
 	}
 
@@ -93,7 +93,7 @@ type CreateEndpointResponse struct {
 
 func (p *Plugin) apiCreateEndpoint(w http.ResponseWriter, r *http.Request) {
 	var req CreateEndpointRequest
-	if err := util.ParseJSONBody(&req, w, r); err != nil {
+	if err := util.ParseJSONOrErrorResponse(&req, w, r); err != nil {
 		return
 	}
 
@@ -119,7 +119,7 @@ type InfoResponse struct {
 
 func (p *Plugin) apiEndpointOperInfo(w http.ResponseWriter, r *http.Request) {
 	var req InfoRequest
-	if err := util.ParseJSONBody(&req, w, r); err != nil {
+	if err := util.ParseJSONOrErrorResponse(&req, w, r); err != nil {
 		return
 	}
 
@@ -140,7 +140,7 @@ type DeleteEndpointRequest struct {
 
 func (p *Plugin) apiDeleteEndpoint(w http.ResponseWriter, r *http.Request) {
 	var req DeleteEndpointRequest
-	if err := util.ParseJSONBody(&req, w, r); err != nil {
+	if err := util.ParseJSONOrErrorResponse(&req, w, r); err != nil {
 		return
 	}
 
@@ -185,7 +185,7 @@ type JoinResponse struct {
 
 func (p *Plugin) apiJoin(w http.ResponseWriter, r *http.Request) {
 	var req JoinRequest
-	if err := util.ParseJSONBody(&req, w, r); err != nil {
+	if err := util.ParseJSONOrErrorResponse(&req, w, r); err != nil {
 		return
 	}
 
@@ -206,7 +206,7 @@ type LeaveRequest struct {
 
 func (p *Plugin) apiLeave(w http.ResponseWriter, r *http.Request) {
 	var req LeaveRequest
-	if err := util.ParseJSONBody(&req, w, r); err != nil {
+	if err := util.ParseJSONOrErrorResponse(&req, w, r); err != nil {
 		return
 	}
 

--- a/pkg/plugin/endpoints.go
+++ b/pkg/plugin/endpoints.go
@@ -167,6 +167,15 @@ type InterfaceName struct {
 	DstPrefix string
 }
 
+// libnetwork's route-type encoding for StaticRoute.RouteType.
+// See https://github.com/moby/libnetwork/blob/master/docs/remote.md
+// — 0 ("via gateway") expects a NextHop; 1 ("on-link / connected")
+// has no next hop.
+const (
+	RouteTypeNextHop = 0
+	RouteTypeOnLink  = 1
+)
+
 // StaticRoute contains static route information
 type StaticRoute struct {
 	Destination string

--- a/pkg/plugin/endpoints_test.go
+++ b/pkg/plugin/endpoints_test.go
@@ -46,4 +46,37 @@ func TestApiHealth(t *testing.T) {
 	if got.UptimeSeconds < 2.5 || got.UptimeSeconds > 60 {
 		t.Errorf("uptime should be ~3s after seeding, got %v", got.UptimeSeconds)
 	}
+	if got.TombstoneWriteFailures != 0 {
+		t.Errorf("expected 0 tombstone write failures, got %d", got.TombstoneWriteFailures)
+	}
+}
+
+// TestApiHealth_TombstoneWriteFailureUnhealthy verifies that a non-zero
+// tombstoneWriteFailures counter flips the response to unhealthy. The
+// counter is bumped from addTombstone's saveTombstones error path; we
+// just write to it directly here since the surface we care about is
+// what /Plugin.Health reports, not the disk-write path that already
+// has its own coverage.
+func TestApiHealth_TombstoneWriteFailureUnhealthy(t *testing.T) {
+	p := &Plugin{
+		startTime:      time.Now(),
+		joinHints:      make(map[string]joinHint),
+		persistentDHCP: make(map[string]*dhcpManager),
+	}
+	p.tombstoneWriteFailures.Add(2)
+
+	req := httptest.NewRequest(http.MethodGet, "/Plugin.Health", nil)
+	rec := httptest.NewRecorder()
+	p.apiHealth(rec, req)
+
+	var got HealthResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Healthy {
+		t.Error("tombstone write failures must mark plugin unhealthy")
+	}
+	if got.TombstoneWriteFailures != 2 {
+		t.Errorf("expected 2 tombstone failures reported, got %d", got.TombstoneWriteFailures)
+	}
 }

--- a/pkg/plugin/helpers_test.go
+++ b/pkg/plugin/helpers_test.go
@@ -1,0 +1,197 @@
+package plugin
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+// TestShortID covers the safety-net behaviour the function exists for:
+// it must not panic on IDs shorter than 12 chars (which can happen on
+// malformed daemon responses during recovery).
+func TestShortID(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"short", "abc", "abc"},
+		{"exactly_12", "abcdefghijkl", "abcdefghijkl"},
+		{"longer", "abcdefghijklmnop", "abcdefghijkl"},
+		{"docker_endpoint_64hex", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "0123456789ab"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shortID(c.in); got != c.want {
+				t.Errorf("shortID(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestNewChildLink covers the per-mode netlink type selection. The
+// macvlan submode must be MACVLAN_MODE_BRIDGE so children on the same
+// parent can talk to each other; the ipvlan submode must be
+// IPVLAN_MODE_L2 because DHCP needs L2 broadcast to reach the upstream
+// server. Both invariants are subtle enough to deserve a test.
+func TestNewChildLink(t *testing.T) {
+	la := netlink.NewLinkAttrs()
+	la.Name = "dh-test"
+
+	macv, ok := newChildLink(ModeMacvlan, la).(*netlink.Macvlan)
+	if !ok {
+		t.Fatalf("ModeMacvlan: expected *netlink.Macvlan, got %T", newChildLink(ModeMacvlan, la))
+	}
+	if macv.Mode != netlink.MACVLAN_MODE_BRIDGE {
+		t.Errorf("macvlan submode: got %v want MACVLAN_MODE_BRIDGE", macv.Mode)
+	}
+	if macv.LinkAttrs.Name != "dh-test" {
+		t.Errorf("macvlan attrs not threaded: got %q", macv.LinkAttrs.Name)
+	}
+
+	ipv, ok := newChildLink(ModeIPvlan, la).(*netlink.IPVlan)
+	if !ok {
+		t.Fatalf("ModeIPvlan: expected *netlink.IPVlan, got %T", newChildLink(ModeIPvlan, la))
+	}
+	if ipv.Mode != netlink.IPVLAN_MODE_L2 {
+		t.Errorf("ipvlan submode: got %v want IPVLAN_MODE_L2 (DHCP needs L2 broadcast)", ipv.Mode)
+	}
+
+	// Default falls back to macvlan — protects bridge-mode callers
+	// that pass through here on a code-path that doesn't validate mode
+	// strings (currently none, but cheap to guard).
+	if _, ok := newChildLink("", la).(*netlink.Macvlan); !ok {
+		t.Errorf("empty mode should default to macvlan")
+	}
+}
+
+// TestUpdateJoinHint covers the read-modify-write helper that
+// CreateEndpoint uses to layer in successive bits of state without
+// holding the plugin lock across user callbacks. A refactor that
+// dropped the locking around fn would race with concurrent
+// storeJoinHint calls; a refactor that broke the read-modify-write
+// would clobber prior fields.
+func TestUpdateJoinHint(t *testing.T) {
+	p := newPluginForTest()
+
+	// First update — store IPv4.
+	p.updateJoinHint("ep-1", func(h *joinHint) {
+		v4, _ := netlink.ParseAddr("192.168.0.50/24")
+		h.IPv4 = v4
+		h.Gateway = "192.168.0.1"
+	})
+
+	// Second update — must preserve the v4 we just stored, layer in v6.
+	p.updateJoinHint("ep-1", func(h *joinHint) {
+		if h.IPv4 == nil || h.IPv4.IP.String() != "192.168.0.50" {
+			t.Errorf("update lost prior IPv4: %+v", h.IPv4)
+		}
+		if h.Gateway != "192.168.0.1" {
+			t.Errorf("update lost prior Gateway: %q", h.Gateway)
+		}
+		v6, _ := netlink.ParseAddr("fe80::1/64")
+		h.IPv6 = v6
+	})
+
+	got, ok := p.takeJoinHint("ep-1")
+	if !ok {
+		t.Fatal("hint disappeared")
+	}
+	if got.IPv4 == nil || got.IPv4.IP.String() != "192.168.0.50" {
+		t.Errorf("final IPv4: %+v", got.IPv4)
+	}
+	if got.IPv6 == nil || got.IPv6.IP.String() != "fe80::1" {
+		t.Errorf("final IPv6: %+v", got.IPv6)
+	}
+	if got.Gateway != "192.168.0.1" {
+		t.Errorf("final Gateway: %q", got.Gateway)
+	}
+}
+
+// TestUpdateJoinHint_Concurrent guards the locking discipline. N
+// goroutines layering successive updates onto disjoint endpoint IDs
+// must not race; a refactor that dropped the mutex would trip -race.
+func TestUpdateJoinHint_Concurrent(t *testing.T) {
+	p := newPluginForTest()
+
+	const N = 32
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func(i int) {
+			defer wg.Done()
+			id := "ep-" + string(rune('a'+i%26))
+			p.updateJoinHint(id, func(h *joinHint) { h.Gateway = "10.0.0.1" })
+			p.updateJoinHint(id, func(h *joinHint) { h.Gateway += "/24" })
+		}(i)
+	}
+	wg.Wait()
+}
+
+// TestDHCPManager_LastIPsAndSetter covers the ipMu-guarded accessor
+// pair. Writes happen on the udhcpc renew goroutine; reads happen on
+// the Leave path. Without the mutex (or with a partial implementation
+// that updated only one side) the race detector would flag — and
+// stale-read bugs would silently feed wrong IPs into the tombstone.
+func TestDHCPManager_LastIPsAndSetter(t *testing.T) {
+	m := &dhcpManager{}
+
+	// Zero state.
+	if v4, v6 := m.lastIPs(); v4 != nil || v6 != nil {
+		t.Errorf("zero manager: expected nil/nil, got %+v / %+v", v4, v6)
+	}
+
+	v4, _ := netlink.ParseAddr("10.0.0.1/24")
+	v6, _ := netlink.ParseAddr("fe80::1/64")
+
+	m.setLastIP(false, v4)
+	if got4, got6 := m.lastIPs(); got4 != v4 || got6 != nil {
+		t.Errorf("after v4 set: got4=%v got6=%v want v4 only", got4, got6)
+	}
+
+	m.setLastIP(true, v6)
+	if got4, got6 := m.lastIPs(); got4 != v4 || got6 != v6 {
+		t.Errorf("after v6 set: got4=%v got6=%v", got4, got6)
+	}
+
+	// Overwrite v4 — v6 must survive.
+	v4b, _ := netlink.ParseAddr("10.0.0.2/24")
+	m.setLastIP(false, v4b)
+	if got4, got6 := m.lastIPs(); got4 != v4b || got6 != v6 {
+		t.Errorf("after v4 overwrite: got4=%v got6=%v", got4, got6)
+	}
+}
+
+// TestDHCPManager_LogFields is a thin guard against the structured-log
+// keys drifting — operators have grafana queries that pivot on
+// `network` / `endpoint` / `is_ipv6`, and a rename would silently
+// break them.
+func TestDHCPManager_LogFields(t *testing.T) {
+	m := &dhcpManager{
+		joinReq: JoinRequest{
+			NetworkID:  "0123456789abcdef0000000000000000",
+			EndpointID: "fedcba9876543210ffffffffffffffff",
+			SandboxKey: "/var/run/docker/netns/abc",
+		},
+	}
+	for _, v6 := range []bool{false, true} {
+		f := m.logFields(v6)
+		for _, key := range []string{"network", "endpoint", "sandbox", "is_ipv6"} {
+			if _, ok := f[key]; !ok {
+				t.Errorf("v6=%v: missing log key %q", v6, key)
+			}
+		}
+		if got := f["is_ipv6"].(bool); got != v6 {
+			t.Errorf("is_ipv6: got %v want %v", got, v6)
+		}
+		// network/endpoint must be the shortened form so logs stay scannable.
+		if got := f["network"].(string); got != "0123456789ab" {
+			t.Errorf("network field not shortened: %q", got)
+		}
+		if got := f["endpoint"].(string); got != "fedcba987654" {
+			t.Errorf("endpoint field not shortened: %q", got)
+		}
+	}
+}

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -562,13 +562,17 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 	p.rememberEndpoint(r.EndpointID, endpointFingerprint{MAC: mac, IPv4: v4IP, IPv6: v6IP, Hostname: hostname})
 
 	log.WithFields(log.Fields{
+		"network":  shortID(r.NetworkID),
+		"endpoint": shortID(r.EndpointID),
+	}).Info("Endpoint created")
+	log.WithFields(log.Fields{
 		"network":     shortID(r.NetworkID),
 		"endpoint":    shortID(r.EndpointID),
 		"mac_address": mac,
 		"ip":          res.Interface.Address,
 		"ipv6":        res.Interface.AddressIPv6,
 		"gateway":     gateway,
-	}).Info("Endpoint created")
+	}).Debug("Endpoint details")
 
 	return res, nil
 }
@@ -716,12 +720,12 @@ func (p *Plugin) addRoutes(opts *DHCPNetworkOptions, v6 bool, bridge netlink.Lin
 		staticRoute := &StaticRoute{
 			Destination: route.Dst.String(),
 			// Default to an on-link route
-			RouteType: 1,
+			RouteType: RouteTypeOnLink,
 		}
 		res.StaticRoutes = append(res.StaticRoutes, staticRoute)
 
 		if route.Gw != nil {
-			staticRoute.RouteType = 0
+			staticRoute.RouteType = RouteTypeNextHop
 			staticRoute.NextHop = route.Gw.String()
 
 			log.

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sync"
 
 	dNetwork "github.com/docker/docker/api/types/network"
 	"github.com/mitchellh/mapstructure"
@@ -177,12 +178,40 @@ func (p *Plugin) CreateNetwork(r CreateNetworkRequest) error {
 	return nil
 }
 
-// DeleteNetwork "deletes" a DHCP network (does nothing, the bridge is managed by the user)
+// DeleteNetwork "deletes" a DHCP network (the bridge is managed by the
+// user). We also evict any persistent DHCP managers attached to this
+// network: libnetwork doesn't issue Leave for endpoints in stopped
+// containers when the network is removed, so without this prune they
+// linger as ghost entries in /Plugin.Health.active_endpoints. Stop is
+// safe to call against a manager whose underlying netns is gone — it
+// just unblocks the udhcpc-events loop and returns; udhcpc itself may
+// have already self-exited because its netns vanished.
 func (p *Plugin) DeleteNetwork(r DeleteNetworkRequest) error {
 	if err := deleteOptions(r.NetworkID); err != nil {
 		log.WithError(err).WithField("network", r.NetworkID).
 			Warn("Failed to remove persisted options; harmless leftover")
 	}
+
+	orphaned := p.takeDHCPManagersForNetwork(r.NetworkID)
+	if len(orphaned) > 0 {
+		log.WithFields(log.Fields{
+			"network": r.NetworkID,
+			"count":   len(orphaned),
+		}).Info("Stopping orphaned DHCP managers on network removal")
+		var wg sync.WaitGroup
+		for _, m := range orphaned {
+			wg.Add(1)
+			go func(m *dhcpManager) {
+				defer wg.Done()
+				if err := m.Stop(); err != nil {
+					log.WithError(err).WithField("network", r.NetworkID).
+						Warn("Orphaned manager stop returned error; manager already removed from registry")
+				}
+			}(m)
+		}
+		wg.Wait()
+	}
+
 	log.WithField("network", r.NetworkID).Info("Network deleted")
 	return nil
 }

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -802,8 +802,8 @@ func (p *Plugin) Join(ctx context.Context, r JoinRequest) (JoinResponse, error) 
 	// (success or failure), so it's safe to call against a manager whose
 	// Start is still in flight.
 	m := newDHCPManager(p.docker, r, opts)
-	m.LastIP = hint.IPv4
-	m.LastIPv6 = hint.IPv6
+	m.setLastIP(false, hint.IPv4)
+	m.setLastIP(true, hint.IPv6)
 	m.MacAddress = hint.MacAddress
 	p.registerDHCPManager(r.EndpointID, m)
 
@@ -846,16 +846,19 @@ func (p *Plugin) Leave(ctx context.Context, r LeaveRequest) error {
 	// Refresh the endpoint fingerprint with the most recent v4/v6 IPs
 	// the persistent client saw, *whether or not Stop succeeded*. Stop
 	// drains the event goroutine before returning even on error, so
-	// manager.LastIP* are stable to read here. Doing this on the error
-	// path too means a wedged-udhcpc shutdown still produces a tombstone
-	// with the latest known lease (W-4) — otherwise DeleteEndpoint
-	// would lay down a tombstone with the stale initial-DISCOVER IPs.
+	// the read here is sequenced after every renew that's going to
+	// happen — but go through ipMu anyway so the race detector doesn't
+	// have to reason through `select`. Doing this on the error path too
+	// means a wedged-udhcpc shutdown still produces a tombstone with
+	// the latest known lease (W-4) — otherwise DeleteEndpoint would
+	// lay down a tombstone with the stale initial-DISCOVER IPs.
+	v4Addr, v6Addr := manager.lastIPs()
 	v4, v6 := "", ""
-	if manager.LastIP != nil && manager.LastIP.IP != nil {
-		v4 = manager.LastIP.IP.String()
+	if v4Addr != nil && v4Addr.IP != nil {
+		v4 = v4Addr.IP.String()
 	}
-	if manager.LastIPv6 != nil && manager.LastIPv6.IP != nil {
-		v6 = manager.LastIPv6.IP.String()
+	if v6Addr != nil && v6Addr.IP != nil {
+		v6 = v6Addr.IP.String()
 	}
 	p.updateEndpointIPs(r.EndpointID, v4, v6)
 

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -106,13 +106,17 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 				requestedIP = tombIP
 			}
 			log.WithFields(log.Fields{
+				"network":  shortID(r.NetworkID),
+				"endpoint": shortID(r.EndpointID),
+				"hostname": hostname,
+			}).Info("Inherited MAC/IP from recent endpoint on same network (likely container restart)")
+			log.WithFields(log.Fields{
 				"network":      shortID(r.NetworkID),
 				"endpoint":     shortID(r.EndpointID),
-				"hostname":     hostname,
 				"mac_address":  tombMAC,
 				"requested_ip": requestedIP,
 				"prior_ipv6":   tombIPv6,
-			}).Info("Inherited MAC/IP from recent endpoint on same network (likely container restart)")
+			}).Debug("Tombstone inheritance details")
 		}
 	}
 
@@ -248,15 +252,19 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 	}
 
 	log.WithFields(log.Fields{
+		"network":  shortID(r.NetworkID),
+		"endpoint": shortID(r.EndpointID),
+		"mode":     mode,
+		"parent":   opts.Parent,
+	}).Info("Endpoint created")
+	log.WithFields(log.Fields{
 		"network":     shortID(r.NetworkID),
 		"endpoint":    shortID(r.EndpointID),
-		"mode":        mode,
-		"parent":      opts.Parent,
 		"mac_address": hintMAC,
 		"ip":          res.Interface.Address,
 		"ipv6":        res.Interface.AddressIPv6,
 		"gateway":     hintGW,
-	}).Info("Endpoint created")
+	}).Debug("Endpoint details")
 
 	return res, nil
 }

--- a/pkg/plugin/parent_attached_test.go
+++ b/pkg/plugin/parent_attached_test.go
@@ -1,0 +1,100 @@
+package plugin
+
+import (
+	"testing"
+)
+
+// TestParentAttachedEndpointOperInfo_NoLink covers the expected case:
+// by the time anyone polls EndpointOperInfo for a macvlan/ipvlan
+// endpoint, the child link has typically been moved into the
+// container's netns. The host-side LinkByName lookup fails — that's
+// not an error; we still return the static fields (mode, parent,
+// host-link name) so libnetwork has something to display.
+func TestParentAttachedEndpointOperInfo_NoLink(t *testing.T) {
+	p := newPluginForTest()
+
+	opts := DHCPNetworkOptions{Mode: ModeMacvlan, Parent: "ens18"}
+	r := InfoRequest{
+		NetworkID:  "0123456789abcdef0123456789abcdef",
+		EndpointID: "fedcba9876543210fedcba9876543210",
+	}
+	res, err := p.parentAttachedEndpointOperInfo(opts, r)
+	if err != nil {
+		t.Fatalf("oper info: %v", err)
+	}
+
+	want := map[string]string{
+		"mode":          ModeMacvlan,
+		"parent":        "ens18",
+		"sub_link_host": subLinkName(r.EndpointID),
+		"sub_link_mac":  "", // expected empty: the link is in the container netns by now
+	}
+	for k, v := range want {
+		if got := res.Value[k]; got != v {
+			t.Errorf("Value[%q]: got %q want %q", k, got, v)
+		}
+	}
+}
+
+// TestParentAttachedEndpointOperInfo_IPvlan covers the ipvlan path —
+// same flow as macvlan but the mode field is encoded differently and
+// libnetwork-facing operators rely on it being honest.
+func TestParentAttachedEndpointOperInfo_IPvlan(t *testing.T) {
+	p := newPluginForTest()
+	opts := DHCPNetworkOptions{Mode: ModeIPvlan, Parent: "ens18"}
+	r := InfoRequest{NetworkID: "n", EndpointID: "0123456789abcdef0123456789abcdef"}
+
+	res, err := p.parentAttachedEndpointOperInfo(opts, r)
+	if err != nil {
+		t.Fatalf("oper info: %v", err)
+	}
+	if res.Value["mode"] != ModeIPvlan {
+		t.Errorf("mode: got %q want %q", res.Value["mode"], ModeIPvlan)
+	}
+}
+
+// TestDeleteParentAttachedEndpoint_LinkAlreadyGone is the expected
+// path on container teardown: the macvlan/ipvlan child has been
+// reaped along with the container netns by the time we get here.
+// LinkByName fails with "not found"; the function logs and returns
+// nil. A regression that propagated the netlink error here would
+// surface as spurious DeleteEndpoint failures on every clean shutdown.
+func TestDeleteParentAttachedEndpoint_LinkAlreadyGone(t *testing.T) {
+	p := newPluginForTest()
+	r := DeleteEndpointRequest{
+		NetworkID:  "n",
+		EndpointID: "deadbeef0001deadbeef0002deadbeef0003deadbeef0004deadbeef0005dead",
+	}
+	if err := p.deleteParentAttachedEndpoint(r); err != nil {
+		t.Errorf("expected nil for missing link, got %v", err)
+	}
+}
+
+// TestNewDHCPManager covers the constructor — verifies the channels
+// are initialized non-nil (a refactor that swapped to lazy
+// initialization would deadlock Stop's <-startedCh on a manager
+// whose Start was never called).
+func TestNewDHCPManager(t *testing.T) {
+	r := JoinRequest{NetworkID: "net-1", EndpointID: "ep-1"}
+	opts := DHCPNetworkOptions{Mode: ModeMacvlan, Parent: "ens18"}
+	m := newDHCPManager(nil, r, opts)
+
+	if m.joinReq.NetworkID != "net-1" {
+		t.Errorf("joinReq not threaded: %+v", m.joinReq)
+	}
+	if m.opts.Mode != ModeMacvlan {
+		t.Errorf("opts not threaded: %+v", m.opts)
+	}
+	if m.stopChan == nil {
+		t.Error("stopChan must be non-nil so Stop's close() doesn't panic")
+	}
+	if m.startedCh == nil {
+		t.Error("startedCh must be non-nil so Stop's <-startedCh doesn't deadlock")
+	}
+	// Channel must be unclosed initially — Start closes it on completion.
+	select {
+	case <-m.startedCh:
+		t.Error("startedCh should not be closed at construction")
+	default:
+	}
+}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -582,9 +582,20 @@ func (p *Plugin) initialDHCPHostname(ctx context.Context, networkID, endpointID 
 	ctx, cancel := context.WithTimeout(ctx, initialDHCPHostnameLookupTimeout)
 	defer cancel()
 
+	// Each Docker call inside the poll body is bounded much tighter
+	// than the outer 2s budget so a single hung NetworkInspect /
+	// ContainerInspect doesn't burn the whole window. The Docker client
+	// itself has its own 2s per-request timeout (NewPlugin), but that's
+	// the same as our entire poll budget — without an inner cap, one
+	// stuck call effectively turns the 100ms retry interval into a 2s
+	// retry interval. Cap the inner ctx at the poll interval.
+	const dockerCallTimeout = 200 * time.Millisecond
+
 	var hostname string
 	_ = util.AwaitCondition(ctx, func() (bool, error) {
-		dockerNet, err := p.docker.NetworkInspect(ctx, networkID, dNetwork.InspectOptions{})
+		inner, innerCancel := context.WithTimeout(ctx, dockerCallTimeout)
+		defer innerCancel()
+		dockerNet, err := p.docker.NetworkInspect(inner, networkID, dNetwork.InspectOptions{})
 		if err != nil {
 			// Don't propagate the error — we want to keep retrying
 			// while the timeout has time. The caller treats an empty
@@ -600,7 +611,7 @@ func (p *Plugin) initialDHCPHostname(ctx context.Context, networkID, endpointID 
 			if strings.HasPrefix(ctrID, "ep-") {
 				return false, nil
 			}
-			ctr, err := p.docker.ContainerInspect(ctx, ctrID)
+			ctr, err := p.docker.ContainerInspect(inner, ctrID)
 			if err != nil {
 				return false, nil
 			}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -178,6 +178,13 @@ type Plugin struct {
 	// are now running without renewal.
 	recoveredOK    atomic.Int32
 	recoveryFailed atomic.Int32
+
+	// tombstoneWriteFailures counts saveTombstones failures (disk full,
+	// EROFS) from addTombstone. Reported on /Plugin.Health so operators
+	// can detect a degraded restart-stability window — every failure
+	// here means one container that won't get its previous MAC/IP back
+	// on restart until the disk recovers.
+	tombstoneWriteFailures atomic.Int32
 }
 
 // storeJoinHint records the state collected during CreateEndpoint so
@@ -232,6 +239,27 @@ func (p *Plugin) takeDHCPManager(endpointID string) (*dhcpManager, bool) {
 		delete(p.persistentDHCP, endpointID)
 	}
 	return m, ok
+}
+
+// takeDHCPManagersForNetwork atomically retrieves and removes every
+// DHCP manager whose JoinRequest belongs to networkID. Used by
+// DeleteNetwork to evict managers that libnetwork didn't issue a Leave
+// for — typically the recovery-then-network-removed path: the plugin
+// recovered an endpoint into its registry, the network was deleted
+// while the container's netns was already gone, and no Leave RPC ever
+// arrived. Without this prune, /Plugin.Health's active_endpoints
+// count drifts upward across network upgrade cycles.
+func (p *Plugin) takeDHCPManagersForNetwork(networkID string) []*dhcpManager {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var out []*dhcpManager
+	for id, m := range p.persistentDHCP {
+		if m.joinReq.NetworkID == networkID {
+			out = append(out, m)
+			delete(p.persistentDHCP, id)
+		}
+	}
+	return out
 }
 
 // endpointFingerprint is the stable identity of a live endpoint we
@@ -323,6 +351,7 @@ func (p *Plugin) addTombstone(networkID, hostname, mac, ipv4, ipv6 string) {
 		DeletedAt:   time.Now(),
 	})
 	if err := saveTombstones(ts); err != nil {
+		p.tombstoneWriteFailures.Add(1)
 		log.WithError(err).Warn("Failed to persist tombstone; container restart may pick a new MAC/IP")
 	}
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -49,6 +50,14 @@ const (
 // on first renewal, so the worst case is "first lease appears in the
 // upstream DHCP server's table without a hostname for a few minutes".
 const initialDHCPHostnameLookupTimeout = 2 * time.Second
+
+// recoveryBudget caps the wall-time the plugin spends rebuilding its
+// in-memory state for already-attached endpoints on startup. Each
+// endpoint's recovery does its own DHCP DISCOVER through udhcpc with
+// network-IO timeouts; this is the umbrella above all of them. Beyond
+// it, recovery is abandoned and the affected endpoints surface as
+// recovery_failed on /Plugin.Health.
+const recoveryBudget = 30 * time.Second
 
 // clientIDFromEndpoint derives a stable DHCP option-61 client identifier
 // from a Docker endpoint ID. Docker's endpoint IDs are 64 hex chars
@@ -693,10 +702,9 @@ func NewPlugin(awaitTimeout time.Duration) (*Plugin, error) {
 	// background goroutine — the previous behaviour — opened a window
 	// where a fresh CreateEndpoint could race recovery's Start for the
 	// same endpoint: the map check is mutex-protected, but Start runs
-	// outside the mutex. Recovery is bounded at 30s, which is acceptable
-	// plugin-enable latency.
+	// outside the mutex. recoveryBudget bounds plugin-enable latency.
 	{
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), recoveryBudget)
 		p.recoverEndpoints(ctx)
 		cancel()
 	}
@@ -706,6 +714,12 @@ func NewPlugin(awaitTimeout time.Duration) (*Plugin, error) {
 
 // Listen starts the plugin server
 func (p *Plugin) Listen(bindSock string) error {
+	// Best-effort: remove a stale socket file from a prior run so
+	// net.Listen doesn't EADDRINUSE on it. Production plugin runtimes
+	// recreate the workdir between starts, so this is a no-op there;
+	// it matters for local / test runs where the file lingers.
+	_ = os.Remove(bindSock)
+
 	l, err := net.Listen("unix", bindSock)
 	if err != nil {
 		return err

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -494,8 +494,8 @@ func (p *Plugin) recoverOneEndpoint(ctx context.Context, networkID, endpointID, 
 		EndpointID: endpointID,
 	}
 	m := newDHCPManager(p.docker, fakeJoin, opts)
-	m.LastIP = ipv4
-	m.LastIPv6 = ipv6
+	m.setLastIP(false, ipv4)
+	m.setLastIP(true, ipv6)
 	m.MacAddress = mac
 	p.registerDHCPManager(endpointID, m)
 
@@ -659,15 +659,18 @@ func NewPlugin(awaitTimeout time.Duration) (*Plugin, error) {
 		Handler: handlers.CustomLoggingHandler(nil, mux, util.WriteAccessLog),
 	}
 
-	// Kick off endpoint recovery in the background. We don't block
-	// plugin startup on it: libnetwork RPCs for fresh networks should
-	// be served immediately. Recovery serialises against those via the
-	// Plugin mutex on the maps.
-	go func() {
+	// Run endpoint recovery synchronously before NewPlugin returns
+	// (and thus before Listen accepts the first RPC). Doing it on a
+	// background goroutine — the previous behaviour — opened a window
+	// where a fresh CreateEndpoint could race recovery's Start for the
+	// same endpoint: the map check is mutex-protected, but Start runs
+	// outside the mutex. Recovery is bounded at 30s, which is acceptable
+	// plugin-enable latency.
+	{
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
 		p.recoverEndpoints(ctx)
-	}()
+		cancel()
+	}
 
 	return &p, nil
 }

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -1,6 +1,9 @@
 package plugin
 
 import (
+	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -215,4 +218,32 @@ func TestClientIDFromEndpoint(t *testing.T) {
 	if string(a) == string(c) {
 		t.Errorf("derivation collided on different inputs")
 	}
+}
+
+// TestListen_RemovesStaleSocket covers the I-9 fix: Listen must
+// best-effort unlink any leftover socket file before binding so a
+// previous unclean shutdown doesn't EADDRINUSE the new one. Driving
+// the full Listen would block on Serve, so we replicate the prelude:
+// pre-place a regular file at the socket path and confirm the unlink
+// path clears it before net.Listen would fail.
+func TestListen_RemovesStaleSocket(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "stale.sock")
+
+	// Pre-place a non-socket file at the target path. net.Listen would
+	// fail with EADDRINUSE / "address already in use" on this path
+	// without the os.Remove in Listen.
+	if err := os.WriteFile(sockPath, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// Mirror Listen's prelude. We can't call p.Listen directly because
+	// Serve blocks; the unlink + Listen sequence is what we care about.
+	_ = os.Remove(sockPath)
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("net.Listen after prelude: %v (the os.Remove in Listen should have cleared the path)", err)
+	}
+	_ = l.Close()
+	_ = os.Remove(sockPath)
 }

--- a/pkg/plugin/race_test.go
+++ b/pkg/plugin/race_test.go
@@ -121,3 +121,54 @@ func TestPlugin_JoinHintFlow(t *testing.T) {
 		t.Error("takeDHCPManager must remove the entry it returns")
 	}
 }
+
+// TestTakeDHCPManagersForNetwork_PrunesByNetwork covers the #44 fix:
+// DeleteNetwork must evict every manager attached to the disappearing
+// network, leaving managers on other networks untouched. It's the
+// underlying primitive — DeleteNetwork's HTTP path also calls Stop on
+// each, but Stop's blocking semantics are exercised separately in
+// integration testing.
+func TestTakeDHCPManagersForNetwork_PrunesByNetwork(t *testing.T) {
+	p := &Plugin{
+		joinHints:      make(map[string]joinHint),
+		persistentDHCP: make(map[string]*dhcpManager),
+	}
+	mkMgr := func(networkID string) *dhcpManager {
+		return &dhcpManager{joinReq: JoinRequest{NetworkID: networkID}}
+	}
+	mA1 := mkMgr("net-A")
+	mA2 := mkMgr("net-A")
+	mB1 := mkMgr("net-B")
+	p.registerDHCPManager("ep-A1", mA1)
+	p.registerDHCPManager("ep-A2", mA2)
+	p.registerDHCPManager("ep-B1", mB1)
+
+	got := p.takeDHCPManagersForNetwork("net-A")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 managers evicted for net-A, got %d", len(got))
+	}
+	// Order isn't guaranteed (map iteration); verify by set membership.
+	have := map[*dhcpManager]bool{got[0]: true, got[1]: true}
+	if !have[mA1] || !have[mA2] {
+		t.Errorf("evicted set missing one of mA1/mA2: %+v", got)
+	}
+	if have[mB1] {
+		t.Error("net-B manager was wrongly evicted")
+	}
+
+	// Registry should now hold only the unrelated manager.
+	if _, ok := p.takeDHCPManager("ep-A1"); ok {
+		t.Error("ep-A1 should already be gone")
+	}
+	if _, ok := p.takeDHCPManager("ep-A2"); ok {
+		t.Error("ep-A2 should already be gone")
+	}
+	if m, ok := p.takeDHCPManager("ep-B1"); !ok || m != mB1 {
+		t.Errorf("ep-B1 should still be there: ok=%v m=%v", ok, m)
+	}
+
+	// Calling again on the now-empty network is a clean no-op.
+	if got := p.takeDHCPManagersForNetwork("net-A"); len(got) != 0 {
+		t.Errorf("expected empty result on second call, got %d managers", len(got))
+	}
+}

--- a/pkg/plugin/state_test.go
+++ b/pkg/plugin/state_test.go
@@ -2,8 +2,10 @@ package plugin
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -248,6 +250,41 @@ func TestTombstones_EmptyHostnameMatchesAny(t *testing.T) {
 	mac, _, _, ok := p.consumeTombstone("net-A", "alpha")
 	if !ok || mac != "aa:aa:aa:aa:aa:aa" {
 		t.Errorf("v0.5.0 tombstone should still match: got (%q, %v)", mac, ok)
+	}
+}
+
+// TestTombstones_ConcurrentAddDoesNotLose asserts that N parallel
+// addTombstone calls all land on disk. tombstoneMu serializes the
+// read-modify-write today; a refactor that drops the mutex would
+// silently lose entries because each writer's load+marshal loses
+// concurrent peers' updates. Run with -race for the full guarantee.
+func TestTombstones_ConcurrentAddDoesNotLose(t *testing.T) {
+	withStateDir(t, t.TempDir())
+	p := newPluginForTest()
+
+	const N = 50
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func(i int) {
+			defer wg.Done()
+			p.addTombstone(
+				fmt.Sprintf("net-%d", i),
+				"",
+				fmt.Sprintf("aa:bb:cc:dd:%02x:%02x", i>>8, i&0xff),
+				fmt.Sprintf("10.0.0.%d", (i%254)+1),
+				"",
+			)
+		}(i)
+	}
+	wg.Wait()
+
+	ts, err := loadTombstones()
+	if err != nil {
+		t.Fatalf("loadTombstones: %v", err)
+	}
+	if len(ts) != N {
+		t.Errorf("lost tombstones under concurrent adds: got %d, want %d", len(ts), N)
 	}
 }
 

--- a/pkg/plugin/tombstone_failure_test.go
+++ b/pkg/plugin/tombstone_failure_test.go
@@ -1,0 +1,104 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAddTombstone_SaveFailureBumpsHealthCounter exercises the failure
+// path of addTombstone -> saveTombstones -> tombstoneWriteFailures.
+// Operators rely on /Plugin.Health.tombstone_write_failures going
+// non-zero to detect a degraded restart-stability window (disk full,
+// EROFS, etc.); without this test the counter could be silently
+// disconnected from saveTombstones errors and nobody would notice
+// until a real disk problem masked another disk problem.
+//
+// We trigger the failure by pointing stateDir at a path whose parent
+// is a regular file — os.MkdirAll fails on "not a directory", which
+// short-circuits saveTombstones with a clean error.
+func TestAddTombstone_SaveFailureBumpsHealthCounter(t *testing.T) {
+	parent := t.TempDir()
+	// A regular file masquerading as the parent of our state dir.
+	blocker := filepath.Join(parent, "blocker")
+	if err := os.WriteFile(blocker, []byte{}, 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	// stateDir = blocker/state — MkdirAll on this fails because
+	// `blocker` is a regular file, not a directory.
+	withStateDir(t, filepath.Join(blocker, "state"))
+
+	p := newPluginForTest()
+
+	// Sanity: counter starts at zero.
+	if got := p.tombstoneWriteFailures.Load(); got != 0 {
+		t.Fatalf("counter should start at 0, got %d", got)
+	}
+
+	p.addTombstone("net-A", "alpha", "aa:bb:cc:dd:ee:ff", "10.0.0.1", "")
+
+	if got := p.tombstoneWriteFailures.Load(); got != 1 {
+		t.Errorf("save failure must bump tombstoneWriteFailures: got %d, want 1", got)
+	}
+}
+
+// TestSaveTombstones_DirCreationFailure mirrors the above at the
+// saveTombstones level — the stateDir-as-child-of-regular-file trick
+// gives us the MkdirAll error path, which is what surfaces the disk
+// problem to addTombstone in production.
+func TestSaveTombstones_DirCreationFailure(t *testing.T) {
+	parent := t.TempDir()
+	blocker := filepath.Join(parent, "blocker")
+	if err := os.WriteFile(blocker, []byte{}, 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	withStateDir(t, filepath.Join(blocker, "state"))
+
+	if err := saveTombstones([]tombstone{{NetworkID: "net-A"}}); err == nil {
+		t.Fatal("expected error when stateDir parent is a regular file")
+	}
+}
+
+// TestSaveOptions_DirCreationFailure is the saveOptions analogue —
+// covers the equivalent MkdirAll error in the options-persistence
+// code path, the one netOptions tries to backfill from on first call.
+func TestSaveOptions_DirCreationFailure(t *testing.T) {
+	parent := t.TempDir()
+	blocker := filepath.Join(parent, "blocker")
+	if err := os.WriteFile(blocker, []byte{}, 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	withStateDir(t, filepath.Join(blocker, "state"))
+
+	if err := saveOptions("net-Z", DHCPNetworkOptions{Bridge: "br0"}); err == nil {
+		t.Fatal("expected error when stateDir parent is a regular file")
+	}
+}
+
+// TestDeleteOptions_PermissionError covers the non-IsNotExist branch
+// of deleteOptions: when the state file exists but cannot be removed
+// (e.g. the parent directory is read-only), the wrapping error must
+// propagate so DeleteNetwork's caller can log it.
+//
+// Skipped under root because chmod 0o500 doesn't prevent writes for
+// privileged users.
+func TestDeleteOptions_PermissionError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("chmod-based DAC tests don't apply to root")
+	}
+	dir := t.TempDir()
+	withStateDir(t, dir)
+	// Create a real options file first so loadOptions could see it.
+	if err := saveOptions("net-perm", DHCPNetworkOptions{Bridge: "br0"}); err != nil {
+		t.Fatalf("setup save: %v", err)
+	}
+	// Make the parent dir read-only so os.Remove on the child fails.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	if err := deleteOptions("net-perm"); err == nil {
+		t.Fatal("expected error when state dir is read-only")
+	}
+}

--- a/pkg/udhcpc/client_args_test.go
+++ b/pkg/udhcpc/client_args_test.go
@@ -1,0 +1,195 @@
+package udhcpc
+
+import (
+	"strings"
+	"testing"
+)
+
+// hasArg returns whether args contains exactly target.
+func hasArg(args []string, target string) bool {
+	for _, a := range args {
+		if a == target {
+			return true
+		}
+	}
+	return false
+}
+
+// TestNewDHCPClient_RequestedIPv4 covers the recovery hint: when the
+// caller passed RequestedIP, udhcpc must get `-r ADDR` so the server
+// has a chance to ACK the same lease the container is already using.
+func TestNewDHCPClient_RequestedIPv4(t *testing.T) {
+	c, err := NewDHCPClient("eth0", &DHCPClientOptions{
+		RequestedIP: "192.168.0.50",
+	})
+	if err != nil {
+		t.Fatalf("NewDHCPClient: %v", err)
+	}
+	// Walk the args looking for the -r/value pair.
+	found := false
+	for i := 0; i < len(c.cmd.Args)-1; i++ {
+		if c.cmd.Args[i] == "-r" && c.cmd.Args[i+1] == "192.168.0.50" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected `-r 192.168.0.50`, got args: %v", c.cmd.Args)
+	}
+}
+
+// TestNewDHCPClient_RequestedIPNotPassedToV6 covers the v6 carve-out.
+// busybox udhcpc6 has no -r equivalent, so a v6 client must never get
+// the flag — passing it would make udhcpc6 reject its own arg list.
+func TestNewDHCPClient_RequestedIPNotPassedToV6(t *testing.T) {
+	c, err := NewDHCPClient("eth0", &DHCPClientOptions{
+		V6:          true,
+		RequestedIP: "fe80::1",
+	})
+	if err != nil {
+		t.Fatalf("NewDHCPClient: %v", err)
+	}
+	if hasArg(c.cmd.Args, "-r") {
+		t.Errorf("DHCPv6 client must not receive -r; args: %v", c.cmd.Args)
+	}
+}
+
+// TestNewDHCPClient_VendorIDv4Only covers the same v4/v6 split for
+// the vendor-id flag (-V). udhcpc6 doesn't accept -V either.
+func TestNewDHCPClient_VendorIDv4Only(t *testing.T) {
+	c4, err := NewDHCPClient("eth0", &DHCPClientOptions{})
+	if err != nil {
+		t.Fatalf("NewDHCPClient v4: %v", err)
+	}
+	if !hasArg(c4.cmd.Args, "-V") || !hasArg(c4.cmd.Args, VendorID) {
+		t.Errorf("v4 client should set -V %s; args: %v", VendorID, c4.cmd.Args)
+	}
+
+	c6, err := NewDHCPClient("eth0", &DHCPClientOptions{V6: true})
+	if err != nil {
+		t.Fatalf("NewDHCPClient v6: %v", err)
+	}
+	if hasArg(c6.cmd.Args, "-V") {
+		t.Errorf("v6 client must not set -V; args: %v", c6.cmd.Args)
+	}
+}
+
+// TestNewDHCPClient_BinarySelection asserts the v4/v6 client process
+// path lookup. Wrong binary name = silent fail-to-spawn; this test
+// catches a refactor that swapped the constants.
+func TestNewDHCPClient_BinarySelection(t *testing.T) {
+	c4, err := NewDHCPClient("eth0", &DHCPClientOptions{})
+	if err != nil {
+		t.Fatalf("v4: %v", err)
+	}
+	if c4.cmd.Args[0] != "udhcpc" {
+		t.Errorf("v4 binary: got %q want udhcpc", c4.cmd.Args[0])
+	}
+
+	c6, err := NewDHCPClient("eth0", &DHCPClientOptions{V6: true})
+	if err != nil {
+		t.Fatalf("v6: %v", err)
+	}
+	if c6.cmd.Args[0] != "udhcpc6" {
+		t.Errorf("v6 binary: got %q want udhcpc6", c6.cmd.Args[0])
+	}
+}
+
+// TestNewDHCPClient_HandlerScriptDefault covers the empty-string
+// fallback. A regression that dropped the default would surface as
+// `udhcpc` exiting immediately because `-s` got an empty arg.
+func TestNewDHCPClient_HandlerScriptDefault(t *testing.T) {
+	c, err := NewDHCPClient("eth0", &DHCPClientOptions{})
+	if err != nil {
+		t.Fatalf("NewDHCPClient: %v", err)
+	}
+	for i := 0; i < len(c.cmd.Args)-1; i++ {
+		if c.cmd.Args[i] == "-s" {
+			if c.cmd.Args[i+1] != DefaultHandler {
+				t.Errorf("default handler: got %q want %q", c.cmd.Args[i+1], DefaultHandler)
+			}
+			return
+		}
+	}
+	t.Errorf("no -s flag found; args: %v", c.cmd.Args)
+}
+
+// TestNewDHCPClient_HandlerScriptOverride covers the explicit override —
+// the handler-script knob exists primarily so tests can point at a
+// scratch script; making sure the override is respected guards that
+// path.
+func TestNewDHCPClient_HandlerScriptOverride(t *testing.T) {
+	custom := "/tmp/my-handler.sh"
+	c, err := NewDHCPClient("eth0", &DHCPClientOptions{HandlerScript: custom})
+	if err != nil {
+		t.Fatalf("NewDHCPClient: %v", err)
+	}
+	for i := 0; i < len(c.cmd.Args)-1; i++ {
+		if c.cmd.Args[i] == "-s" {
+			if c.cmd.Args[i+1] != custom {
+				t.Errorf("custom handler: got %q want %q", c.cmd.Args[i+1], custom)
+			}
+			return
+		}
+	}
+	t.Errorf("no -s flag found; args: %v", c.cmd.Args)
+}
+
+// TestNewDHCPClient_HostnameV6FQDNEncoding covers the v6 hostname
+// option encoding (RFC4704). On v6 the hostname goes through option
+// 27 (0x27) with one flags byte + length byte + ASCII hostname.
+// A regression that emitted the v4-style "hostname:..." form for v6
+// would silently drop the hostname from DHCPv6 leases.
+func TestNewDHCPClient_HostnameV6FQDNEncoding(t *testing.T) {
+	c, err := NewDHCPClient("eth0", &DHCPClientOptions{
+		V6:       true,
+		Hostname: "my-host", // 7 ASCII bytes
+	})
+	if err != nil {
+		t.Fatalf("NewDHCPClient: %v", err)
+	}
+
+	// expected payload: flags=0x01, len=0x07, "my-host" => 010706d6d792d686f7374... no
+	// actually: 01 07 then ASCII "my-host" = 6d 79 2d 68 6f 73 74
+	const want = "0x27:0107" + "6d792d686f7374"
+	found := false
+	for i := 0; i < len(c.cmd.Args)-1; i++ {
+		if c.cmd.Args[i] == "-x" && c.cmd.Args[i+1] == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected v6 hostname encoded as %q; args: %v", want, c.cmd.Args)
+	}
+
+	// And the v4 hostname form must NOT also leak through on v6.
+	for i := 0; i < len(c.cmd.Args)-1; i++ {
+		if c.cmd.Args[i] == "-x" && strings.HasPrefix(c.cmd.Args[i+1], "hostname:") {
+			t.Errorf("v6 client should not emit v4 `hostname:` form; args: %v", c.cmd.Args)
+		}
+	}
+}
+
+// TestNewDHCPClient_ForegroundAndInterface covers the always-on flags.
+// `-f` (foreground) is what makes process supervision work — without
+// it udhcpc daemonises and we lose the child PID. `-i <iface>` is the
+// link to attach to. Both are non-negotiable.
+func TestNewDHCPClient_ForegroundAndInterface(t *testing.T) {
+	c, err := NewDHCPClient("ens18", &DHCPClientOptions{})
+	if err != nil {
+		t.Fatalf("NewDHCPClient: %v", err)
+	}
+	if !hasArg(c.cmd.Args, "-f") {
+		t.Errorf("expected -f (foreground); args: %v", c.cmd.Args)
+	}
+	for i := 0; i < len(c.cmd.Args)-1; i++ {
+		if c.cmd.Args[i] == "-i" {
+			if c.cmd.Args[i+1] != "ens18" {
+				t.Errorf("interface: got %q want ens18", c.cmd.Args[i+1])
+			}
+			return
+		}
+	}
+	t.Errorf("no -i flag found; args: %v", c.cmd.Args)
+}

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -38,14 +38,45 @@ var (
 	ErrNoSandbox = errors.New("missing joined endpoint state")
 )
 
+// ErrToStatus maps a sentinel error to its HTTP status. Validation
+// errors (caller-supplied bad input) produce 400. Upstream-DHCP and
+// retryable Docker-state-transition errors produce 502 / 503 / 409
+// so the wire shape is meaningful to non-libnetwork consumers; the
+// libnetwork integration treats all 5xx the same so this is purely
+// a clarity win for direct API users / logs / dashboards.
+//
+// Anything not enumerated here falls through to 500 — those are
+// either internal plumbing failures (netlink, fs) or unexpected
+// daemon errors, where 500 is the honest answer.
 func ErrToStatus(err error) int {
 	switch {
+	// Caller-supplied validation failures.
 	case errors.Is(err, ErrIPAM), errors.Is(err, ErrBridgeRequired), errors.Is(err, ErrNotBridge),
 		errors.Is(err, ErrBridgeUsed), errors.Is(err, ErrMACAddress),
 		errors.Is(err, ErrInvalidMode), errors.Is(err, ErrParentRequired),
 		errors.Is(err, ErrParentInvalid), errors.Is(err, ErrParentDown),
 		errors.Is(err, ErrModeMismatch):
 		return http.StatusBadRequest
+
+	// Upstream DHCP server didn't respond — not our fault, not the
+	// caller's. 502 (Bad Gateway) matches the "we depend on an
+	// upstream that misbehaved" semantics.
+	case errors.Is(err, ErrNoLease):
+		return http.StatusBadGateway
+
+	// Docker is in a transient state where our prerequisite isn't
+	// available yet (the container or sandbox is being torn up/down).
+	// 503 (Service Unavailable) signals "retry later".
+	case errors.Is(err, ErrNoContainer), errors.Is(err, ErrNoSandbox):
+		return http.StatusServiceUnavailable
+
+	// Stage state mismatch — Join arrived without CreateEndpoint
+	// hints, or DeleteEndpoint without a registered fingerprint.
+	// 409 (Conflict) matches "the resource isn't in a state that
+	// permits this operation".
+	case errors.Is(err, ErrNoHint), errors.Is(err, ErrNotVEth):
+		return http.StatusConflict
+
 	default:
 		return http.StatusInternalServerError
 	}

--- a/pkg/util/errors_test.go
+++ b/pkg/util/errors_test.go
@@ -24,12 +24,16 @@ func TestErrToStatus(t *testing.T) {
 		{"ParentDown", ErrParentDown, http.StatusBadRequest},
 		{"ModeMismatch", ErrModeMismatch, http.StatusBadRequest},
 
-		// Internal errors fall through to 500
-		{"NoLease", ErrNoLease, http.StatusInternalServerError},
-		{"NoHint", ErrNoHint, http.StatusInternalServerError},
-		{"NotVEth", ErrNotVEth, http.StatusInternalServerError},
-		{"NoContainer", ErrNoContainer, http.StatusInternalServerError},
-		{"NoSandbox", ErrNoSandbox, http.StatusInternalServerError},
+		// Upstream-misbehaviour: DHCP server didn't reply.
+		{"NoLease", ErrNoLease, http.StatusBadGateway},
+
+		// Transient Docker state — retryable.
+		{"NoContainer", ErrNoContainer, http.StatusServiceUnavailable},
+		{"NoSandbox", ErrNoSandbox, http.StatusServiceUnavailable},
+
+		// Stage state mismatch — request arrived in the wrong order.
+		{"NoHint", ErrNoHint, http.StatusConflict},
+		{"NotVEth", ErrNotVEth, http.StatusConflict},
 
 		// Anything we don't know about is a 500
 		{"unknown", errors.New("something else"), http.StatusInternalServerError},
@@ -51,5 +55,15 @@ func TestErrToStatus_Wrapped(t *testing.T) {
 	wrapped := fmt.Errorf("validation context: %w", ErrParentRequired)
 	if got := ErrToStatus(wrapped); got != http.StatusBadRequest {
 		t.Errorf("wrapped ErrParentRequired should map to 400, got %d", got)
+	}
+	// Also exercise the new non-400 mappings under wrapping.
+	if got := ErrToStatus(fmt.Errorf("upstream: %w", ErrNoLease)); got != http.StatusBadGateway {
+		t.Errorf("wrapped ErrNoLease should map to 502, got %d", got)
+	}
+	if got := ErrToStatus(fmt.Errorf("teardown race: %w", ErrNoSandbox)); got != http.StatusServiceUnavailable {
+		t.Errorf("wrapped ErrNoSandbox should map to 503, got %d", got)
+	}
+	if got := ErrToStatus(fmt.Errorf("missing: %w", ErrNoHint)); got != http.StatusConflict {
+		t.Errorf("wrapped ErrNoHint should map to 409, got %d", got)
 	}
 }

--- a/pkg/util/http_test.go
+++ b/pkg/util/http_test.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gorilla/handlers"
+)
+
+// TestWriteAccessLog_DoesNotPanic exercises the access-log adapter
+// over the field shape that gorilla/handlers passes in. It's a thin
+// wrapper around logrus.Tracef but the field layout is what makes
+// it pluggable into handlers.CustomLoggingHandler — a refactor that
+// changed the signature would silently break the access-log path
+// at server startup.
+func TestWriteAccessLog_DoesNotPanic(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/Plugin.Health", nil)
+	u, err := url.Parse("/Plugin.Health")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	WriteAccessLog(&bytes.Buffer{}, handlers.LogFormatterParams{
+		Request:    req,
+		URL:        *u,
+		StatusCode: 200,
+		Size:       42,
+	})
+}

--- a/pkg/util/json.go
+++ b/pkg/util/json.go
@@ -46,8 +46,21 @@ func JSONErrResponse(w http.ResponseWriter, err error, statusCode int) {
 	}
 }
 
-// ParseJSONBody attempts to parse the request body as JSON
-func ParseJSONBody(v interface{}, w http.ResponseWriter, r *http.Request) error {
+// ParseJSONOrErrorResponse decodes the request body as JSON into v.
+// On failure it ALSO writes a 400 JSON error response to w; the
+// caller is expected to early-return on a non-nil error and not
+// touch w again. The verbose name is deliberate: the prior name
+// (ParseJSONBody) read as a pure parse, but the function quietly
+// took over response writing — a future caller writing the
+// obvious-looking
+//
+//	if err := ParseJSONBody(&req, w, r); err != nil {
+//	    JSONErrResponse(w, err, ...); return
+//	}
+//
+// would double-write headers. This name makes the response-writing
+// side-effect impossible to overlook at the call site.
+func ParseJSONOrErrorResponse(v interface{}, w http.ResponseWriter, r *http.Request) error {
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(v); err != nil {

--- a/pkg/util/json_test.go
+++ b/pkg/util/json_test.go
@@ -1,0 +1,177 @@
+package util
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestJSONResponse_OK(t *testing.T) {
+	rec := httptest.NewRecorder()
+	JSONResponse(rec, map[string]string{"hello": "world"}, http.StatusCreated)
+
+	if got := rec.Code; got != http.StatusCreated {
+		t.Fatalf("status: got %d want %d", got, http.StatusCreated)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("content-type: got %q want application/json", ct)
+	}
+	var out map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if out["hello"] != "world" {
+		t.Fatalf("body: got %v", out)
+	}
+}
+
+// unencodable forces json.Encode to fail so we can exercise the 500 fallback.
+type unencodable struct{}
+
+func (unencodable) MarshalJSON() ([]byte, error) { return nil, errors.New("nope") }
+
+func TestJSONResponse_EncodeFailureFallsBackTo500(t *testing.T) {
+	rec := httptest.NewRecorder()
+	JSONResponse(rec, unencodable{}, http.StatusOK)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d want 500", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Fatalf("content-type: got %q want text/plain*", ct)
+	}
+	if !strings.Contains(rec.Body.String(), "Failed to serialize") {
+		t.Fatalf("body: got %q", rec.Body.String())
+	}
+}
+
+func TestJSONErrResponse_UsesErrToStatusWhenZero(t *testing.T) {
+	rec := httptest.NewRecorder()
+	JSONErrResponse(rec, ErrParentRequired, 0)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/problem+json" {
+		t.Fatalf("content-type: got %q", ct)
+	}
+	var out struct {
+		Err string `json:"Err"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Err != ErrParentRequired.Error() {
+		t.Fatalf("err body: got %q", out.Err)
+	}
+}
+
+func TestJSONErrResponse_ExplicitStatusOverrides(t *testing.T) {
+	rec := httptest.NewRecorder()
+	JSONErrResponse(rec, errors.New("anything"), http.StatusTeapot)
+
+	if rec.Code != http.StatusTeapot {
+		t.Fatalf("status: got %d want 418", rec.Code)
+	}
+}
+
+func TestParseJSONOrErrorResponse_OK(t *testing.T) {
+	body := strings.NewReader(`{"name":"foo"}`)
+	req := httptest.NewRequest(http.MethodPost, "/", body)
+	rec := httptest.NewRecorder()
+
+	var v struct {
+		Name string `json:"name"`
+	}
+	if err := ParseJSONOrErrorResponse(&v, rec, req); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if v.Name != "foo" {
+		t.Fatalf("decoded: got %+v", v)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("recorder default code changed unexpectedly: %d", rec.Code)
+	}
+}
+
+func TestParseJSONOrErrorResponse_BadJSONWrites400(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("not-json"))
+	rec := httptest.NewRecorder()
+
+	var v struct{}
+	if err := ParseJSONOrErrorResponse(&v, rec, req); err == nil {
+		t.Fatal("expected error from invalid JSON")
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400", rec.Code)
+	}
+}
+
+func TestParseJSONOrErrorResponse_UnknownFieldRejected(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"unexpected":1}`))
+	rec := httptest.NewRecorder()
+
+	var v struct {
+		Known string `json:"known"`
+	}
+	if err := ParseJSONOrErrorResponse(&v, rec, req); err == nil {
+		t.Fatal("expected error from unknown field")
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400", rec.Code)
+	}
+}
+
+func TestAwaitCondition_OkImmediately(t *testing.T) {
+	calls := 0
+	err := AwaitCondition(context.Background(), func() (bool, error) {
+		calls++
+		return true, nil
+	}, time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls: got %d want 1", calls)
+	}
+}
+
+func TestAwaitCondition_OkAfterPolling(t *testing.T) {
+	calls := 0
+	err := AwaitCondition(context.Background(), func() (bool, error) {
+		calls++
+		return calls >= 3, nil
+	}, time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if calls < 3 {
+		t.Fatalf("calls: got %d want >=3", calls)
+	}
+}
+
+func TestAwaitCondition_PropagatesCondError(t *testing.T) {
+	want := errors.New("boom")
+	err := AwaitCondition(context.Background(), func() (bool, error) {
+		return false, want
+	}, time.Millisecond)
+	if !errors.Is(err, want) {
+		t.Fatalf("err: got %v want %v", err, want)
+	}
+}
+
+func TestAwaitCondition_RespectsContextCancel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	err := AwaitCondition(ctx, func() (bool, error) {
+		return false, nil
+	}, 5*time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err: got %v want DeadlineExceeded", err)
+	}
+}


### PR DESCRIPTION
## Summary

Bundle of code-review-driven fixes plus the unit-test coverage bump (20.2% → 30.7%). Fully smoke-tested on a live integration host: golden path, multi-container, docker inspect truthfulness, LAN reachability (gateway, peer, internet), `/Plugin.Health`, daemon restart no-hang.

### Highlights
- **Concurrency hazards eliminated** (W-1, W-5, W-11): synchronous recovery before listener; `dhcpManager.lastIP*` under `ipMu`; concurrent-add tombstone test (`-race` clean).
- **Lifecycle stability** (W-2, #44): tombstone-write failures surface on `/Plugin.Health.tombstone_write_failures`; `DeleteNetwork` prunes orphaned managers from the recovery-then-network-removed window.
- **Operational ergonomics** (N-3, N-7): SIGHUP reopens the log file for logrotate; `log.Fatal` replaced with a cleanup helper that closes the log file first.
- **HTTP error mapping widened** (N-9): `ErrNoLease → 502`, `ErrNoContainer/ErrNoSandbox → 503`, `ErrNoHint/ErrNotVEth → 409`. Direct API consumers now get meaningful status codes.
- **API hygiene** (N-8): `ParseJSONBody` renamed to `ParseJSONOrErrorResponse` — the verbose name makes the response-writing side-effect impossible to overlook at the call site.
- **Dockerfile hardening** (N-11, I-1, I-2): Alpine base pinned by digest, apk packages pinned by version, `CAP_SYS_PTRACE` dropped from the plugin manifest (verified by smoke test that the plugin still enters container netns without it).
- **Code-review polish** (I-3, I-6, I-8, I-9, I-10, #30, #45): MAC/IP demoted to DEBUG in INFO logs, magic numbers given named constants, `RouteType` integer literals replaced with `RouteTypeNextHop`/`RouteTypeOnLink`, govulncheck findings documented as not applicable to client-only usage, stale unix socket cleaned up on `Listen`, compose external-network merge gotcha documented.

### Test coverage
20.2% → 30.7% via three rounds of unit-test additions:
- `pkg/util` 10.3% → 63.8%
- `pkg/plugin` 20.1% → 28.7%
- `pkg/udhcpc` 27.9% → 33.7%

The remaining ~70% is integration code that requires a real netns + parent NIC + DHCP server. Tracked under #56 (v0.7.0 — live integration test harness with self-hosted runner).

### Smoke-tested gates (live integration host)
- Plugin builds clean from `dev` tip; `make create enable` works.
- Network create with `mode=macvlan -o parent=<nic>`; container gets DHCP-issued IP from the LAN pool, not the reserved switch IP.
- Multi-container distinct leases; `docker inspect` reports the real DHCP IP.
- Container reaches gateway, peers on the same network, public internet.
- Lease release on container stop (clean teardown; `-R` flag verified by unit test).
- `/Plugin.Health` returns `healthy=true`, all counters at 0.
- `systemctl restart docker` completes in ~21s with no hang — the upstream's known failure mode is gone.

### Known limitation
- Tombstone TTL (10s) is shorter than a typical daemon restart window (15–30s), so MAC/IP can change across `systemctl restart docker` even with `--restart=always`. Tracked under #55 for v0.6.1; the documented contract (MAC/IP stability across `docker restart <ctr>`) is unaffected.

Closes #45, #44, #42, #40, #39, #38, #34, #31, #30, #29, #27, #24, #23, #22, #21, #20, #14, #11, #10