### PR TITLE
Integration test harness (v0.7.0)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,54 @@
+name: Integration
+
+# Live integration tests against the plugin. Run on the self-hosted
+# `gpu1` runner because they need privileges (CAP_NET_ADMIN, mount/
+# netns ops, bind UDP/67) and a real DHCP server (dnsmasq) — neither
+# is feasible on free GitHub-hosted runners.
+#
+# SECURITY: this workflow runs as root on the maintainer's hardware.
+# Repo Settings → Actions → General → "Fork pull request workflows
+# from outside collaborators" is set to "Require approval for all
+# outside collaborators" so external PRs sit in pending until manually
+# approved.
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    runs-on: [self-hosted, gpu1]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      # Best-effort: clean any orphans from a previous run that
+      # panicked mid-setup. Safe to run even on a clean state.
+      - name: Cleanup orphans from previous runs
+        run: bash test/integration/cleanup-orphans.sh
+
+      # Verify the plugin is installed + enabled before we run tests.
+      # The plugin install is a one-time operator action on the runner
+      # (we deliberately don't reinstall per-PR — that would mutate
+      # daemon-global state and conflict with smoke testing on the
+      # same host).
+      - name: Verify plugin enabled
+        run: |
+          if ! docker plugin ls --format '{{.Name}}: enabled={{.Enabled}}' \
+              | grep -q '^ghcr.io/claymore666/docker-net-dhcp:golang: enabled=true$'; then
+            echo "Plugin ghcr.io/claymore666/docker-net-dhcp:golang is not enabled."
+            echo "Operator action required: docker plugin install + enable on the runner."
+            docker plugin ls
+            exit 1
+          fi
+
+      - name: Run integration tests
+        run: make integration-test

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,10 +30,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.25'
-          cache: true
+      # The Go toolchain is pre-installed on the runner via
+      # test/integration/install-go-runner.sh (one-time operator
+      # action). Skipping actions/setup-go saves ~30s per run on
+      # this runner since the version in go.mod (1.25) doesn't ship
+      # in apt anyway. If go is missing, fail loudly so the runner
+      # operator sees the install step they need to run.
+      - name: Verify Go toolchain
+        run: |
+          if ! command -v go >/dev/null; then
+            echo "go not in PATH on this runner."
+            echo "Run: sudo bash test/integration/install-go-runner.sh"
+            exit 1
+          fi
+          go version
 
       # Best-effort: clean any orphans from a previous run that
       # panicked mid-setup. Safe to run even on a clean state.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -56,13 +56,14 @@ jobs:
       # daemon-global state and conflict with smoke testing on the
       # same host).
       #
-      # The harness reads INTEGRATION_PLUGIN_REF (set below) and
-      # falls back to :golang. We point at :dev for the v0.7.0 PR
-      # so the udhcpc -B fix for ipvlan (#62) can be verified before
-      # the operator promotes the same build to :golang.
+      # The harness reads INTEGRATION_PLUGIN_REF and defaults to
+      # :golang. Setting it explicitly here documents the contract;
+      # CI runs always use :golang. To stage a fix on :dev before
+      # promoting, override INTEGRATION_PLUGIN_REF in this step
+      # for one PR cycle, then promote and revert.
       - name: Verify plugin enabled
         env:
-          INTEGRATION_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:dev
+          INTEGRATION_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:golang
         run: |
           if ! docker plugin ls --format '{{.Name}}: enabled={{.Enabled}}' \
               | grep -q "^${INTEGRATION_PLUGIN_REF}: enabled=true$"; then
@@ -74,5 +75,5 @@ jobs:
 
       - name: Run integration tests
         env:
-          INTEGRATION_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:dev
+          INTEGRATION_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:golang
         run: make integration-test

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,6 +30,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+
       # Best-effort: clean any orphans from a previous run that
       # panicked mid-setup. Safe to run even on a clean state.
       - name: Cleanup orphans from previous runs

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,15 +55,24 @@ jobs:
       # (we deliberately don't reinstall per-PR — that would mutate
       # daemon-global state and conflict with smoke testing on the
       # same host).
+      #
+      # The harness reads INTEGRATION_PLUGIN_REF (set below) and
+      # falls back to :golang. We point at :dev for the v0.7.0 PR
+      # so the udhcpc -B fix for ipvlan (#62) can be verified before
+      # the operator promotes the same build to :golang.
       - name: Verify plugin enabled
+        env:
+          INTEGRATION_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:dev
         run: |
           if ! docker plugin ls --format '{{.Name}}: enabled={{.Enabled}}' \
-              | grep -q '^ghcr.io/claymore666/docker-net-dhcp:golang: enabled=true$'; then
-            echo "Plugin ghcr.io/claymore666/docker-net-dhcp:golang is not enabled."
-            echo "Operator action required: docker plugin install + enable on the runner."
+              | grep -q "^${INTEGRATION_PLUGIN_REF}: enabled=true$"; then
+            echo "Plugin ${INTEGRATION_PLUGIN_REF} is not enabled."
+            echo "Operator action required: build + install + enable on the runner."
             docker plugin ls
             exit 1
           fi
 
       - name: Run integration tests
+        env:
+          INTEGRATION_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:dev
         run: make integration-test

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PLATFORMS ?= linux/amd64,linux/arm64
 SOURCES = $(shell find pkg/ cmd/ -name '*.go')
 BINARY = bin/net-dhcp
 
-.PHONY: all debug build create enable disable pdebug push clean
+.PHONY: all debug build create enable disable pdebug push clean integration-test integration-cleanup
 
 all: create enable
 
@@ -53,3 +53,23 @@ clean:
 	-rm -rf multiarch/
 	-rm -rf plugin/
 	-rm bin/*
+
+# Live integration tests. Need privileges (CAP_NET_ADMIN, mount/netns
+# ops, bind UDP/67) and the plugin already enabled at PLUGIN_NAME:golang.
+# Locally: `sudo make integration-test`. CI: runner is root, target
+# detects and skips the sudo wrapper.
+integration-test:
+	@if [ "$$(id -u)" -ne 0 ]; then \
+		echo "integration-test must run as root. Re-run with sudo."; \
+		exit 1; \
+	fi
+	go test -v -tags integration -count=1 -timeout 5m ./test/integration/...
+
+# Manual orphan cleanup for when an integration test panics mid-setup
+# and leaves dh-itest-* interfaces / containers / networks behind.
+integration-cleanup:
+	@if [ "$$(id -u)" -ne 0 ]; then \
+		echo "integration-cleanup must run as root. Re-run with sudo."; \
+		exit 1; \
+	fi
+	bash test/integration/cleanup-orphans.sh

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -39,11 +39,16 @@ wiring, the udhcpc client wrapper.
 
 Twelve active tests, suite-wall-clock ~3:30 on the runner:
 
-- **Lifecycle** — full create→run→inspect→leave→delete in macvlan
-  and bridge modes. ipvlan parity test exists but is currently
-  skipped because broadcast `OFFER` delivery to the slave doesn't
-  work when the parent is a veth (real LAN parents work; tracked in
-  the v0.7.0 follow-up issue).
+- **Lifecycle** — full create→run→inspect→leave→delete in macvlan,
+  bridge, and ipvlan-L2 modes. The ipvlan path required two
+  plumbing fixes (closes #62): `udhcpc -B` so DISCOVER asks for a
+  broadcast OFFER (ipvlan slaves share the parent MAC and have no
+  way to demux a unicast OFFER addressed to that shared MAC), and
+  not echoing the link's MAC back in `CreateEndpointResponse` (the
+  kernel rejects any MAC change on ipvlan slaves with EOPNOTSUPP,
+  even setting to the current value, so libnetwork must leave the
+  link alone). Both behaviours are gated on `mode == ipvlan` and
+  don't affect macvlan or bridge.
 - **Tombstone** — `docker restart <ctr>` preserves MAC + IP via the
   v0.5.x stability mechanism.
 - **Recovery: plugin recycle** — `docker plugin disable -f` +

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,73 @@ vulnerable code path is reachable from the plugin process, so no
 action is required. Recorded here so future audits don't
 re-investigate. (Original report: third-pass code review, 2026-05-04.)
 
+## v0.7.0
+
+Live integration test harness running on every PR via a self-hosted
+runner with the outside-collaborator approval gate enabled. The
+plugin now has automated end-to-end coverage of the surface that
+`go test` couldn't reach before — `CreateEndpoint`, `Join`, `Leave`,
+`recoverEndpoints`, `dhcpManager.{Start,Stop}`, parent-attached link
+wiring, the udhcpc client wrapper.
+
+### What's exercised
+
+Twelve active tests, suite-wall-clock ~3:30 on the runner:
+
+- **Lifecycle** — full create→run→inspect→leave→delete in macvlan
+  and bridge modes. ipvlan parity test exists but is currently
+  skipped because broadcast `OFFER` delivery to the slave doesn't
+  work when the parent is a veth (real LAN parents work; tracked in
+  the v0.7.0 follow-up issue).
+- **Tombstone** — `docker restart <ctr>` preserves MAC + IP via the
+  v0.5.x stability mechanism.
+- **Recovery: plugin recycle** — `docker plugin disable -f` +
+  `enable` while a container is attached; `Plugin.Health.recovered_ok`
+  ticks past zero and the container's IP/MAC survive.
+- **Recovery: daemon restart** — `systemctl restart docker` with a
+  `--restart=always` container; the daemon comes back, the container
+  comes back, the IP/MAC are preserved (empirically via the tombstone
+  path, since graceful shutdown ran `Leave`).
+- **Concurrency** — four containers attached simultaneously each get
+  a distinct lease; doubles as a deadlock smoke test against
+  per-network-lock regressions.
+- **Error paths** — option-validation rejections (invalid mode,
+  missing parent, wrong-mode options, IPAM not null) plus
+  netlink-state ones (parent down, parent is a bridge, malformed
+  driver-opt ip).
+
+### Architecture
+
+A single shared `Fixture` covers both the parent-attached path
+(`dh-itest-host` veth + dnsmasq on `192.168.99/24`) and the
+bridge-mode path (`dh-itest-br2` Linux bridge + a second dnsmasq on
+`192.168.100/24`). Distinct subnets keep the two DHCP servers from
+racing. The bridge fixture handles the two known landmines that broke
+earlier attempts: STP `forward_delay` defaulting to 15s (set to 0)
+and Docker's default-DROP `FORWARD` policy combined with
+`br_netfilter` causing bridged DHCP to be silently dropped (mitigated
+with two narrow `iptables ACCEPT` rules scoped to the bridge
+interface, removed in teardown).
+
+### CI
+
+`.github/workflows/integration.yml` runs the suite on a self-hosted
+runner. Outside-collaborator approval is required for any PR from a
+non-collaborator account, so external PRs can't get free root on the
+runner host. The Go toolchain is pre-installed via
+`test/integration/install-go-runner.sh` to skip `actions/setup-go`
+and shave ~30s off every run.
+
+### Coverage
+
+Unit-test coverage is unchanged at the bundle level (`pkg/util` 64%,
+`pkg/udhcpc` 34%, `pkg/plugin` 29%). The integration suite isn't
+reflected in those numbers because the plugin runs as a separate
+docker-installed process. Wiring up Go 1.20+ binary-coverage
+instrumentation through the plugin image, with a host `GOCOVERDIR`
+mount and an end-of-run `go tool covdata percent`, is tracked as the
+first item of v0.8.0.
+
 ## v0.6.0
 
 Bundle of code-review-driven fixes plus a unit-test coverage bump

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -214,6 +214,11 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 		V6:          v6,
 		Namespace:   m.nsPath,
 		RequestedIP: requestedIP,
+		// ipvlan slaves share the parent's MAC; without -B the server
+		// may unicast renewals to the parent and the kernel has no
+		// way to demux to the right slave. Setting Broadcast for
+		// every renewal in ipvlan mode keeps lease lifecycle stable.
+		Broadcast: m.opts.effectiveMode() == ModeIPvlan,
 		// Same client-id the initial DISCOVER used in CreateEndpoint,
 		// so renewals are seen as the same client by the server.
 		ClientID: clientIDFromEndpoint(m.joinReq.EndpointID),

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -157,7 +157,15 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 			return fmt.Errorf("failed to set %v link up: %w", mode, err)
 		}
 
-		if r.Interface == nil || r.Interface.MacAddress == "" {
+		// libnetwork applies res.Interface.MacAddress to the link
+		// during Join via netlink LinkSetHardwareAddr. The ipvlan
+		// driver rejects any MAC change (slaves share the parent's
+		// MAC by kernel design), even setting to the current value,
+		// with EOPNOTSUPP. So we skip the MAC response entirely for
+		// ipvlan; libnetwork leaves the link's MAC as-is, and
+		// docker inspect picks the inherited MAC up via netlink
+		// after Join finishes.
+		if mode != ModeIPvlan && (r.Interface == nil || r.Interface.MacAddress == "") {
 			res.Interface.MacAddress = mac.String()
 		}
 

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -182,9 +182,10 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 			defer cancel()
 
 			clientOpts := &udhcpc.DHCPClientOptions{
-				V6:       v6,
-				Hostname: hostname,
-				ClientID: clientID,
+				V6:        v6,
+				Hostname:  hostname,
+				ClientID:  clientID,
+				Broadcast: mode == ModeIPvlan,
 			}
 			if !v6 {
 				clientOpts.RequestedIP = requestedIP

--- a/pkg/udhcpc/client.go
+++ b/pkg/udhcpc/client.go
@@ -51,6 +51,17 @@ type DHCPClientOptions struct {
 	// stable bytes make sense (typically a hash of the Docker EndpointID).
 	ClientID []byte
 
+	// Broadcast (v4 only) makes udhcpc set the BROADCAST flag in the
+	// DHCPDISCOVER, telling the server to send the OFFER as L2
+	// broadcast rather than unicast to chaddr. Required for ipvlan-L2:
+	// every slave shares the parent's MAC, so a unicast OFFER lands
+	// on the parent and the kernel has no L3 hint to demux it to the
+	// right slave (the slave's IP isn't configured yet). For macvlan
+	// and bridge modes it's harmless — modern DHCP servers honour the
+	// flag and clients receive the broadcast on their own interface.
+	// Maps to udhcpc's `-B`.
+	Broadcast bool
+
 	HandlerScript string
 }
 
@@ -104,6 +115,10 @@ func NewDHCPClient(iface string, opts *DHCPClientOptions) (*DHCPClient, error) {
 
 	if opts.RequestedIP != "" && !opts.V6 {
 		c.cmd.Args = append(c.cmd.Args, "-r", opts.RequestedIP)
+	}
+
+	if opts.Broadcast && !opts.V6 {
+		c.cmd.Args = append(c.cmd.Args, "-B")
 	}
 
 	if opts.Hostname != "" {

--- a/pkg/udhcpc/client_args_test.go
+++ b/pkg/udhcpc/client_args_test.go
@@ -173,6 +173,50 @@ func TestNewDHCPClient_HostnameV6FQDNEncoding(t *testing.T) {
 
 // TestNewDHCPClient_ForegroundAndInterface covers the always-on flags.
 // `-f` (foreground) is what makes process supervision work — without
+// TestNewDHCPClient_BroadcastV4 covers the ipvlan-required broadcast
+// flag: when Broadcast is set on a v4 client, `-B` makes udhcpc set
+// the BROADCAST bit in DISCOVER so the server replies with an L2
+// broadcast OFFER. ipvlan slaves share the parent's MAC and have no
+// way to receive a unicast OFFER addressed to that shared MAC, so
+// without -B the lease handshake hangs.
+func TestNewDHCPClient_BroadcastV4(t *testing.T) {
+	c, err := NewDHCPClient("eth0", &DHCPClientOptions{Broadcast: true})
+	if err != nil {
+		t.Fatalf("NewDHCPClient: %v", err)
+	}
+	if !hasArg(c.cmd.Args, "-B") {
+		t.Errorf("expected -B for Broadcast=true; got args: %v", c.cmd.Args)
+	}
+}
+
+// TestNewDHCPClient_BroadcastNotPassedToV6 covers the v6 carve-out:
+// DHCPv6 has no equivalent client-broadcast-flag concept; passing -B
+// to udhcpc6 (which doesn't recognise it) would just confuse the
+// argv. Match the existing v4-only carve-outs (-r, -V).
+func TestNewDHCPClient_BroadcastNotPassedToV6(t *testing.T) {
+	c, err := NewDHCPClient("eth0", &DHCPClientOptions{V6: true, Broadcast: true})
+	if err != nil {
+		t.Fatalf("NewDHCPClient: %v", err)
+	}
+	if hasArg(c.cmd.Args, "-B") {
+		t.Errorf("v6 client must not get -B; got args: %v", c.cmd.Args)
+	}
+}
+
+// TestNewDHCPClient_BroadcastDefaultOff: regression guard for macvlan
+// and bridge modes. These don't need -B (their kernel paths dispatch
+// per-MAC and per-veth respectively), and we want the simpler RFC
+// default for callers that don't opt in.
+func TestNewDHCPClient_BroadcastDefaultOff(t *testing.T) {
+	c, err := NewDHCPClient("eth0", &DHCPClientOptions{})
+	if err != nil {
+		t.Fatalf("NewDHCPClient: %v", err)
+	}
+	if hasArg(c.cmd.Args, "-B") {
+		t.Errorf("-B must be off by default; got args: %v", c.cmd.Args)
+	}
+}
+
 // it udhcpc daemonises and we lose the child PID. `-i <iface>` is the
 // link to attach to. Both are non-negotiable.
 func TestNewDHCPClient_ForegroundAndInterface(t *testing.T) {

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,8 +1,8 @@
 # Integration test harness
 
-Live, end-to-end tests for the plugin: real network namespaces, real
-parent NICs (veth pairs), a real DHCP server (pure-Go via
-`insomniacslk/dhcp`), and a real Docker daemon driving the plugin
+Live, end-to-end tests for the plugin: real network namespaces, a
+real parent NIC (one end of a veth pair), a real DHCP server (host
+`dnsmasq` subprocess), and a real Docker daemon driving the plugin
 through libnetwork. These cover the integration surface that `go
 test` can't reach without privileges — `CreateEndpoint`, `Join`,
 `Leave`, `recoverEndpoints`, `dhcpManager.{Start,Stop}`,
@@ -11,75 +11,114 @@ parent-attached link wiring, `udhcpc.{Start,Finish,Wait,GetIP}`.
 ## Running locally
 
 ```sh
-make integration-test
+sudo make integration-test
 ```
 
-The Makefile target wraps `sudo go test -tags integration
-./test/integration/...` because the harness creates bridges, veth
-pairs, and a UDP listener on `:67`. Plain `go test ./...` skips
-this directory entirely thanks to the `//go:build integration` tag
-on every file here, so unit-test cadence stays fast.
+The Makefile target wraps `go test -tags integration
+./test/integration/...`. Plain `go test ./...` skips this directory
+entirely thanks to the `//go:build integration` tag on every file
+here, so the unit-test cadence stays fast.
 
 ## Prerequisites
 
-- Linux host with `iproute2` and Docker installed.
+- Linux host with `iproute2`, `dnsmasq`, and Docker installed.
 - The plugin enabled at `ghcr.io/claymore666/docker-net-dhcp:golang`.
   The harness verifies this in `TestMain`; it does **not** install
   the plugin for you (deliberate — installing affects the daemon's
-  global state).
-- `sudo` for the test binary (privileges: `CAP_NET_ADMIN`,
-  `CAP_SYS_ADMIN`, ability to bind UDP `:67`).
+  global state and would conflict with smoke testing on the same
+  host).
+- Root (privileges: `CAP_NET_ADMIN` for veth + macvlan link work,
+  ability to bind UDP `:67` for `dnsmasq`).
 
 ## What's covered
 
-See [`#56`](https://github.com/claymore666/docker-net-dhcp/issues/56)
-for the umbrella scope. Tests are organised by lifecycle phase:
+See [#56](https://github.com/claymore666/docker-net-dhcp/issues/56)
+for the umbrella scope. Tests so far:
 
-- `lifecycle_bridge_test.go` — full create→run→inspect→leave→delete
-  in bridge mode.
-- `lifecycle_macvlan_test.go` — same, in macvlan mode.
-- `lifecycle_ipvlan_test.go` — same, in ipvlan L2 mode.
-- `recovery_test.go` — plugin disable/enable; daemon restart with
-  `--restart=always` containers.
-- `tombstone_test.go` — `docker restart <ctr>` preserves MAC + IP.
-- `concurrency_test.go` — N containers attached simultaneously.
-- `errors_test.go` — invalid mode, parent down, parent is bridge,
-  IPAM not null, conflicting `--ip`.
+- `lifecycle_macvlan_test.go` — full create→run→inspect→leave→delete
+  in macvlan mode.
+- `lifecycle_ipvlan_test.go` — same, in ipvlan-L2 mode. Currently
+  `t.Skip`'d because broadcast OFFER delivery to the slave doesn't
+  work when the parent is a veth (real LAN parents work — covered
+  by manual smoke testing). Tracked as
+  [#62](https://github.com/claymore666/docker-net-dhcp/issues/62).
+- `tombstone_restart_test.go` — `docker restart <ctr>` preserves
+  MAC + IP via the tombstone mechanism.
+- `concurrency_test.go` — N containers attached simultaneously each
+  get a distinct lease.
+- `errors_test.go` — invalid mode, missing parent, wrong-mode
+  options, IPAM not null. Validation-only; never reaches DHCP.
+
+Tests run **serially** by design. None of the current cases call
+`t.Parallel()`, even though most would be safe — the recovery and
+daemon-restart tests planned for #56 will mutate global daemon
+state (plugin disable/enable, `systemctl restart docker`), and
+those have to run alone. Keeping the suite serial avoids designing
+in a foot-gun where a future test inadvertently runs concurrently
+with one that drops the docker socket.
+
+If a future test is *clearly* read-only and pure-validation (like
+the `errors_test.go` cases), parallelizing it as a `t.Run` subtest
+is fine — but think before adding `t.Parallel()` to a top-level
+test.
 
 ## CI
 
-The same suite runs on a self-hosted runner (gpu1) for every PR, with
-the **outside-collaborator approval gate** turned on so external PRs
+The same suite runs on a self-hosted runner for every PR, with the
+**outside-collaborator approval gate** turned on so external PRs
 don't get free root on the runner host. See
 `.github/workflows/integration.yml`.
 
-## Architecture
+The workflow assumes the Go toolchain is pre-installed on the
+runner — `actions/setup-go@v5` is skipped to save ~30s/run. If
+you're standing up a new runner, run the operator script once:
 
-Each test owns its own bridge + veth pair + DHCP server, set up and
-torn down in `t.Cleanup`. Tests do not share fixture state, so
-parallel runs (`go test -parallel N`) are safe.
+```sh
+sudo bash test/integration/install-go-runner.sh
+```
+
+This downloads the Go version pinned in `go.mod` from go.dev and
+drops it under `/usr/local/go`, with `/usr/local/bin/go` symlinked
+in. Re-running upgrades in place.
+
+## Architecture
 
 ```
 [host netns]
-  dh-test-br-<unique>   (Linux bridge, no IP on host)
-       |
-       +-- veth-host-<unique>  (parent NIC for plugin's macvlan/ipvlan)
-       +-- veth-dhcp-<unique>  (other end of pair, in netns lan)
-
-[netns lan-<unique>]
-  veth-dhcp-<unique>    (192.168.99.1/24)
-       |
-       (pure-Go DHCP server bound here, pool 192.168.99.10–99.99)
+  dh-itest-host  <─── veth pair ───>  dh-itest-dhcp  (192.168.99.1/24)
+        │                                  │
+   parent= for                         dnsmasq listens here
+   plugin's macvlan                    pool: 192.168.99.10–99
+   children                            lease: 30s
 ```
 
-For bridge-mode tests, the plugin's network has `bridge=dh-test-br`.
-For macvlan/ipvlan tests, `parent=veth-host-<unique>`.
+A single shared `Fixture` (`test/integration/harness/fixture.go`)
+owns the veth pair and the dnsmasq subprocess for the whole `go
+test` invocation. Tests that want a network call
+`harness.CreateNetwork(t, ctx, ..., "macvlan", nil)` which uses
+`dh-itest-host` as the parent.
+
+Bridge mode is not yet covered here — it needs a separate fixture
+(Linux bridge + a different subnet to avoid host-routing conflicts).
+Tracked in #56.
 
 ## Debugging a failed test
 
 1. Run with `-v` to see the harness setup logs.
-2. The DHCP server logs every DISCOVER/REQUEST/RELEASE on a per-test
-   channel; failed tests dump the captured packets at the end.
+2. The failed test's `t.Cleanup` dumps the captured `dnsmasq` log
+   (every DISCOVER/REQUEST/ACK/RELEASE) at the end — the wire
+   conversation is usually enough to localise the problem.
 3. `t.Cleanup` is best-effort. If a test panics mid-setup, run
-   `sudo ./test/integration/cleanup-orphans.sh` to remove leftover
-   `dh-test-*` interfaces and netnses.
+   `sudo bash test/integration/cleanup-orphans.sh` to remove
+   leftover `dh-itest-*` interfaces, networks, and the `dnsmasq`
+   process if it's still running.
+
+## ipvlan + veth
+
+`TestLifecycleIPvlan_GoldenPath` is currently skipped because the
+DHCP `OFFER` (broadcast — see `--dhcp-broadcast` in the fixture)
+doesn't reach the ipvlan slave inside the container netns when the
+parent is a veth. Real hardware NIC parents work fine — that path
+is covered by manual LAN smoke testing. The harness limitation is
+tracked as #62; un-skipping the test once #62 is resolved is the
+acceptance criterion.

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -56,6 +56,13 @@ for the umbrella scope. Tests so far:
 - `recovery_test.go` — `docker plugin disable -f` + `enable` while
   a container is attached; asserts Plugin.Health.recovered_ok ≥ 1
   and the container's IP/MAC survive the recycle.
+- `recovery_daemon_test.go` — `systemctl restart docker` mid-suite
+  with a `--restart=always` container attached; asserts the daemon
+  comes back, the container restarts, and the IP/MAC are
+  preserved. Empirically the IP is preserved via the tombstone
+  path (graceful shutdown calls Leave) rather than recoverEndpoints
+  — the test logs both paths' counters but tests on the
+  user-visible invariant.
 
 Tests run **serially** by design. None of the current cases call
 `t.Parallel()`, even though most would be safe — the recovery and

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,85 @@
+# Integration test harness
+
+Live, end-to-end tests for the plugin: real network namespaces, real
+parent NICs (veth pairs), a real DHCP server (pure-Go via
+`insomniacslk/dhcp`), and a real Docker daemon driving the plugin
+through libnetwork. These cover the integration surface that `go
+test` can't reach without privileges — `CreateEndpoint`, `Join`,
+`Leave`, `recoverEndpoints`, `dhcpManager.{Start,Stop}`,
+parent-attached link wiring, `udhcpc.{Start,Finish,Wait,GetIP}`.
+
+## Running locally
+
+```sh
+make integration-test
+```
+
+The Makefile target wraps `sudo go test -tags integration
+./test/integration/...` because the harness creates bridges, veth
+pairs, and a UDP listener on `:67`. Plain `go test ./...` skips
+this directory entirely thanks to the `//go:build integration` tag
+on every file here, so unit-test cadence stays fast.
+
+## Prerequisites
+
+- Linux host with `iproute2` and Docker installed.
+- The plugin enabled at `ghcr.io/claymore666/docker-net-dhcp:golang`.
+  The harness verifies this in `TestMain`; it does **not** install
+  the plugin for you (deliberate — installing affects the daemon's
+  global state).
+- `sudo` for the test binary (privileges: `CAP_NET_ADMIN`,
+  `CAP_SYS_ADMIN`, ability to bind UDP `:67`).
+
+## What's covered
+
+See [`#56`](https://github.com/claymore666/docker-net-dhcp/issues/56)
+for the umbrella scope. Tests are organised by lifecycle phase:
+
+- `lifecycle_bridge_test.go` — full create→run→inspect→leave→delete
+  in bridge mode.
+- `lifecycle_macvlan_test.go` — same, in macvlan mode.
+- `lifecycle_ipvlan_test.go` — same, in ipvlan L2 mode.
+- `recovery_test.go` — plugin disable/enable; daemon restart with
+  `--restart=always` containers.
+- `tombstone_test.go` — `docker restart <ctr>` preserves MAC + IP.
+- `concurrency_test.go` — N containers attached simultaneously.
+- `errors_test.go` — invalid mode, parent down, parent is bridge,
+  IPAM not null, conflicting `--ip`.
+
+## CI
+
+The same suite runs on a self-hosted runner (gpu1) for every PR, with
+the **outside-collaborator approval gate** turned on so external PRs
+don't get free root on the runner host. See
+`.github/workflows/integration.yml`.
+
+## Architecture
+
+Each test owns its own bridge + veth pair + DHCP server, set up and
+torn down in `t.Cleanup`. Tests do not share fixture state, so
+parallel runs (`go test -parallel N`) are safe.
+
+```
+[host netns]
+  dh-test-br-<unique>   (Linux bridge, no IP on host)
+       |
+       +-- veth-host-<unique>  (parent NIC for plugin's macvlan/ipvlan)
+       +-- veth-dhcp-<unique>  (other end of pair, in netns lan)
+
+[netns lan-<unique>]
+  veth-dhcp-<unique>    (192.168.99.1/24)
+       |
+       (pure-Go DHCP server bound here, pool 192.168.99.10–99.99)
+```
+
+For bridge-mode tests, the plugin's network has `bridge=dh-test-br`.
+For macvlan/ipvlan tests, `parent=veth-host-<unique>`.
+
+## Debugging a failed test
+
+1. Run with `-v` to see the harness setup logs.
+2. The DHCP server logs every DISCOVER/REQUEST/RELEASE on a per-test
+   channel; failed tests dump the captured packets at the end.
+3. `t.Cleanup` is best-effort. If a test panics mid-setup, run
+   `sudo ./test/integration/cleanup-orphans.sh` to remove leftover
+   `dh-test-*` interfaces and netnses.

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -37,6 +37,9 @@ for the umbrella scope. Tests so far:
 
 - `lifecycle_macvlan_test.go` — full create→run→inspect→leave→delete
   in macvlan mode.
+- `lifecycle_bridge_test.go` — same, in bridge mode (uses the
+  bridge fixture: separate Linux bridge + second dnsmasq on
+  192.168.100/24).
 - `lifecycle_ipvlan_test.go` — same, in ipvlan-L2 mode. Currently
   `t.Skip`'d because broadcast OFFER delivery to the slave doesn't
   work when the parent is a veth (real LAN parents work — covered
@@ -46,8 +49,13 @@ for the umbrella scope. Tests so far:
   MAC + IP via the tombstone mechanism.
 - `concurrency_test.go` — N containers attached simultaneously each
   get a distinct lease.
-- `errors_test.go` — invalid mode, missing parent, wrong-mode
-  options, IPAM not null. Validation-only; never reaches DHCP.
+- `errors_test.go`, `errors_netlink_test.go` — option-validation
+  rejections (invalid mode, missing parent, wrong-mode options,
+  IPAM not null) plus netlink-state ones (parent down, parent is
+  a bridge, malformed driver-opt ip).
+- `recovery_test.go` — `docker plugin disable -f` + `enable` while
+  a container is attached; asserts Plugin.Health.recovered_ok ≥ 1
+  and the container's IP/MAC survive the recycle.
 
 Tests run **serially** by design. None of the current cases call
 `t.Parallel()`, even though most would be safe — the recovery and
@@ -85,22 +93,34 @@ in. Re-running upgrades in place.
 
 ```
 [host netns]
-  dh-itest-host  <─── veth pair ───>  dh-itest-dhcp  (192.168.99.1/24)
-        │                                  │
-   parent= for                         dnsmasq listens here
-   plugin's macvlan                    pool: 192.168.99.10–99
-   children                            lease: 30s
+
+  Macvlan/ipvlan path:
+    dh-itest-host  <─ veth ─>  dh-itest-dhcp  (192.168.99.1/24)
+          │                          │
+     parent= for                dnsmasq #1
+     plugin children            pool 192.168.99.10–99
+
+  Bridge path:
+    dh-itest-br2  (192.168.100.1/24)
+          │
+     bridge= for                dnsmasq #2 bound to br2
+     plugin endpoints           pool 192.168.100.10–99
+                                + iptables FORWARD ACCEPT
+                                  (br_netfilter would otherwise
+                                  drop bridged DHCP under docker's
+                                  default-DROP FORWARD policy)
 ```
 
-A single shared `Fixture` (`test/integration/harness/fixture.go`)
-owns the veth pair and the dnsmasq subprocess for the whole `go
-test` invocation. Tests that want a network call
-`harness.CreateNetwork(t, ctx, ..., "macvlan", nil)` which uses
-`dh-itest-host` as the parent.
+A single shared `Fixture` (`test/integration/harness/fixture.go`,
+`harness/bridge.go`) owns both subnets for the whole `go test`
+invocation. Tests select a path by mode:
+`harness.CreateNetwork(t, ctx, ..., "macvlan", nil)` uses
+`dh-itest-host` as the parent; `"bridge"` uses `dh-itest-br2`.
 
-Bridge mode is not yet covered here — it needs a separate fixture
-(Linux bridge + a different subnet to avoid host-routing conflicts).
-Tracked in #56.
+Distinct subnets keep the two dnsmasq instances cleanly isolated
+from each other — without that, two DHCP servers on the same
+broadcast domain would race and tests would bind whichever
+answered first.
 
 ## Debugging a failed test
 

--- a/test/integration/cleanup-orphans.sh
+++ b/test/integration/cleanup-orphans.sh
@@ -42,14 +42,28 @@ if docker plugin inspect "$plugin_ref" >/dev/null 2>&1; then
     docker plugin enable "$plugin_ref" 2>&1 | sed 's/^/  /' || true
 fi
 
-echo "=== killing lingering dnsmasq listening on dh-itest-dhcp ==="
-# dnsmasq with --interface=dh-itest-dhcp argv signature
-pids=$(pgrep -f -- '--interface=dh-itest-dhcp' || true)
+echo "=== killing lingering dnsmasq processes started by the harness ==="
+# Both fixtures share the dh-itest-* prefix on their --interface= flag,
+# so a single pgrep pattern catches both the macvlan-side dnsmasq
+# (--interface=dh-itest-dhcp) and the bridge-side one
+# (--interface=dh-itest-br2).
+pids=$(pgrep -f -- '--interface=dh-itest-' || true)
 if [[ -n "$pids" ]]; then
     kill -TERM $pids 2>/dev/null || true
     sleep 1
     kill -KILL $pids 2>/dev/null || true
     echo "  killed: $pids"
 fi
+
+echo "=== removing harness-installed iptables FORWARD rules ==="
+# The bridge fixture inserts ACCEPT rules so docker's default-deny
+# FORWARD policy doesn't drop bridged DHCP. -D is run in a loop because
+# iptables only deletes one matching rule per call, and a panicked run
+# can leave duplicates.
+for direction in -i -o; do
+    while iptables -C FORWARD "$direction" dh-itest-br2 -j ACCEPT 2>/dev/null; do
+        iptables -D FORWARD "$direction" dh-itest-br2 -j ACCEPT 2>&1 | sed 's/^/  /'
+    done
+done
 
 echo "=== done ==="

--- a/test/integration/cleanup-orphans.sh
+++ b/test/integration/cleanup-orphans.sh
@@ -33,6 +33,15 @@ for if in $(ip -br link 2>/dev/null | awk '/^dh-itest-/{print $1}' | sed 's|@.*|
     ip link del "$if" 2>/dev/null || true
 done
 
+echo "=== ensuring plugin is enabled (recovery test may have left it disabled) ==="
+# If the recovery test panicked between disable and enable, the plugin is
+# stuck off and every subsequent run will fail at VerifyPluginEnabled.
+# PluginEnable is idempotent — already-enabled returns an error we ignore.
+plugin_ref="ghcr.io/claymore666/docker-net-dhcp:golang"
+if docker plugin inspect "$plugin_ref" >/dev/null 2>&1; then
+    docker plugin enable "$plugin_ref" 2>&1 | sed 's/^/  /' || true
+fi
+
 echo "=== killing lingering dnsmasq listening on dh-itest-dhcp ==="
 # dnsmasq with --interface=dh-itest-dhcp argv signature
 pids=$(pgrep -f -- '--interface=dh-itest-dhcp' || true)

--- a/test/integration/cleanup-orphans.sh
+++ b/test/integration/cleanup-orphans.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Manual cleanup for integration-test orphans. Run as root after a
+# test panics mid-setup. Safe to run repeatedly.
+#
+# Removes:
+#   - dh-itest-* docker networks
+#   - dh-itest-* docker containers
+#   - dh-itest-* host network interfaces (veth pair, etc.)
+#   - lingering dnsmasq processes started by the harness
+
+set -u
+
+if [[ $EUID -ne 0 ]]; then
+    echo "must run as root" >&2
+    exit 1
+fi
+
+echo "=== removing dh-itest-* containers ==="
+ids=$(docker ps -a --filter 'name=dh-itest-' --format '{{.ID}}')
+if [[ -n "$ids" ]]; then
+    docker rm -f $ids 2>&1 | sed 's/^/  /'
+fi
+
+echo "=== removing dh-itest-* networks ==="
+nets=$(docker network ls --filter 'name=dh-itest-' --format '{{.ID}}')
+if [[ -n "$nets" ]]; then
+    docker network rm $nets 2>&1 | sed 's/^/  /'
+fi
+
+echo "=== removing dh-itest-* host interfaces ==="
+for if in $(ip -br link 2>/dev/null | awk '/^dh-itest-/{print $1}' | sed 's|@.*||'); do
+    echo "  ip link del $if"
+    ip link del "$if" 2>/dev/null || true
+done
+
+echo "=== killing lingering dnsmasq listening on dh-itest-dhcp ==="
+# dnsmasq with --interface=dh-itest-dhcp argv signature
+pids=$(pgrep -f -- '--interface=dh-itest-dhcp' || true)
+if [[ -n "$pids" ]]; then
+    kill -TERM $pids 2>/dev/null || true
+    sleep 1
+    kill -KILL $pids 2>/dev/null || true
+    echo "  killed: $pids"
+fi
+
+echo "=== done ==="

--- a/test/integration/concurrency_test.go
+++ b/test/integration/concurrency_test.go
@@ -1,0 +1,88 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+)
+
+// TestConcurrency_DistinctLeases starts N containers on the same
+// macvlan network in parallel and asserts each gets a distinct IP
+// from the DHCP pool. Doubles as a deadlock smoke test:
+// CreateEndpoint takes networkLock per-network, so a regression that
+// upgraded that to a global lock or held it across the udhcpc -q call
+// would serialize starts and quickly blow the timeout.
+//
+// N=4 keeps the test fast (one short-lease dnsmasq, one veth) while
+// being enough to surface a serialization regression: 4 sequential
+// 5-second udhcpc roundtrips would already exceed the per-container
+// IPAcquisitionBudget if the lock were held wrong.
+func TestConcurrency_DistinctLeases(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	const N = 4
+	netName := "dh-itest-concurrency-net"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+
+	type result struct {
+		idx  int
+		ipv4 string
+		mac  string
+		err  error
+	}
+	results := make(chan result, N)
+
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					results <- result{idx: i, err: fmt.Errorf("panic: %v", r)}
+				}
+			}()
+			ctrName := fmt.Sprintf("dh-itest-concurrency-ctr-%d", i)
+			_, ipv4, mac := harness.RunContainer(t, ctx, netName, ctrName)
+			results <- result{idx: i, ipv4: ipv4, mac: mac}
+		}(i)
+	}
+	wg.Wait()
+	close(results)
+
+	seenIPs := make(map[string]int, N)
+	seenMACs := make(map[string]int, N)
+	for r := range results {
+		if r.err != nil {
+			t.Errorf("worker %d: %v", r.idx, r.err)
+			continue
+		}
+		harness.AssertIP(t, r.ipv4)
+		if other, dup := seenIPs[r.ipv4]; dup {
+			t.Errorf("duplicate IP %s assigned to workers %d and %d", r.ipv4, other, r.idx)
+		}
+		if other, dup := seenMACs[r.mac]; dup {
+			t.Errorf("duplicate MAC %s assigned to workers %d and %d", r.mac, other, r.idx)
+		}
+		seenIPs[r.ipv4] = r.idx
+		seenMACs[r.mac] = r.idx
+		t.Logf("worker %d: ip=%s mac=%s", r.idx, r.ipv4, r.mac)
+	}
+	if len(seenIPs) != N {
+		t.Fatalf("expected %d distinct IPs, got %d", N, len(seenIPs))
+	}
+}

--- a/test/integration/errors_netlink_test.go
+++ b/test/integration/errors_netlink_test.go
@@ -74,7 +74,9 @@ func TestErrors_ParentIsBridge(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	const brName = "dh-itest-bridge-test"
+	// Linux IFNAMSIZ caps interface names at 15 characters + NUL.
+	// "dh-itest-br" is 11; fits with room for a suffix.
+	const brName = "dh-itest-br"
 	br := &netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Name: brName}}
 	if err := netlink.LinkAdd(br); err != nil {
 		t.Fatalf("LinkAdd(%s bridge): %v", brName, err)
@@ -114,22 +116,24 @@ func TestErrors_ParentIsBridge(t *testing.T) {
 	}
 }
 
-// TestErrors_IPCollision drives the resolveExplicitV4 conflict
-// branch in CreateEndpoint: libnetwork hands us an Interface.Address
-// from `--ip=A`, while the endpoint-level driver-opt `ip=B` says
-// something different. The plugin can't choose silently — it
-// refuses with ErrIPAM-wrapped "conflicting static IP".
+// TestErrors_DriverOptIPMalformed drives the resolveExplicitV4
+// driver-opt validation branch in CreateEndpoint: an endpoint-level
+// `ip=` driver-opt that doesn't parse as a bare IPv4 must be
+// rejected with ErrIPAM wrapping.
 //
-// The created network and (failed) container are cleaned up in
-// t.Cleanup. The container create is what fails — ContainerCreate
-// asks libnetwork to reach the plugin's CreateEndpoint, which is
-// where the conflict is detected.
-func TestErrors_IPCollision(t *testing.T) {
+// The conflict path (Interface.Address from --ip vs driver-opt ip)
+// is unreachable through the docker API on a null-IPAM network —
+// libnetwork rejects --ip with "user specified IP address is
+// supported only when connecting to networks with user configured
+// subnets", before the plugin's CreateEndpoint sees it. The
+// driver-opt path is the one we can exercise end-to-end here, and
+// it covers the same parsing helper.
+func TestErrors_DriverOptIPMalformed(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	netName := "dh-itest-err-ipcoll"
-	ctrName := "dh-itest-err-ipcoll-ctr"
+	netName := "dh-itest-err-droptip"
+	ctrName := "dh-itest-err-droptip-ctr"
 	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
 
 	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
@@ -138,18 +142,13 @@ func TestErrors_IPCollision(t *testing.T) {
 	}
 	defer cli.Close()
 
-	const (
-		ipFromIface = "192.168.99.40"
-		ipFromOpt   = "192.168.99.41"
-	)
 	_, createErr := cli.ContainerCreate(ctx,
 		&container.Config{Image: harness.TestImage, Cmd: []string{"sleep", "infinity"}},
 		&container.HostConfig{},
 		&network.NetworkingConfig{
 			EndpointsConfig: map[string]*network.EndpointSettings{
 				netName: {
-					IPAMConfig: &network.EndpointIPAMConfig{IPv4Address: ipFromIface},
-					DriverOpts: map[string]string{"ip": ipFromOpt},
+					DriverOpts: map[string]string{"ip": "not-a-valid-ip"},
 				},
 			},
 		},
@@ -161,11 +160,11 @@ func TestErrors_IPCollision(t *testing.T) {
 		_ = cli.ContainerRemove(bg, ctrName, container.RemoveOptions{Force: true})
 	})
 	if createErr == nil {
-		t.Fatalf("expected ContainerCreate to fail on conflicting --ip / driver-opt ip, got success")
+		t.Fatalf("expected ContainerCreate to fail on malformed driver-opt ip, got success")
 	}
-	if !strings.Contains(strings.ToLower(createErr.Error()), "conflicting static ip") {
-		t.Errorf("error missing expected substring 'conflicting static IP'\nactual: %s", createErr.Error())
+	if !strings.Contains(strings.ToLower(createErr.Error()), "invalid driver-opt ip") {
+		t.Errorf("error missing expected substring 'invalid driver-opt ip'\nactual: %s", createErr.Error())
 	} else {
-		t.Logf("✓ ip-collision rejected: %s", createErr.Error())
+		t.Logf("✓ malformed driver-opt ip rejected: %s", createErr.Error())
 	}
 }

--- a/test/integration/errors_netlink_test.go
+++ b/test/integration/errors_netlink_test.go
@@ -1,0 +1,171 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	docker "github.com/docker/docker/client"
+	"github.com/vishvananda/netlink"
+)
+
+// TestErrors_ParentDown drives validateParentForChild's down-state
+// branch. Brings the host veth admin-down, attempts to create a
+// macvlan network on it, asserts the plugin rejects the create
+// with ErrParentDown wrapping. Restores the link to UP in
+// t.Cleanup so subsequent tests still see a healthy parent.
+func TestErrors_ParentDown(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	link, err := netlink.LinkByName(harness.HostVeth)
+	if err != nil {
+		t.Fatalf("LinkByName(%s): %v", harness.HostVeth, err)
+	}
+	if err := netlink.LinkSetDown(link); err != nil {
+		t.Fatalf("LinkSetDown(%s): %v", harness.HostVeth, err)
+	}
+	t.Cleanup(func() {
+		if err := netlink.LinkSetUp(link); err != nil {
+			t.Logf("WARN: failed to restore %s to UP: %v", harness.HostVeth, err)
+		}
+	})
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	netName := "dh-itest-err-parent-down"
+	res, createErr := cli.NetworkCreate(ctx, netName, network.CreateOptions{
+		Driver: harness.DriverName,
+		IPAM:   &network.IPAM{Driver: "null"},
+		Options: map[string]string{
+			"mode":   "macvlan",
+			"parent": harness.HostVeth,
+		},
+	})
+	if createErr == nil {
+		_ = cli.NetworkRemove(context.Background(), res.ID)
+		t.Fatalf("expected NetworkCreate to fail with parent-down error, got success")
+	}
+	if !strings.Contains(strings.ToLower(createErr.Error()), "parent interface is down") {
+		t.Errorf("error missing expected substring 'parent interface is down'\nactual: %s", createErr.Error())
+	} else {
+		t.Logf("✓ parent-down rejected: %s", createErr.Error())
+	}
+}
+
+// TestErrors_ParentIsBridge drives validateParentForChild's
+// disallowed-type branch. Creates a transient Linux bridge in the
+// host netns, points the plugin at it as a macvlan parent, asserts
+// rejection. macvlan over a bridge is something the kernel itself
+// would happily allow but produces nonsensical behaviour for our
+// use case (broadcast loops, MAC learning conflicts), so the
+// plugin refuses up-front.
+func TestErrors_ParentIsBridge(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const brName = "dh-itest-bridge-test"
+	br := &netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Name: brName}}
+	if err := netlink.LinkAdd(br); err != nil {
+		t.Fatalf("LinkAdd(%s bridge): %v", brName, err)
+	}
+	t.Cleanup(func() {
+		if l, err := netlink.LinkByName(brName); err == nil {
+			_ = netlink.LinkDel(l)
+		}
+	})
+	if err := netlink.LinkSetUp(br); err != nil {
+		t.Fatalf("LinkSetUp(%s): %v", brName, err)
+	}
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	netName := "dh-itest-err-parent-bridge"
+	res, createErr := cli.NetworkCreate(ctx, netName, network.CreateOptions{
+		Driver: harness.DriverName,
+		IPAM:   &network.IPAM{Driver: "null"},
+		Options: map[string]string{
+			"mode":   "macvlan",
+			"parent": brName,
+		},
+	})
+	if createErr == nil {
+		_ = cli.NetworkRemove(context.Background(), res.ID)
+		t.Fatalf("expected NetworkCreate to fail when parent is a bridge, got success")
+	}
+	if !strings.Contains(strings.ToLower(createErr.Error()), "unsuitable for macvlan") {
+		t.Errorf("error missing expected substring 'unsuitable for macvlan'\nactual: %s", createErr.Error())
+	} else {
+		t.Logf("✓ parent-is-bridge rejected: %s", createErr.Error())
+	}
+}
+
+// TestErrors_IPCollision drives the resolveExplicitV4 conflict
+// branch in CreateEndpoint: libnetwork hands us an Interface.Address
+// from `--ip=A`, while the endpoint-level driver-opt `ip=B` says
+// something different. The plugin can't choose silently — it
+// refuses with ErrIPAM-wrapped "conflicting static IP".
+//
+// The created network and (failed) container are cleaned up in
+// t.Cleanup. The container create is what fails — ContainerCreate
+// asks libnetwork to reach the plugin's CreateEndpoint, which is
+// where the conflict is detected.
+func TestErrors_IPCollision(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-err-ipcoll"
+	ctrName := "dh-itest-err-ipcoll-ctr"
+	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	const (
+		ipFromIface = "192.168.99.40"
+		ipFromOpt   = "192.168.99.41"
+	)
+	_, createErr := cli.ContainerCreate(ctx,
+		&container.Config{Image: harness.TestImage, Cmd: []string{"sleep", "infinity"}},
+		&container.HostConfig{},
+		&network.NetworkingConfig{
+			EndpointsConfig: map[string]*network.EndpointSettings{
+				netName: {
+					IPAMConfig: &network.EndpointIPAMConfig{IPv4Address: ipFromIface},
+					DriverOpts: map[string]string{"ip": ipFromOpt},
+				},
+			},
+		},
+		nil,
+		ctrName,
+	)
+	t.Cleanup(func() {
+		bg := context.Background()
+		_ = cli.ContainerRemove(bg, ctrName, container.RemoveOptions{Force: true})
+	})
+	if createErr == nil {
+		t.Fatalf("expected ContainerCreate to fail on conflicting --ip / driver-opt ip, got success")
+	}
+	if !strings.Contains(strings.ToLower(createErr.Error()), "conflicting static ip") {
+		t.Errorf("error missing expected substring 'conflicting static IP'\nactual: %s", createErr.Error())
+	} else {
+		t.Logf("✓ ip-collision rejected: %s", createErr.Error())
+	}
+}

--- a/test/integration/errors_netlink_test.go
+++ b/test/integration/errors_netlink_test.go
@@ -142,7 +142,7 @@ func TestErrors_DriverOptIPMalformed(t *testing.T) {
 	}
 	defer cli.Close()
 
-	_, createErr := cli.ContainerCreate(ctx,
+	created, createErr := cli.ContainerCreate(ctx,
 		&container.Config{Image: harness.TestImage, Cmd: []string{"sleep", "infinity"}},
 		&container.HostConfig{},
 		&network.NetworkingConfig{
@@ -159,12 +159,23 @@ func TestErrors_DriverOptIPMalformed(t *testing.T) {
 		bg := context.Background()
 		_ = cli.ContainerRemove(bg, ctrName, container.RemoveOptions{Force: true})
 	})
-	if createErr == nil {
-		t.Fatalf("expected ContainerCreate to fail on malformed driver-opt ip, got success")
+
+	// libnetwork sometimes defers CreateEndpoint from ContainerCreate
+	// to ContainerStart; either path is fine, but the plugin must
+	// reject before the container actually runs. Capture whichever
+	// call fails.
+	var failure string
+	if createErr != nil {
+		failure = createErr.Error()
+	} else if startErr := cli.ContainerStart(ctx, created.ID, container.StartOptions{}); startErr != nil {
+		failure = startErr.Error()
 	}
-	if !strings.Contains(strings.ToLower(createErr.Error()), "invalid driver-opt ip") {
-		t.Errorf("error missing expected substring 'invalid driver-opt ip'\nactual: %s", createErr.Error())
+	if failure == "" {
+		t.Fatalf("expected ContainerCreate or ContainerStart to fail on malformed driver-opt ip, both succeeded")
+	}
+	if !strings.Contains(strings.ToLower(failure), "invalid driver-opt ip") {
+		t.Errorf("error missing expected substring 'invalid driver-opt ip'\nactual: %s", failure)
 	} else {
-		t.Logf("✓ malformed driver-opt ip rejected: %s", createErr.Error())
+		t.Logf("✓ malformed driver-opt ip rejected: %s", failure)
 	}
 }

--- a/test/integration/errors_test.go
+++ b/test/integration/errors_test.go
@@ -16,37 +16,52 @@ import (
 // errorCases drive TestErrors_NetworkCreateValidation. Each case
 // exercises a validation branch in pkg/plugin/network.go (via the
 // libnetwork remote-driver protocol) — the plugin should refuse the
-// network up-front, before any DHCP traffic is ever attempted. The
-// `wantSubstr` is a fragment of the error string the plugin emits;
-// it travels through dockerd, so we match loosely on substring to
-// stay tolerant of dockerd's wrapping.
+// network up-front, before any DHCP traffic is ever attempted.
+//
+// `opts` is the COMPLETE driver-options map; no auto-injection. That
+// keeps each row honest about exactly which combination it's hitting,
+// at the cost of re-typing parent= for the macvlan rows.
+//
+// `wantSubstr` is matched case-insensitively as a substring of the
+// dockerd-wrapped error string. Loose-matching keeps these tests
+// stable across libnetwork wording changes; tightening to exact
+// equality would buy nothing.
 var errorCases = []struct {
 	name       string
-	mode       string
 	opts       map[string]string
 	ipam       *network.IPAM // nil → null IPAM (the supported case)
 	wantSubstr string
 }{
 	{
 		name:       "InvalidMode",
-		mode:       "moonbridge",
+		opts:       map[string]string{"mode": "moonbridge"},
 		wantSubstr: "invalid mode",
 	},
 	{
 		name:       "MacvlanMissingParent",
-		mode:       "macvlan",
-		opts:       map[string]string{}, // explicitly clear parent
+		opts:       map[string]string{"mode": "macvlan"},
 		wantSubstr: "parent required",
 	},
 	{
-		name:       "BridgeWithParent",
-		mode:       "bridge",
-		opts:       map[string]string{"parent": "lo"},
+		// Sets `bridge=foo` on a macvlan network. The plugin's
+		// validator checks `Parent != ""` first then refuses any
+		// foreign option for the chosen mode, so this exercises the
+		// ErrModeMismatch branch (bridge cannot be set in
+		// mode=macvlan).
+		name: "MacvlanWithBridge",
+		opts: map[string]string{
+			"mode":   "macvlan",
+			"parent": harness.HostVeth,
+			"bridge": "foo",
+		},
 		wantSubstr: "does not apply to selected mode",
 	},
 	{
-		name:       "IPAMNotNull",
-		mode:       "macvlan",
+		name: "IPAMNotNull",
+		opts: map[string]string{
+			"mode":   "macvlan",
+			"parent": harness.HostVeth,
+		},
 		ipam:       &network.IPAM{Driver: "default"},
 		wantSubstr: "null IPAM driver",
 	},
@@ -55,9 +70,9 @@ var errorCases = []struct {
 // TestErrors_NetworkCreateValidation walks the validation matrix.
 // These cases never reach DHCP, so the only setup required is that
 // the plugin is enabled (TestMain enforces) and the host-side veth
-// exists for the macvlan cases (the fixture also creates it). No
-// network is actually persisted on success of the assertion — we
-// expect each create to fail.
+// exists for the macvlan cases (the fixture also creates it). On
+// expected-failure rows no network is persisted; on regression we
+// clean up so the next test run starts fresh.
 func TestErrors_NetworkCreateValidation(t *testing.T) {
 	for _, tc := range errorCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -70,19 +85,6 @@ func TestErrors_NetworkCreateValidation(t *testing.T) {
 			}
 			defer cli.Close()
 
-			opts := map[string]string{"mode": tc.mode}
-			// Only inject the harness parent if the case didn't set
-			// the parent option (or absence of it) explicitly. The
-			// MacvlanMissingParent case wants no parent at all.
-			if tc.mode == "macvlan" || tc.mode == "ipvlan" {
-				if _, ok := tc.opts["parent"]; ok || tc.opts == nil {
-					opts["parent"] = harness.HostVeth
-				}
-			}
-			for k, v := range tc.opts {
-				opts[k] = v
-			}
-
 			ipam := tc.ipam
 			if ipam == nil {
 				ipam = &network.IPAM{Driver: "null"}
@@ -92,10 +94,8 @@ func TestErrors_NetworkCreateValidation(t *testing.T) {
 			res, err := cli.NetworkCreate(ctx, netName, network.CreateOptions{
 				Driver:  harness.DriverName,
 				IPAM:    ipam,
-				Options: opts,
+				Options: tc.opts,
 			})
-			// Belt + braces: if a regression somehow lets the create
-			// succeed, clean it up so the next test run starts fresh.
 			if err == nil {
 				_ = cli.NetworkRemove(context.Background(), res.ID)
 				t.Fatalf("expected NetworkCreate to fail with %q substring, got success", tc.wantSubstr)

--- a/test/integration/errors_test.go
+++ b/test/integration/errors_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	"github.com/docker/docker/api/types/network"
+	docker "github.com/docker/docker/client"
+)
+
+// errorCases drive TestErrors_NetworkCreateValidation. Each case
+// exercises a validation branch in pkg/plugin/network.go (via the
+// libnetwork remote-driver protocol) — the plugin should refuse the
+// network up-front, before any DHCP traffic is ever attempted. The
+// `wantSubstr` is a fragment of the error string the plugin emits;
+// it travels through dockerd, so we match loosely on substring to
+// stay tolerant of dockerd's wrapping.
+var errorCases = []struct {
+	name       string
+	mode       string
+	opts       map[string]string
+	ipam       *network.IPAM // nil → null IPAM (the supported case)
+	wantSubstr string
+}{
+	{
+		name:       "InvalidMode",
+		mode:       "moonbridge",
+		wantSubstr: "invalid mode",
+	},
+	{
+		name:       "MacvlanMissingParent",
+		mode:       "macvlan",
+		opts:       map[string]string{}, // explicitly clear parent
+		wantSubstr: "parent required",
+	},
+	{
+		name:       "BridgeWithParent",
+		mode:       "bridge",
+		opts:       map[string]string{"parent": "lo"},
+		wantSubstr: "does not apply to selected mode",
+	},
+	{
+		name:       "IPAMNotNull",
+		mode:       "macvlan",
+		ipam:       &network.IPAM{Driver: "default"},
+		wantSubstr: "null IPAM driver",
+	},
+}
+
+// TestErrors_NetworkCreateValidation walks the validation matrix.
+// These cases never reach DHCP, so the only setup required is that
+// the plugin is enabled (TestMain enforces) and the host-side veth
+// exists for the macvlan cases (the fixture also creates it). No
+// network is actually persisted on success of the assertion — we
+// expect each create to fail.
+func TestErrors_NetworkCreateValidation(t *testing.T) {
+	for _, tc := range errorCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+			if err != nil {
+				t.Fatalf("docker client: %v", err)
+			}
+			defer cli.Close()
+
+			opts := map[string]string{"mode": tc.mode}
+			// Only inject the harness parent if the case didn't set
+			// the parent option (or absence of it) explicitly. The
+			// MacvlanMissingParent case wants no parent at all.
+			if tc.mode == "macvlan" || tc.mode == "ipvlan" {
+				if _, ok := tc.opts["parent"]; ok || tc.opts == nil {
+					opts["parent"] = harness.HostVeth
+				}
+			}
+			for k, v := range tc.opts {
+				opts[k] = v
+			}
+
+			ipam := tc.ipam
+			if ipam == nil {
+				ipam = &network.IPAM{Driver: "null"}
+			}
+
+			netName := "dh-itest-err-" + strings.ToLower(tc.name)
+			res, err := cli.NetworkCreate(ctx, netName, network.CreateOptions{
+				Driver:  harness.DriverName,
+				IPAM:    ipam,
+				Options: opts,
+			})
+			// Belt + braces: if a regression somehow lets the create
+			// succeed, clean it up so the next test run starts fresh.
+			if err == nil {
+				_ = cli.NetworkRemove(context.Background(), res.ID)
+				t.Fatalf("expected NetworkCreate to fail with %q substring, got success", tc.wantSubstr)
+			}
+			msg := err.Error()
+			if !strings.Contains(strings.ToLower(msg), strings.ToLower(tc.wantSubstr)) {
+				t.Errorf("error message missing expected substring %q\nactual: %s", tc.wantSubstr, msg)
+			} else {
+				t.Logf("✓ %s rejected: %s", tc.name, msg)
+			}
+		})
+	}
+}

--- a/test/integration/harness/bridge.go
+++ b/test/integration/harness/bridge.go
@@ -1,0 +1,197 @@
+//go:build integration
+
+package harness
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/vishvananda/netlink"
+)
+
+// Bridge-mode fixture state. The plugin's bridge mode is structurally
+// different from the parent-attached modes — it expects a Linux bridge
+// the user already created and assigns each container a per-endpoint
+// veth into that bridge. We therefore run a *second* dnsmasq on a
+// distinct subnet so the bridge-mode tests don't collide with the
+// macvlan/ipvlan path's pool.
+//
+// Why on a separate subnet? Two DHCP servers on the same broadcast
+// domain would race and the plugin's containers would bind whichever
+// answered first. Distinct L2 (this is a separate Linux bridge in the
+// host netns, no link to the macvlan veth pair) plus distinct L3
+// (192.168.100/24 vs 192.168.99/24) keeps them cleanly isolated.
+const (
+	// BridgeName is the Linux bridge the plugin's bridge-mode tests
+	// pass as `bridge=`. Chosen to fit IFNAMSIZ (15 chars + NUL).
+	BridgeName = "dh-itest-br2"
+	// BridgeAddr is the static IPv4 the harness puts on the bridge so
+	// dnsmasq has something to bind to.
+	BridgeAddr = "192.168.100.1/24"
+
+	// BridgeDHCPPoolStart / End / SubnetCIDR mirror the macvlan
+	// fixture's constants but on the bridge subnet.
+	BridgeDHCPPoolStart = "192.168.100.10"
+	BridgeDHCPPoolEnd   = "192.168.100.99"
+	BridgeSubnetCIDR    = "192.168.100.0/24"
+)
+
+// startBridge brings up the bridge fixture: a Linux bridge with a
+// static IP, iptables FORWARD ACCEPT rules so DHCP isn't dropped by
+// docker's default-deny FORWARD policy (br_netfilter routes bridged
+// traffic through iptables when loaded), and a second dnsmasq bound
+// to the bridge.
+//
+// The bridge is named distinctly from the veth pair to avoid any
+// confusion at teardown — both use the same dh-itest-* prefix the
+// orphan-cleanup script keys on, but distinct names so removal
+// order doesn't matter.
+func (f *Fixture) startBridge() error {
+	la := netlink.NewLinkAttrs()
+	la.Name = BridgeName
+	br := &netlink.Bridge{LinkAttrs: la}
+	if err := netlink.LinkAdd(br); err != nil {
+		return fmt.Errorf("LinkAdd bridge %s: %w", BridgeName, err)
+	}
+	link, err := netlink.LinkByName(BridgeName)
+	if err != nil {
+		return fmt.Errorf("LinkByName bridge: %w", err)
+	}
+
+	// Disable STP forward-delay: the kernel default is 15s, during
+	// which the bridge port is in LISTENING/LEARNING and won't pass
+	// DHCP. With a single bridge and no loop risk in the test setup
+	// it's safe to set forward_delay=0.
+	fdPath := filepath.Join("/sys/class/net", BridgeName, "bridge/forward_delay")
+	if err := os.WriteFile(fdPath, []byte("0"), 0o644); err != nil {
+		return fmt.Errorf("disable STP forward_delay: %w", err)
+	}
+
+	if err := netlink.LinkSetUp(link); err != nil {
+		return fmt.Errorf("LinkSetUp bridge: %w", err)
+	}
+
+	addr, err := netlink.ParseAddr(BridgeAddr)
+	if err != nil {
+		return fmt.Errorf("ParseAddr bridge: %w", err)
+	}
+	if err := netlink.AddrAdd(link, addr); err != nil {
+		return fmt.Errorf("AddrAdd bridge: %w", err)
+	}
+
+	// docker's default FORWARD policy is DROP. With br_netfilter
+	// loaded, even pure-bridge DHCP traffic (UDP 67/68 broadcast on
+	// the same bridge) is run through iptables FORWARD. Without these
+	// inserts the DHCPDISCOVER never reaches dnsmasq.
+	for _, args := range [][]string{
+		{"-I", "FORWARD", "-i", BridgeName, "-j", "ACCEPT"},
+		{"-I", "FORWARD", "-o", BridgeName, "-j", "ACCEPT"},
+	} {
+		if out, err := exec.Command("iptables", args...).CombinedOutput(); err != nil {
+			return fmt.Errorf("iptables %v: %w (%s)", args, err, out)
+		}
+	}
+	f.iptablesInstalled = true
+
+	// Per-run temp dir for the second dnsmasq's lease file + log.
+	tmp, err := os.MkdirTemp("", "dh-itest-br-")
+	if err != nil {
+		return fmt.Errorf("MkdirTemp bridge: %w", err)
+	}
+	f.bridgeLeaseFile = filepath.Join(tmp, "leases")
+	f.bridgeDnsmasqLog = filepath.Join(tmp, "dnsmasq.log")
+
+	logF, err := os.Create(f.bridgeDnsmasqLog)
+	if err != nil {
+		return fmt.Errorf("create bridge dnsmasq log: %w", err)
+	}
+	f.bridgeDnsmasq = exec.Command("/usr/sbin/dnsmasq",
+		"--no-daemon",
+		"--conf-file=/dev/null",
+		"--port=0",
+		"--interface="+BridgeName,
+		"--bind-interfaces",
+		"--except-interface=lo",
+		"--dhcp-range="+BridgeDHCPPoolStart+","+BridgeDHCPPoolEnd+","+LeaseTime,
+		"--dhcp-leasefile="+f.bridgeLeaseFile,
+		"--dhcp-no-override",
+		"--dhcp-broadcast",
+		"--log-dhcp",
+		"--log-facility=-",
+	)
+	f.bridgeDnsmasq.Stdout = logF
+	f.bridgeDnsmasq.Stderr = logF
+	f.bridgeDnsmasq.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := f.bridgeDnsmasq.Start(); err != nil {
+		return fmt.Errorf("start bridge dnsmasq: %w", err)
+	}
+	// Bind takes <50ms in practice but allow a beat for the listen
+	// socket to come up.
+	time.Sleep(200 * time.Millisecond)
+	return nil
+}
+
+// stopBridge tears down whatever startBridge brought up. Idempotent
+// and best-effort: each step swallows errors so a partial setup can
+// still be cleaned, and a leftover from a previous panic'd run is
+// removed too (the LinkByName/LinkDel pair handles that).
+func (f *Fixture) stopBridge() {
+	if f.bridgeDnsmasq != nil && f.bridgeDnsmasq.Process != nil {
+		_ = f.bridgeDnsmasq.Process.Signal(syscall.SIGTERM)
+		done := make(chan struct{})
+		go func() { _ = f.bridgeDnsmasq.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			_ = f.bridgeDnsmasq.Process.Kill()
+			<-done
+		}
+	}
+	if f.bridgeLeaseFile != "" {
+		_ = os.RemoveAll(filepath.Dir(f.bridgeLeaseFile))
+	}
+	if f.iptablesInstalled {
+		for _, args := range [][]string{
+			{"-D", "FORWARD", "-i", BridgeName, "-j", "ACCEPT"},
+			{"-D", "FORWARD", "-o", BridgeName, "-j", "ACCEPT"},
+		} {
+			_ = exec.Command("iptables", args...).Run()
+		}
+		f.iptablesInstalled = false
+	}
+	if link, err := netlink.LinkByName(BridgeName); err == nil {
+		_ = netlink.LinkDel(link)
+	}
+}
+
+// DumpBridgeLogs prints the bridge-fixture dnsmasq log. Symmetric
+// with DumpLogs for the macvlan side.
+func (f *Fixture) DumpBridgeLogs(write func(string)) {
+	if f.bridgeDnsmasqLog == "" {
+		write("(bridge fixture not started)")
+		return
+	}
+	data, err := os.ReadFile(f.bridgeDnsmasqLog)
+	if err != nil {
+		write(fmt.Sprintf("(could not read bridge dnsmasq log: %v)", err))
+		return
+	}
+	write("--- bridge dnsmasq log ---\n" + string(data))
+}
+
+// IsInBridgePool reports whether ip falls in the bridge fixture's
+// DHCP-handed range. Symmetric with IsInPool for the macvlan side.
+func IsInBridgePool(ip net.IP) bool {
+	v4 := ip.To4()
+	if v4 == nil {
+		return false
+	}
+	start := net.ParseIP(BridgeDHCPPoolStart).To4()
+	end := net.ParseIP(BridgeDHCPPoolEnd).To4()
+	return bytesGE(v4, start) && bytesLE(v4, end)
+}

--- a/test/integration/harness/container.go
+++ b/test/integration/harness/container.go
@@ -1,0 +1,181 @@
+//go:build integration
+
+package harness
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/network"
+	docker "github.com/docker/docker/client"
+)
+
+const (
+	// TestImage is what `docker run` pulls if absent. alpine:3.20 is
+	// pinned so a registry blip doesn't suddenly change runtime
+	// behaviour mid-test-run; busybox-shipping `ip` is what we need.
+	TestImage = "alpine:3.20"
+	// IPAcquisitionBudget caps how long Run waits for a container to
+	// have a non-empty IP after start. The plugin's CreateEndpoint
+	// returns synchronously after udhcpc gets a lease, so the docker
+	// inspect should reflect the IP within milliseconds; the budget
+	// is generous to absorb real-world dnsmasq RTTs and image pulls.
+	IPAcquisitionBudget = 15 * time.Second
+)
+
+// EnsureImage pulls TestImage if not already present locally. Run from
+// TestMain to amortize the pull across the whole suite.
+func EnsureImage(ctx context.Context) error {
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		return fmt.Errorf("docker client: %w", err)
+	}
+	defer cli.Close()
+	// Try inspect first; pull only on miss.
+	if _, err := cli.ImageInspect(ctx, TestImage); err == nil {
+		return nil
+	}
+	rc, err := cli.ImagePull(ctx, TestImage, image.PullOptions{})
+	if err != nil {
+		return fmt.Errorf("ImagePull: %w", err)
+	}
+	defer rc.Close()
+	// Drain the stream so the pull completes synchronously.
+	buf := make([]byte, 4096)
+	for {
+		_, err := rc.Read(buf)
+		if err != nil {
+			break
+		}
+	}
+	return nil
+}
+
+// RunContainer starts a long-lived alpine container attached to the
+// given plugin-driven network and returns its container ID once the
+// IP is available. Registers a t.Cleanup to stop+remove the container.
+//
+// The container runs `sleep infinity`, so tests can exec into it for
+// connectivity checks. cmd is appended to the args if you want a
+// different entrypoint shape.
+func RunContainer(t *testing.T, ctx context.Context, networkName, containerName string) (id, ipv4, mac string) {
+	t.Helper()
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	t.Cleanup(func() { _ = cli.Close() })
+
+	create, err := cli.ContainerCreate(ctx,
+		&container.Config{
+			Image: TestImage,
+			Cmd:   []string{"sleep", "infinity"},
+			// Hostname surfaces in the tombstone for restart-stability tests.
+			Hostname: containerName,
+		},
+		&container.HostConfig{
+			AutoRemove: false, // we remove explicitly in cleanup
+		},
+		&network.NetworkingConfig{
+			EndpointsConfig: map[string]*network.EndpointSettings{
+				networkName: {},
+			},
+		},
+		nil,
+		containerName,
+	)
+	if err != nil {
+		t.Fatalf("ContainerCreate(%s): %v", containerName, err)
+	}
+	id = create.ID
+	t.Cleanup(func() {
+		// Best-effort kill+remove; logs the error but doesn't fail the test.
+		bg := context.Background()
+		_ = cli.ContainerStop(bg, id, container.StopOptions{})
+		if err := cli.ContainerRemove(bg, id, container.RemoveOptions{Force: true}); err != nil && !isNotFound(err) {
+			t.Logf("WARN: ContainerRemove(%s): %v", id, err)
+		}
+	})
+
+	if err := cli.ContainerStart(ctx, id, container.StartOptions{}); err != nil {
+		t.Fatalf("ContainerStart(%s): %v", id, err)
+	}
+
+	// Poll docker inspect until the network endpoint reports an IP.
+	deadline := time.Now().Add(IPAcquisitionBudget)
+	for time.Now().Before(deadline) {
+		ins, err := cli.ContainerInspect(ctx, id)
+		if err != nil {
+			t.Fatalf("ContainerInspect(%s): %v", id, err)
+		}
+		for _, ep := range ins.NetworkSettings.Networks {
+			if ep.IPAddress != "" {
+				return id, ep.IPAddress, ep.MacAddress
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("container %s did not get an IP within %v", containerName, IPAcquisitionBudget)
+	return // unreachable
+}
+
+// ExecOutput runs `docker exec` with the given args and returns
+// combined stdout+stderr as a string. Use for quick assertions like
+// `ip -4 addr show eth0` from inside a test container.
+func ExecOutput(t *testing.T, ctx context.Context, containerID string, cmd ...string) string {
+	t.Helper()
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	exec, err := cli.ContainerExecCreate(ctx, containerID, container.ExecOptions{
+		Cmd:          cmd,
+		AttachStdout: true,
+		AttachStderr: true,
+	})
+	if err != nil {
+		t.Fatalf("ExecCreate: %v", err)
+	}
+	att, err := cli.ContainerExecAttach(ctx, exec.ID, container.ExecStartOptions{})
+	if err != nil {
+		t.Fatalf("ExecAttach: %v", err)
+	}
+	defer att.Close()
+	buf := make([]byte, 8192)
+	var out strings.Builder
+	for {
+		n, err := att.Reader.Read(buf)
+		if n > 0 {
+			out.Write(buf[:n])
+		}
+		if err != nil {
+			break
+		}
+	}
+	return out.String()
+}
+
+// AssertIP fails the test if got is not a valid IPv4 in the DHCP pool.
+// Common helper to keep the assertion phrasing consistent.
+func AssertIP(t *testing.T, got string) net.IP {
+	t.Helper()
+	ip := net.ParseIP(got)
+	if ip == nil {
+		t.Fatalf("not a valid IP: %q", got)
+	}
+	if ip.To4() == nil {
+		t.Fatalf("not an IPv4: %q", got)
+	}
+	if !IsInPool(ip) {
+		t.Fatalf("IP %q outside DHCP pool [%s, %s]", got, DHCPPoolStart, DHCPPoolEnd)
+	}
+	return ip
+}

--- a/test/integration/harness/container.go
+++ b/test/integration/harness/container.go
@@ -163,8 +163,9 @@ func ExecOutput(t *testing.T, ctx context.Context, containerID string, cmd ...st
 	return out.String()
 }
 
-// AssertIP fails the test if got is not a valid IPv4 in the DHCP pool.
-// Common helper to keep the assertion phrasing consistent.
+// AssertIP fails the test if got is not a valid IPv4 in the macvlan
+// fixture's DHCP pool. Common helper to keep the assertion phrasing
+// consistent.
 func AssertIP(t *testing.T, got string) net.IP {
 	t.Helper()
 	ip := net.ParseIP(got)
@@ -176,6 +177,22 @@ func AssertIP(t *testing.T, got string) net.IP {
 	}
 	if !IsInPool(ip) {
 		t.Fatalf("IP %q outside DHCP pool [%s, %s]", got, DHCPPoolStart, DHCPPoolEnd)
+	}
+	return ip
+}
+
+// AssertBridgeIP is the bridge-fixture analogue of AssertIP.
+func AssertBridgeIP(t *testing.T, got string) net.IP {
+	t.Helper()
+	ip := net.ParseIP(got)
+	if ip == nil {
+		t.Fatalf("not a valid IP: %q", got)
+	}
+	if ip.To4() == nil {
+		t.Fatalf("not an IPv4: %q", got)
+	}
+	if !IsInBridgePool(ip) {
+		t.Fatalf("IP %q outside bridge DHCP pool [%s, %s]", got, BridgeDHCPPoolStart, BridgeDHCPPoolEnd)
 	}
 	return ip
 }

--- a/test/integration/harness/fixture.go
+++ b/test/integration/harness/fixture.go
@@ -1,0 +1,256 @@
+//go:build integration
+
+// Package harness sets up the privileged fixture (veth pair, DHCP
+// server) shared by every integration test. Per the v0.7.0 design
+// (5c hybrid isolation), tests share the bridge + DHCP server but
+// own their own plugin network and container — so the fixture lives
+// for the whole `go test` invocation, set up in TestMain.
+package harness
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	// HostVeth is the veth end the plugin attaches its macvlan/ipvlan
+	// child to (i.e. driver-opt parent=DH_ITEST_PARENT).
+	HostVeth = "dh-itest-host"
+	// DhcpVeth is the other end of the pair; dnsmasq listens here.
+	DhcpVeth = "dh-itest-dhcp"
+
+	// DHCPServerAddr is the static IP we put on DhcpVeth. Inside the
+	// pool dnsmasq advertises, .1 is reserved for the server.
+	DHCPServerAddr = "192.168.99.1/24"
+	// DHCPPoolStart / DHCPPoolEnd / LeaseTime drive dnsmasq's
+	// --dhcp-range. The 30s lease is short enough to exercise renewal
+	// in test wall-time without flaking on dnsmasq response delays.
+	DHCPPoolStart = "192.168.99.10"
+	DHCPPoolEnd   = "192.168.99.99"
+	LeaseTime     = "30s"
+
+	// SubnetCIDR is what callers expect IP assertions to fall inside.
+	SubnetCIDR = "192.168.99.0/24"
+)
+
+// Fixture owns the lifecycle of the shared integration-test environment.
+// Use New() in TestMain; defer f.Teardown(). Re-running on a host with
+// leftover state from a panicked previous run is safe — Teardown is
+// idempotent and Setup tears down before creating.
+type Fixture struct {
+	dnsmasq    *exec.Cmd
+	leaseFile  string
+	dnsmasqLog string
+}
+
+// New creates the veth pair, brings both ends up, addresses the DHCP
+// end, and starts dnsmasq. Returns an error if any step fails; on
+// failure, partial state is cleaned up before returning.
+func New() (*Fixture, error) {
+	if os.Geteuid() != 0 {
+		return nil, fmt.Errorf("integration tests must run as root (got uid=%d). Use 'sudo make integration-test' or run the runner as root", os.Geteuid())
+	}
+
+	// Idempotent: kill any stragglers from a previous panic'd run.
+	cleanupNetlink()
+
+	// Veth pair. We make HostVeth the "parent NIC" the plugin will
+	// attach macvlan/ipvlan children to; DhcpVeth carries dnsmasq.
+	la := netlink.NewLinkAttrs()
+	la.Name = HostVeth
+	veth := &netlink.Veth{LinkAttrs: la, PeerName: DhcpVeth}
+	if err := netlink.LinkAdd(veth); err != nil {
+		return nil, fmt.Errorf("LinkAdd veth: %w", err)
+	}
+
+	hostLink, err := netlink.LinkByName(HostVeth)
+	if err != nil {
+		return nil, wrapTeardown(fmt.Errorf("LinkByName host: %w", err))
+	}
+	dhcpLink, err := netlink.LinkByName(DhcpVeth)
+	if err != nil {
+		return nil, wrapTeardown(fmt.Errorf("LinkByName dhcp: %w", err))
+	}
+	if err := netlink.LinkSetUp(hostLink); err != nil {
+		return nil, wrapTeardown(fmt.Errorf("LinkSetUp host: %w", err))
+	}
+	if err := netlink.LinkSetUp(dhcpLink); err != nil {
+		return nil, wrapTeardown(fmt.Errorf("LinkSetUp dhcp: %w", err))
+	}
+
+	addr, err := netlink.ParseAddr(DHCPServerAddr)
+	if err != nil {
+		return nil, wrapTeardown(fmt.Errorf("ParseAddr: %w", err))
+	}
+	if err := netlink.AddrAdd(dhcpLink, addr); err != nil {
+		return nil, wrapTeardown(fmt.Errorf("AddrAdd dhcp: %w", err))
+	}
+
+	// dnsmasq lease file + per-run log file in /tmp so the harness
+	// can read leases programmatically and dump logs on test failure.
+	tmp, err := os.MkdirTemp("", "dh-itest-")
+	if err != nil {
+		return nil, wrapTeardown(fmt.Errorf("MkdirTemp: %w", err))
+	}
+	f := &Fixture{
+		leaseFile:  filepath.Join(tmp, "leases"),
+		dnsmasqLog: filepath.Join(tmp, "dnsmasq.log"),
+	}
+
+	if err := f.startDnsmasq(); err != nil {
+		_ = os.RemoveAll(tmp)
+		return nil, wrapTeardown(err)
+	}
+
+	// Wait for dnsmasq to bind. Without this, the first test races
+	// against process startup and the DHCP DISCOVER vanishes.
+	if err := waitDnsmasqReady(2 * time.Second); err != nil {
+		_ = f.Teardown()
+		return nil, err
+	}
+
+	return f, nil
+}
+
+func (f *Fixture) startDnsmasq() error {
+	logF, err := os.Create(f.dnsmasqLog)
+	if err != nil {
+		return fmt.Errorf("create dnsmasq log: %w", err)
+	}
+	// dnsmasq args: foreground, no DNS (port=0), DHCP only on DhcpVeth,
+	// short lease so renewals fire within a test, log every event so
+	// failed tests can dump the conversation.
+	f.dnsmasq = exec.Command("/usr/sbin/dnsmasq",
+		"--no-daemon",
+		"--conf-file=/dev/null",
+		"--port=0",                                            // disable DNS
+		"--interface="+DhcpVeth,                               // DHCP only on this interface
+		"--bind-interfaces",                                   // don't open sockets on others
+		"--except-interface=lo",                               // belt + braces
+		"--dhcp-range="+DHCPPoolStart+","+DHCPPoolEnd+","+LeaseTime,
+		"--dhcp-leasefile="+f.leaseFile,
+		"--dhcp-no-override", // keep the leasefile clean for parsing
+		"--log-dhcp",         // log every DHCP packet
+		"--log-facility=-",   // logs to stderr
+	)
+	f.dnsmasq.Stdout = logF
+	f.dnsmasq.Stderr = logF
+	// dnsmasq must outlive the parent's first SIGINT during a Ctrl-C
+	// in interactive `go test` — Go test runners forward SIGINT to
+	// child processes, but dnsmasq.Process.Kill in Teardown handles
+	// the explicit case. Setpgid avoids dnsmasq inheriting signals
+	// from the test runner's process group.
+	f.dnsmasq.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	return f.dnsmasq.Start()
+}
+
+func waitDnsmasqReady(budget time.Duration) error {
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		// Probe by checking the DHCP socket is bound. dnsmasq listens
+		// on the DhcpVeth interface for UDP/67. We just check whether
+		// SOMETHING is bound on :67 — there's no other DHCP server in
+		// the test fixture, so it's unambiguous.
+		conn, err := net.ListenUDP("udp4", &net.UDPAddr{Port: 67})
+		if err != nil {
+			// Bind failure means dnsmasq has it. Good.
+			return nil
+		}
+		_ = conn.Close()
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("dnsmasq did not bind UDP/67 within %v", budget)
+}
+
+// Teardown stops dnsmasq, removes the veth pair, and cleans up the
+// per-run temp directory. Idempotent. Always check the returned
+// error in tests via t.Cleanup.
+func (f *Fixture) Teardown() error {
+	var firstErr error
+	if f.dnsmasq != nil && f.dnsmasq.Process != nil {
+		// SIGTERM, give it 2s, then SIGKILL.
+		_ = f.dnsmasq.Process.Signal(syscall.SIGTERM)
+		done := make(chan struct{})
+		go func() { _ = f.dnsmasq.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			_ = f.dnsmasq.Process.Kill()
+			<-done
+		}
+	}
+	if f.leaseFile != "" {
+		_ = os.RemoveAll(filepath.Dir(f.leaseFile))
+	}
+	cleanupNetlink()
+	return firstErr
+}
+
+// cleanupNetlink removes any HostVeth (and thus the paired DhcpVeth)
+// left over from a previous run. Best-effort.
+func cleanupNetlink() {
+	if link, err := netlink.LinkByName(HostVeth); err == nil {
+		_ = netlink.LinkDel(link)
+	}
+	// Belt + braces: if HostVeth is gone but DhcpVeth somehow survived
+	// (kernel oddity), remove it too.
+	if link, err := netlink.LinkByName(DhcpVeth); err == nil {
+		_ = netlink.LinkDel(link)
+	}
+}
+
+// wrapTeardown ensures partial setup state is cleaned up if New
+// fails midway, so the next test run starts fresh.
+func wrapTeardown(err error) error {
+	cleanupNetlink()
+	return err
+}
+
+// LeaseFile returns the path to dnsmasq's lease file for tests that
+// want to assert on lease state directly. Format documented in
+// dnsmasq(8): "expiration_epoch MAC IP hostname client-id".
+func (f *Fixture) LeaseFile() string { return f.leaseFile }
+
+// DumpLogs prints captured dnsmasq stderr to the testing.T log on
+// failure. Tests should call this from a t.Cleanup with a check for
+// t.Failed().
+func (f *Fixture) DumpLogs(write func(string)) {
+	data, err := os.ReadFile(f.dnsmasqLog)
+	if err != nil {
+		write(fmt.Sprintf("(could not read dnsmasq log: %v)", err))
+		return
+	}
+	write("--- dnsmasq log ---\n" + string(data))
+}
+
+// Subnet returns the /24 CIDR of the DHCP-managed subnet, parsed.
+// Tests use this to assert "container IP falls in pool".
+func Subnet() *net.IPNet {
+	_, ipnet, _ := net.ParseCIDR(SubnetCIDR)
+	return ipnet
+}
+
+// IsInPool returns whether ip is in the DHCP-handed range
+// [DHCPPoolStart, DHCPPoolEnd]. Stricter than just "in subnet" — a
+// container that grabbed the .1 server address would be in subnet
+// but not in pool, and that's a bug worth flagging.
+func IsInPool(ip net.IP) bool {
+	v4 := ip.To4()
+	if v4 == nil {
+		return false
+	}
+	start := net.ParseIP(DHCPPoolStart).To4()
+	end := net.ParseIP(DHCPPoolEnd).To4()
+	return bytesGE(v4, start) && bytesLE(v4, end)
+}
+
+func bytesGE(a, b net.IP) bool { return strings.Compare(string(a), string(b)) >= 0 }
+func bytesLE(a, b net.IP) bool { return strings.Compare(string(a), string(b)) <= 0 }

--- a/test/integration/harness/fixture.go
+++ b/test/integration/harness/fixture.go
@@ -2,9 +2,15 @@
 
 // Package harness sets up the privileged fixture (veth pair, DHCP
 // server) shared by every integration test. Per the v0.7.0 design
-// (5c hybrid isolation), tests share the bridge + DHCP server but
-// own their own plugin network and container — so the fixture lives
-// for the whole `go test` invocation, set up in TestMain.
+// (5c hybrid isolation), tests share the fixture but own their own
+// plugin network and container — so the fixture lives for the whole
+// `go test` invocation, set up in TestMain.
+//
+// Current scope: macvlan + ipvlan (parent-attached) modes. Bridge
+// mode needs a separate fixture (Linux bridge + dnsmasq listening on
+// the bridge interface, on a distinct subnet to avoid host routing
+// conflicts) and is tracked as a follow-up — see test/integration/
+// README.md.
 package harness
 
 import (
@@ -21,18 +27,17 @@ import (
 )
 
 const (
-	// HostVeth is the veth end the plugin attaches its macvlan/ipvlan
-	// child to (i.e. driver-opt parent=DH_ITEST_PARENT).
+	// HostVeth is the veth end the plugin attaches macvlan/ipvlan
+	// children to (driver-opt parent=HostVeth).
 	HostVeth = "dh-itest-host"
 	// DhcpVeth is the other end of the pair; dnsmasq listens here.
 	DhcpVeth = "dh-itest-dhcp"
 
-	// DHCPServerAddr is the static IP we put on DhcpVeth. Inside the
-	// pool dnsmasq advertises, .1 is reserved for the server.
+	// DHCPServerAddr is the static IP on DhcpVeth.
 	DHCPServerAddr = "192.168.99.1/24"
 	// DHCPPoolStart / DHCPPoolEnd / LeaseTime drive dnsmasq's
-	// --dhcp-range. The 30s lease is short enough to exercise renewal
-	// in test wall-time without flaking on dnsmasq response delays.
+	// --dhcp-range. 30s lease is short enough to exercise renewal
+	// in test wall-time without flaking on response delays.
 	DHCPPoolStart = "192.168.99.10"
 	DHCPPoolEnd   = "192.168.99.99"
 	LeaseTime     = "30s"
@@ -62,8 +67,6 @@ func New() (*Fixture, error) {
 	// Idempotent: kill any stragglers from a previous panic'd run.
 	cleanupNetlink()
 
-	// Veth pair. We make HostVeth the "parent NIC" the plugin will
-	// attach macvlan/ipvlan children to; DhcpVeth carries dnsmasq.
 	la := netlink.NewLinkAttrs()
 	la.Name = HostVeth
 	veth := &netlink.Veth{LinkAttrs: la, PeerName: DhcpVeth}
@@ -94,8 +97,7 @@ func New() (*Fixture, error) {
 		return nil, wrapTeardown(fmt.Errorf("AddrAdd dhcp: %w", err))
 	}
 
-	// dnsmasq lease file + per-run log file in /tmp so the harness
-	// can read leases programmatically and dump logs on test failure.
+	// Per-run temp dir for dnsmasq lease file + log.
 	tmp, err := os.MkdirTemp("", "dh-itest-")
 	if err != nil {
 		return nil, wrapTeardown(fmt.Errorf("MkdirTemp: %w", err))
@@ -110,8 +112,6 @@ func New() (*Fixture, error) {
 		return nil, wrapTeardown(err)
 	}
 
-	// Wait for dnsmasq to bind. Without this, the first test races
-	// against process startup and the DHCP DISCOVER vanishes.
 	if err := waitDnsmasqReady(2 * time.Second); err != nil {
 		_ = f.Teardown()
 		return nil, err
@@ -125,9 +125,6 @@ func (f *Fixture) startDnsmasq() error {
 	if err != nil {
 		return fmt.Errorf("create dnsmasq log: %w", err)
 	}
-	// dnsmasq args: foreground, no DNS (port=0), DHCP only on DhcpVeth,
-	// short lease so renewals fire within a test, log every event so
-	// failed tests can dump the conversation.
 	f.dnsmasq = exec.Command("/usr/sbin/dnsmasq",
 		"--no-daemon",
 		"--conf-file=/dev/null",
@@ -137,17 +134,20 @@ func (f *Fixture) startDnsmasq() error {
 		"--except-interface=lo", // belt + braces
 		"--dhcp-range="+DHCPPoolStart+","+DHCPPoolEnd+","+LeaseTime,
 		"--dhcp-leasefile="+f.leaseFile,
-		"--dhcp-no-override", // keep the leasefile clean for parsing
-		"--log-dhcp",         // log every DHCP packet
-		"--log-facility=-",   // logs to stderr
+		"--dhcp-no-override",
+		// dhcp-broadcast forces OFFER/ACK to be sent as L2 broadcast
+		// regardless of the client's broadcast flag. Required for
+		// ipvlan-L2 mode: the slave's IP isn't registered with the
+		// parent's ipvlan until the lease is configured (chicken &
+		// egg), so unicast OFFERs addressed to parent MAC can't be
+		// routed to the slave during initial DHCP. Real LAN DHCP
+		// servers typically broadcast anyway; this matches that.
+		"--dhcp-broadcast",
+		"--log-dhcp",
+		"--log-facility=-",
 	)
 	f.dnsmasq.Stdout = logF
 	f.dnsmasq.Stderr = logF
-	// dnsmasq must outlive the parent's first SIGINT during a Ctrl-C
-	// in interactive `go test` — Go test runners forward SIGINT to
-	// child processes, but dnsmasq.Process.Kill in Teardown handles
-	// the explicit case. Setpgid avoids dnsmasq inheriting signals
-	// from the test runner's process group.
 	f.dnsmasq.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	return f.dnsmasq.Start()
 }
@@ -155,13 +155,8 @@ func (f *Fixture) startDnsmasq() error {
 func waitDnsmasqReady(budget time.Duration) error {
 	deadline := time.Now().Add(budget)
 	for time.Now().Before(deadline) {
-		// Probe by checking the DHCP socket is bound. dnsmasq listens
-		// on the DhcpVeth interface for UDP/67. We just check whether
-		// SOMETHING is bound on :67 — there's no other DHCP server in
-		// the test fixture, so it's unambiguous.
 		conn, err := net.ListenUDP("udp4", &net.UDPAddr{Port: 67})
 		if err != nil {
-			// Bind failure means dnsmasq has it. Good.
 			return nil
 		}
 		_ = conn.Close()
@@ -171,12 +166,10 @@ func waitDnsmasqReady(budget time.Duration) error {
 }
 
 // Teardown stops dnsmasq, removes the veth pair, and cleans up the
-// per-run temp directory. Idempotent. Always check the returned
-// error in tests via t.Cleanup.
+// per-run temp directory. Idempotent.
 func (f *Fixture) Teardown() error {
 	var firstErr error
 	if f.dnsmasq != nil && f.dnsmasq.Process != nil {
-		// SIGTERM, give it 2s, then SIGKILL.
 		_ = f.dnsmasq.Process.Signal(syscall.SIGTERM)
 		done := make(chan struct{})
 		go func() { _ = f.dnsmasq.Wait(); close(done) }()
@@ -194,16 +187,13 @@ func (f *Fixture) Teardown() error {
 	return firstErr
 }
 
-// cleanupNetlink removes any HostVeth (and thus the paired DhcpVeth)
-// left over from a previous run. Best-effort.
+// cleanupNetlink removes any leftover fixture interfaces from a
+// previous run. Best-effort.
 func cleanupNetlink() {
-	if link, err := netlink.LinkByName(HostVeth); err == nil {
-		_ = netlink.LinkDel(link)
-	}
-	// Belt + braces: if HostVeth is gone but DhcpVeth somehow survived
-	// (kernel oddity), remove it too.
-	if link, err := netlink.LinkByName(DhcpVeth); err == nil {
-		_ = netlink.LinkDel(link)
+	for _, name := range []string{HostVeth, DhcpVeth} {
+		if link, err := netlink.LinkByName(name); err == nil {
+			_ = netlink.LinkDel(link)
+		}
 	}
 }
 
@@ -219,9 +209,9 @@ func wrapTeardown(err error) error {
 // dnsmasq(8): "expiration_epoch MAC IP hostname client-id".
 func (f *Fixture) LeaseFile() string { return f.leaseFile }
 
-// DumpLogs prints captured dnsmasq stderr to the testing.T log on
-// failure. Tests should call this from a t.Cleanup with a check for
-// t.Failed().
+// DumpLogs prints captured dnsmasq stderr to a writer (usually
+// t.Log) so failed tests have the wire-level conversation. Tests
+// should call this from a t.Cleanup with a check for t.Failed().
 func (f *Fixture) DumpLogs(write func(string)) {
 	data, err := os.ReadFile(f.dnsmasqLog)
 	if err != nil {
@@ -232,7 +222,6 @@ func (f *Fixture) DumpLogs(write func(string)) {
 }
 
 // Subnet returns the /24 CIDR of the DHCP-managed subnet, parsed.
-// Tests use this to assert "container IP falls in pool".
 func Subnet() *net.IPNet {
 	_, ipnet, _ := net.ParseCIDR(SubnetCIDR)
 	return ipnet

--- a/test/integration/harness/fixture.go
+++ b/test/integration/harness/fixture.go
@@ -50,10 +50,21 @@ const (
 // Use New() in TestMain; defer f.Teardown(). Re-running on a host with
 // leftover state from a panicked previous run is safe — Teardown is
 // idempotent and Setup tears down before creating.
+//
+// The bridge-mode fields (BridgeName, second dnsmasq, iptables rules)
+// are set up alongside the macvlan veth pair so a single fixture
+// covers every mode the suite exercises. Tests that don't touch
+// bridge mode pay only the small one-time setup cost.
 type Fixture struct {
 	dnsmasq    *exec.Cmd
 	leaseFile  string
 	dnsmasqLog string
+
+	// Bridge-mode fixture state (see bridge.go).
+	bridgeDnsmasq     *exec.Cmd
+	bridgeLeaseFile   string
+	bridgeDnsmasqLog  string
+	iptablesInstalled bool
 }
 
 // New creates the veth pair, brings both ends up, addresses the DHCP
@@ -117,6 +128,17 @@ func New() (*Fixture, error) {
 		return nil, err
 	}
 
+	// Bridge fixture comes after the veth/dnsmasq is healthy so a
+	// failure here cleanly tears the partial state back down. We
+	// log-and-skip if the bridge fixture itself fails so the whole
+	// suite isn't lost when only bridge-mode tests need it — but in
+	// practice bridge setup should be just as reliable as the
+	// macvlan path.
+	if err := f.startBridge(); err != nil {
+		_ = f.Teardown()
+		return nil, fmt.Errorf("startBridge: %w", err)
+	}
+
 	return f, nil
 }
 
@@ -165,10 +187,13 @@ func waitDnsmasqReady(budget time.Duration) error {
 	return fmt.Errorf("dnsmasq did not bind UDP/67 within %v", budget)
 }
 
-// Teardown stops dnsmasq, removes the veth pair, and cleans up the
-// per-run temp directory. Idempotent.
+// Teardown stops both dnsmasq processes, removes the veth pair and
+// the bridge, drops the iptables FORWARD rules, and cleans up the
+// per-run temp directories. Idempotent — safe to call twice or after
+// a partial setup.
 func (f *Fixture) Teardown() error {
 	var firstErr error
+	f.stopBridge()
 	if f.dnsmasq != nil && f.dnsmasq.Process != nil {
 		_ = f.dnsmasq.Process.Signal(syscall.SIGTERM)
 		done := make(chan struct{})
@@ -190,7 +215,7 @@ func (f *Fixture) Teardown() error {
 // cleanupNetlink removes any leftover fixture interfaces from a
 // previous run. Best-effort.
 func cleanupNetlink() {
-	for _, name := range []string{HostVeth, DhcpVeth} {
+	for _, name := range []string{HostVeth, DhcpVeth, BridgeName} {
 		if link, err := netlink.LinkByName(name); err == nil {
 			_ = netlink.LinkDel(link)
 		}

--- a/test/integration/harness/fixture.go
+++ b/test/integration/harness/fixture.go
@@ -131,10 +131,10 @@ func (f *Fixture) startDnsmasq() error {
 	f.dnsmasq = exec.Command("/usr/sbin/dnsmasq",
 		"--no-daemon",
 		"--conf-file=/dev/null",
-		"--port=0",                                            // disable DNS
-		"--interface="+DhcpVeth,                               // DHCP only on this interface
-		"--bind-interfaces",                                   // don't open sockets on others
-		"--except-interface=lo",                               // belt + braces
+		"--port=0",              // disable DNS
+		"--interface="+DhcpVeth, // DHCP only on this interface
+		"--bind-interfaces",     // don't open sockets on others
+		"--except-interface=lo", // belt + braces
 		"--dhcp-range="+DHCPPoolStart+","+DHCPPoolEnd+","+LeaseTime,
 		"--dhcp-leasefile="+f.leaseFile,
 		"--dhcp-no-override", // keep the leasefile clean for parsing

--- a/test/integration/harness/health.go
+++ b/test/integration/harness/health.go
@@ -1,0 +1,98 @@
+//go:build integration
+
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"path/filepath"
+	"time"
+
+	docker "github.com/docker/docker/client"
+)
+
+// HealthResponse mirrors pkg/plugin.HealthResponse. Duplicated here
+// so the integration package doesn't pull on pkg/plugin internals.
+type HealthResponse struct {
+	Healthy                bool    `json:"healthy"`
+	UptimeSeconds          float64 `json:"uptime_seconds"`
+	ActiveEndpoints        int     `json:"active_endpoints"`
+	PendingHints           int     `json:"pending_hints"`
+	RecoveredOK            int32   `json:"recovered_ok"`
+	RecoveryFailed         int32   `json:"recovery_failed"`
+	TombstoneWriteFailures int32   `json:"tombstone_write_failures"`
+}
+
+// PluginSocketPath returns the absolute path to PluginRef's UNIX
+// socket. Docker exposes plugin sockets under
+// /run/docker/plugins/<plugin-id>/<sock-name>.sock; both fragments
+// come from PluginInspect. Requires root to dial the socket.
+func PluginSocketPath(ctx context.Context, cli *docker.Client) (string, error) {
+	p, _, err := cli.PluginInspectWithRaw(ctx, PluginRef)
+	if err != nil {
+		return "", fmt.Errorf("PluginInspect: %w", err)
+	}
+	if !p.Enabled {
+		return "", fmt.Errorf("plugin %q is not currently enabled — its socket is gone", PluginRef)
+	}
+	// The plugin manifest declares a single socket; net-dhcp.sock is
+	// the canonical name in this fork's config.json.
+	return filepath.Join("/run/docker/plugins", p.ID, "net-dhcp.sock"), nil
+}
+
+// PluginHealth dials the plugin's socket and returns its
+// /Plugin.Health payload.
+func PluginHealth(ctx context.Context, cli *docker.Client) (*HealthResponse, error) {
+	sock, err := PluginSocketPath(ctx, cli)
+	if err != nil {
+		return nil, err
+	}
+	hc := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", sock)
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://plugin/Plugin.Health", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("dial plugin socket %s: %w", sock, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Plugin.Health returned %s", resp.Status)
+	}
+	var out HealthResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode Plugin.Health: %w", err)
+	}
+	return &out, nil
+}
+
+// WaitPluginEnabled polls PluginInspect until p.Enabled matches want
+// or budget elapses. Use after PluginEnable / PluginDisable to know
+// when the daemon has reflected the state change.
+func WaitPluginEnabled(ctx context.Context, cli *docker.Client, want bool, budget time.Duration) error {
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		p, _, err := cli.PluginInspectWithRaw(ctx, PluginRef)
+		if err == nil && p.Enabled == want {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+	return fmt.Errorf("plugin did not reach enabled=%v within %v", want, budget)
+}

--- a/test/integration/harness/network.go
+++ b/test/integration/harness/network.go
@@ -31,8 +31,9 @@ func CreateNetwork(t *testing.T, ctx context.Context, name, mode string, extraOp
 	switch mode {
 	case "macvlan", "ipvlan":
 		opts["parent"] = HostVeth
+	case "bridge":
+		opts["bridge"] = BridgeName
 	}
-	// Bridge mode needs its own fixture — see test/integration/README.md.
 	for k, v := range extraOpts {
 		opts[k] = v
 	}

--- a/test/integration/harness/network.go
+++ b/test/integration/harness/network.go
@@ -37,8 +37,8 @@ func CreateNetwork(t *testing.T, ctx context.Context, name, mode string, extraOp
 	}
 
 	res, err := cli.NetworkCreate(ctx, name, network.CreateOptions{
-		Driver: DriverName,
-		IPAM:   &network.IPAM{Driver: "null"},
+		Driver:  DriverName,
+		IPAM:    &network.IPAM{Driver: "null"},
 		Options: opts,
 	})
 	if err != nil {

--- a/test/integration/harness/network.go
+++ b/test/integration/harness/network.go
@@ -1,0 +1,62 @@
+//go:build integration
+
+package harness
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types/network"
+	docker "github.com/docker/docker/client"
+)
+
+// CreateNetwork drives `docker network create` with the plugin and
+// the per-test options. Registers a t.Cleanup to delete it. Returns
+// the network ID.
+//
+// mode is "bridge", "macvlan", or "ipvlan". For bridge mode pass
+// bridge=<name>; for macvlan/ipvlan pass parent=<name>. The harness
+// expects HostVeth to be the parent for macvlan/ipvlan — keeps the
+// test surface simple.
+func CreateNetwork(t *testing.T, ctx context.Context, name, mode string, extraOpts map[string]string) string {
+	t.Helper()
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	t.Cleanup(func() { _ = cli.Close() })
+
+	opts := map[string]string{"mode": mode}
+	switch mode {
+	case "macvlan", "ipvlan":
+		opts["parent"] = HostVeth
+	}
+	for k, v := range extraOpts {
+		opts[k] = v
+	}
+
+	res, err := cli.NetworkCreate(ctx, name, network.CreateOptions{
+		Driver: DriverName,
+		IPAM:   &network.IPAM{Driver: "null"},
+		Options: opts,
+	})
+	if err != nil {
+		t.Fatalf("NetworkCreate(%s, mode=%s, opts=%v): %v", name, mode, opts, err)
+	}
+	t.Cleanup(func() {
+		// Use a fresh context so a parent ctx-cancel during a
+		// failure doesn't skip cleanup.
+		if err := cli.NetworkRemove(context.Background(), res.ID); err != nil && !isNotFound(err) {
+			t.Logf("WARN: NetworkRemove(%s): %v", res.ID, err)
+		}
+	})
+	return res.ID
+}
+
+func isNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "No such network")
+}

--- a/test/integration/harness/network.go
+++ b/test/integration/harness/network.go
@@ -32,6 +32,7 @@ func CreateNetwork(t *testing.T, ctx context.Context, name, mode string, extraOp
 	case "macvlan", "ipvlan":
 		opts["parent"] = HostVeth
 	}
+	// Bridge mode needs its own fixture — see test/integration/README.md.
 	for k, v := range extraOpts {
 		opts[k] = v
 	}

--- a/test/integration/harness/plugin.go
+++ b/test/integration/harness/plugin.go
@@ -5,6 +5,7 @@ package harness
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/docker/docker/api/types/filters"
@@ -16,7 +17,17 @@ import (
 // don't install/enable from within tests — that's a global daemon
 // mutation and conflicts with whatever the operator already has set
 // up. The runner's pre-test step handles install (or not).
-const PluginRef = "ghcr.io/claymore666/docker-net-dhcp:golang"
+//
+// The default ":golang" matches the production install. A run can
+// point the harness at a different tag (e.g. ":dev" for a code
+// change being verified before the ":golang" slot is bumped) by
+// setting INTEGRATION_PLUGIN_REF in the environment.
+var PluginRef = func() string {
+	if v := os.Getenv("INTEGRATION_PLUGIN_REF"); v != "" {
+		return v
+	}
+	return "ghcr.io/claymore666/docker-net-dhcp:golang"
+}()
 
 // VerifyPluginEnabled checks that PluginRef is installed and currently
 // enabled in the local Docker daemon. Use from TestMain so the suite
@@ -46,4 +57,4 @@ func VerifyPluginEnabled(ctx context.Context) error {
 
 // DriverName is the network driver name to pass to docker network
 // create — same as PluginRef. Aliased for readability.
-const DriverName = PluginRef
+var DriverName = PluginRef

--- a/test/integration/harness/plugin.go
+++ b/test/integration/harness/plugin.go
@@ -1,0 +1,49 @@
+//go:build integration
+
+package harness
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker/api/types/filters"
+	docker "github.com/docker/docker/client"
+)
+
+// PluginRef is the docker plugin reference the harness expects to be
+// installed and enabled before the test run starts. We deliberately
+// don't install/enable from within tests — that's a global daemon
+// mutation and conflicts with whatever the operator already has set
+// up. The runner's pre-test step handles install (or not).
+const PluginRef = "ghcr.io/claymore666/docker-net-dhcp:golang"
+
+// VerifyPluginEnabled checks that PluginRef is installed and currently
+// enabled in the local Docker daemon. Use from TestMain so the suite
+// fails fast with a clear message instead of every test failing
+// downstream when network create can't find the driver.
+func VerifyPluginEnabled(ctx context.Context) error {
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		return fmt.Errorf("docker client: %w", err)
+	}
+	defer cli.Close()
+	plugins, err := cli.PluginList(ctx, filters.NewArgs())
+	if err != nil {
+		return fmt.Errorf("PluginList: %w", err)
+	}
+	for _, p := range plugins {
+		if p.Name == PluginRef && p.Enabled {
+			return nil
+		}
+	}
+	available := []string{}
+	for _, p := range plugins {
+		available = append(available, fmt.Sprintf("%s(enabled=%v)", p.Name, p.Enabled))
+	}
+	return fmt.Errorf("plugin %q is not enabled. Available: %s. Install/enable it before running integration tests", PluginRef, strings.Join(available, ", "))
+}
+
+// DriverName is the network driver name to pass to docker network
+// create — same as PluginRef. Aliased for readability.
+const DriverName = PluginRef

--- a/test/integration/install-go-runner.sh
+++ b/test/integration/install-go-runner.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Install the Go toolchain for the integration-test runner.
+#
+# Run once, as root, on the self-hosted CI host. The integration
+# workflow then assumes /usr/local/go/bin is on PATH and skips
+# `actions/setup-go@v5` entirely, saving ~30s per run.
+#
+# Distro packages (Debian 13 ships only 1.24) lag the version
+# pinned in go.mod, so we fetch directly from go.dev. The binary
+# tarball is reproducible and the SHA256 is published alongside.
+#
+# Usage:
+#   sudo bash test/integration/install-go-runner.sh
+#
+# Re-run is safe: replaces /usr/local/go atomically.
+
+set -euo pipefail
+
+GO_VERSION="${GO_VERSION:-1.25.0}"
+ARCH="${ARCH:-linux-amd64}"
+TARBALL="go${GO_VERSION}.${ARCH}.tar.gz"
+URL="https://go.dev/dl/${TARBALL}"
+DEST="/usr/local"
+
+if [[ $EUID -ne 0 ]]; then
+    echo "Must run as root (writes to ${DEST}/go). Re-run with sudo." >&2
+    exit 1
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+echo "==> Downloading ${URL}"
+curl -fsSL -o "${tmp}/${TARBALL}" "${URL}"
+
+echo "==> Extracting to ${DEST}"
+# Atomic-ish swap: extract into ${DEST}/go.new, then mv.
+rm -rf "${DEST}/go.new"
+tar -C "${DEST}" -xzf "${tmp}/${TARBALL}"  # creates ${DEST}/go
+# tar -xzf overwrites in place; previous /usr/local/go is replaced.
+
+# /usr/local/bin/go symlink so PATH=/usr/local/bin (default) finds it
+# without needing to source /etc/profile.d additions.
+ln -sf "${DEST}/go/bin/go" /usr/local/bin/go
+ln -sf "${DEST}/go/bin/gofmt" /usr/local/bin/gofmt
+
+echo
+echo "==> Installed:"
+/usr/local/bin/go version
+echo
+echo "Done. The integration workflow will pick this up automatically."

--- a/test/integration/lifecycle_bridge_test.go
+++ b/test/integration/lifecycle_bridge_test.go
@@ -1,0 +1,57 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+)
+
+// TestLifecycleBridge_GoldenPath is the bridge-mode counterpart to
+// TestLifecycleMacvlan_GoldenPath. The plugin's bridge mode predates
+// the macvlan/ipvlan additions and goes through a structurally
+// different code path: per-endpoint veth pair, host side attached to
+// a user-provided Linux bridge, container side moved into the
+// container netns. udhcpc still runs in the container netns, but the
+// DHCP server it talks to here is the second dnsmasq the bridge
+// fixture starts on the bridge interface (192.168.100/24, distinct
+// from the macvlan path's 192.168.99/24 to avoid lease cross-talk).
+//
+// Exercises: CreateNetwork (mode=bridge branch with bridge-link
+// validation), createBridgeEndpoint, dhcpManager.Start over the
+// host-side veth, Join (move container-side veth into netns), Leave,
+// DeleteEndpoint (bridge cleanup branch), DeleteNetwork.
+func TestLifecycleBridge_GoldenPath(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-bridge-golden"
+	ctrName := "dh-itest-bridge-golden-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			fixture.DumpBridgeLogs(func(s string) { t.Log(s) })
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "bridge", nil)
+	id, ipv4, mac := harness.RunContainer(t, ctx, netName, ctrName)
+	t.Logf("container %s: id=%s ip=%s mac=%s", ctrName, id[:12], ipv4, mac)
+
+	ip := harness.AssertBridgeIP(t, ipv4)
+	t.Logf("✓ container IP %s falls in bridge DHCP pool", ip)
+
+	out := harness.ExecOutput(t, ctx, id, "ip", "-4", "addr", "show", "eth0")
+	if !strings.Contains(out, ipv4) {
+		t.Errorf("eth0 inside container does not show docker-inspect IP %q\nactual:\n%s", ipv4, out)
+	}
+	macOut := harness.ExecOutput(t, ctx, id, "ip", "link", "show", "eth0")
+	if !strings.Contains(strings.ToLower(macOut), strings.ToLower(mac)) {
+		t.Errorf("eth0 MAC inside container does not match docker inspect MAC %q\nactual:\n%s", mac, macOut)
+	}
+}

--- a/test/integration/lifecycle_bridge_test.go
+++ b/test/integration/lifecycle_bridge_test.go
@@ -46,12 +46,17 @@ func TestLifecycleBridge_GoldenPath(t *testing.T) {
 	ip := harness.AssertBridgeIP(t, ipv4)
 	t.Logf("✓ container IP %s falls in bridge DHCP pool", ip)
 
-	out := harness.ExecOutput(t, ctx, id, "ip", "-4", "addr", "show", "eth0")
+	// Bridge mode names the in-container interface after the bridge
+	// (DstPrefix=opts.Bridge in pkg/plugin/network.go), not "eth0",
+	// so we check `ip -4 addr` without naming the link. The IP being
+	// configured on *some* interface inside the container netns is
+	// the real invariant.
+	out := harness.ExecOutput(t, ctx, id, "ip", "-4", "addr")
 	if !strings.Contains(out, ipv4) {
-		t.Errorf("eth0 inside container does not show docker-inspect IP %q\nactual:\n%s", ipv4, out)
+		t.Errorf("no interface inside container reports docker-inspect IP %q\nactual:\n%s", ipv4, out)
 	}
-	macOut := harness.ExecOutput(t, ctx, id, "ip", "link", "show", "eth0")
+	macOut := harness.ExecOutput(t, ctx, id, "ip", "link")
 	if !strings.Contains(strings.ToLower(macOut), strings.ToLower(mac)) {
-		t.Errorf("eth0 MAC inside container does not match docker inspect MAC %q\nactual:\n%s", mac, macOut)
+		t.Errorf("no interface inside container reports docker-inspect MAC %q\nactual:\n%s", mac, macOut)
 	}
 }

--- a/test/integration/lifecycle_ipvlan_test.go
+++ b/test/integration/lifecycle_ipvlan_test.go
@@ -1,0 +1,60 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+)
+
+// TestLifecycleIPvlan_GoldenPath mirrors the macvlan golden path with
+// mode=ipvlan. ipvlan-L2 is the default in newChildLink and the only
+// mode that can carry DHCP (which needs L2 broadcast) — this test
+// guards that invariant; an accidental switch to L3 mode would fail
+// here with udhcpc never seeing an OFFER.
+//
+// **Currently skipped**: when the harness's DHCP server runs over a
+// veth-pair parent (our setup) the broadcast OFFER doesn't reach the
+// ipvlan slave inside the container netns. Real LAN DHCP servers
+// (Fritz.Box etc) over a hardware NIC parent work — that path is
+// covered by manual smoke testing. Investigating the veth-parent
+// delivery quirk is tracked as a follow-up; documented in
+// test/integration/README.md "ipvlan + veth" section.
+//
+// One observable mode-specific difference: ipvlan children inherit
+// the parent's MAC, so docker inspect shows the HostVeth MAC instead
+// of a random one. The test asserts the container's eth0 has the
+// same MAC the daemon reported.
+func TestLifecycleIPvlan_GoldenPath(t *testing.T) {
+	t.Skip("ipvlan-L2 broadcast OFFER delivery to a slave whose parent is a veth doesn't work in our harness; tracked as a follow-up. Real LAN DHCP via hardware parent is covered by manual smoke testing.")
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-ipvlan-golden"
+	ctrName := "dh-itest-ipvlan-golden-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "ipvlan", nil)
+	id, ipv4, mac := harness.RunContainer(t, ctx, netName, ctrName)
+	t.Logf("container %s: id=%s ip=%s mac=%s", ctrName, id[:12], ipv4, mac)
+
+	harness.AssertIP(t, ipv4)
+
+	out := harness.ExecOutput(t, ctx, id, "ip", "-4", "addr", "show", "eth0")
+	if !strings.Contains(out, ipv4) {
+		t.Errorf("eth0 inside container does not show docker-inspect IP %q\nactual:\n%s", ipv4, out)
+	}
+	macOut := harness.ExecOutput(t, ctx, id, "ip", "link", "show", "eth0")
+	if !strings.Contains(strings.ToLower(macOut), strings.ToLower(mac)) {
+		t.Errorf("eth0 MAC inside container does not match docker inspect MAC %q\nactual:\n%s", mac, macOut)
+	}
+}

--- a/test/integration/lifecycle_ipvlan_test.go
+++ b/test/integration/lifecycle_ipvlan_test.go
@@ -17,20 +17,19 @@ import (
 // guards that invariant; an accidental switch to L3 mode would fail
 // here with udhcpc never seeing an OFFER.
 //
-// **Currently skipped**: when the harness's DHCP server runs over a
-// veth-pair parent (our setup) the broadcast OFFER doesn't reach the
-// ipvlan slave inside the container netns. Real LAN DHCP servers
-// (Fritz.Box etc) over a hardware NIC parent work — that path is
-// covered by manual smoke testing. Investigating the veth-parent
-// delivery quirk is tracked as a follow-up; documented in
-// test/integration/README.md "ipvlan + veth" section.
-//
 // One observable mode-specific difference: ipvlan children inherit
 // the parent's MAC, so docker inspect shows the HostVeth MAC instead
 // of a random one. The test asserts the container's eth0 has the
 // same MAC the daemon reported.
+//
+// Earlier this test was `t.Skip`'d because the OFFER never reached
+// the slave through a veth parent. The fix landed in pkg/udhcpc:
+// setting the BROADCAST flag in DISCOVER (`udhcpc -B`) for ipvlan
+// mode forces the OFFER to be L2-broadcast at the wire level, which
+// the kernel then floods correctly to all slaves of the parent.
+// dnsmasq's `--dhcp-broadcast` in our fixture is now belt-and-braces
+// rather than the only thing keeping ipvlan honest.
 func TestLifecycleIPvlan_GoldenPath(t *testing.T) {
-	t.Skip("ipvlan-L2 broadcast OFFER delivery to a slave whose parent is a veth doesn't work in our harness; tracked as a follow-up. Real LAN DHCP via hardware parent is covered by manual smoke testing.")
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 

--- a/test/integration/lifecycle_macvlan_test.go
+++ b/test/integration/lifecycle_macvlan_test.go
@@ -1,0 +1,97 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+)
+
+var fixture *harness.Fixture
+
+// TestMain stands up the fixture (veth pair + dnsmasq) once per
+// `go test` invocation. Per the v0.7.0 design choice 5c (hybrid
+// isolation), tests share the fixture but own their own plugin
+// network and container.
+func TestMain(m *testing.M) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	if err := harness.VerifyPluginEnabled(ctx); err != nil {
+		fmt.Fprintln(os.Stderr, "PRE-CHECK:", err)
+		os.Exit(1)
+	}
+	if err := harness.EnsureImage(ctx); err != nil {
+		fmt.Fprintln(os.Stderr, "PRE-CHECK image pull:", err)
+		os.Exit(1)
+	}
+
+	f, err := harness.New()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "FIXTURE:", err)
+		os.Exit(1)
+	}
+	fixture = f
+
+	rc := m.Run()
+	if err := f.Teardown(); err != nil {
+		fmt.Fprintln(os.Stderr, "TEARDOWN:", err)
+	}
+	os.Exit(rc)
+}
+
+// TestLifecycleMacvlan_GoldenPath is the smoke test: create a
+// macvlan-mode network on HostVeth, run a container, assert it gets
+// an IP from the DHCP pool, exec a sanity command, then leave.
+//
+// This single test exercises CreateNetwork (mode=macvlan branch),
+// validateParentForChild, createParentAttachedEndpoint,
+// dhcpManager.Start (initial lease via udhcpc -q), Join (move link
+// into netns), Leave (Stop the manager → DHCPRELEASE), DeleteEndpoint
+// (parent-attached cleanup branch), and DeleteNetwork — covering
+// the macvlan path end-to-end.
+func TestLifecycleMacvlan_GoldenPath(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-macvlan-golden"
+	ctrName := "dh-itest-macvlan-golden-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+	id, ipv4, mac := harness.RunContainer(t, ctx, netName, ctrName)
+	t.Logf("container %s: id=%s ip=%s mac=%s", ctrName, id[:12], ipv4, mac)
+
+	ip := harness.AssertIP(t, ipv4)
+	t.Logf("✓ container IP %s falls in DHCP pool", ip)
+
+	// Sanity: the container's own view of its IP must match docker
+	// inspect (truthfulness invariant — see RELEASE_NOTES v0.6.0).
+	out := harness.ExecOutput(t, ctx, id, "ip", "-4", "addr", "show", "eth0")
+	if !strings.Contains(out, ipv4) {
+		t.Errorf("eth0 inside container does not show docker-inspect IP %q\nactual:\n%s", ipv4, out)
+	}
+
+	// MAC parity: the container's eth0 MAC must equal the docker
+	// inspect MAC. Not strictly required by the design, but a
+	// sudden divergence would mean somebody is lying.
+	if !strings.Contains(strings.ToLower(out), "") {
+		// (presence of `inet` line implies link came up; relying on
+		// the IP check above is enough)
+	}
+	macOut := harness.ExecOutput(t, ctx, id, "ip", "link", "show", "eth0")
+	if !strings.Contains(strings.ToLower(macOut), strings.ToLower(mac)) {
+		t.Errorf("eth0 MAC inside container does not match docker inspect MAC %q\nactual:\n%s", mac, macOut)
+	}
+}

--- a/test/integration/recovery_daemon_test.go
+++ b/test/integration/recovery_daemon_test.go
@@ -21,11 +21,18 @@ import (
 //
 //   - the daemon comes back up (no hang on plugin re-enable — the
 //     historical upstream failure mode this fork modernized away from)
-//   - the container is still running (RestartPolicy=always so containerd
-//     restarts it once dockerd is back)
-//   - recoverEndpoints rebuilt our endpoint's dhcpManager
-//     (Plugin.Health.recovered_ok ≥ 1)
+//   - the container is running again (RestartPolicy=always so docker
+//     brings it back once the daemon is up)
 //   - the IP and MAC are preserved across the restart
+//
+// Intentionally NOT asserted: Plugin.Health.recovered_ok ≥ 1.
+// Whether recovery or the tombstone path runs depends on whether
+// dockerd's graceful shutdown ran Leave on the container's endpoint
+// before going down. If it did, the post-restart container goes
+// through CreateEndpoint+tombstone (recovered_ok stays 0); if it
+// didn't, recoverEndpoints rebuilds the manager (recovered_ok > 0).
+// Both paths yield the same user-visible invariant — same IP and
+// MAC — so we test on that, not on which internal codepath fired.
 //
 // **Do not parallelize.** systemctl restart docker drops every docker
 // connection on the host, including those of any other test running
@@ -125,37 +132,34 @@ func TestRecovery_DaemonRestart_PreservesContainer(t *testing.T) {
 	}
 
 	// Plugin.Health socket is replaced when the plugin process is
-	// respawned by docker. Poll until the new socket answers AND
-	// recovery has run for at least one endpoint.
+	// respawned by docker. Poll until the new socket answers — that
+	// signals plugin enable + recovery have completed (recovery is
+	// synchronous inside NewPlugin before the socket starts
+	// listening, see pkg/plugin/plugin.go).
 	deadline := time.Now().Add(30 * time.Second)
 	var healthAfter *harness.HealthResponse
 	for time.Now().Before(deadline) {
 		h, err := harness.PluginHealth(ctx, cli2)
-		if err == nil && h.RecoveredOK >= 1 {
+		if err == nil {
 			healthAfter = h
 			break
 		}
 		time.Sleep(300 * time.Millisecond)
 	}
 	if healthAfter == nil {
-		t.Fatalf("Plugin.Health.recovered_ok did not reach 1 within 30s after daemon restart")
+		t.Fatalf("Plugin.Health socket did not answer within 30s after daemon restart")
 	}
-	t.Logf("after restart: recovered_ok=%d recovery_failed=%d", healthAfter.RecoveredOK, healthAfter.RecoveryFailed)
+	t.Logf("after restart: recovered_ok=%d recovery_failed=%d (either path is fine; see test header)",
+		healthAfter.RecoveredOK, healthAfter.RecoveryFailed)
 	if healthAfter.RecoveryFailed != 0 {
-		t.Errorf("recovery_failed=%d (recovery saw at least one endpoint it could not rebuild)", healthAfter.RecoveryFailed)
+		t.Errorf("recovery_failed=%d (recovery attempted but couldn't rebuild some endpoint)", healthAfter.RecoveryFailed)
 	}
 
-	ins, err := cli2.ContainerInspect(ctx, id)
-	if err != nil {
-		t.Fatalf("ContainerInspect after restart: %v", err)
-	}
-	var ipAfter, macAfter string
-	for _, ep := range ins.NetworkSettings.Networks {
-		if ep.IPAddress != "" {
-			ipAfter = ep.IPAddress
-			macAfter = ep.MacAddress
-		}
-	}
+	// In the tombstone-path case (graceful shutdown ran Leave) the
+	// container goes through a fresh CreateEndpoint+udhcpc on the
+	// way back up; the endpoint can briefly show no IP after
+	// State.Running flips. Poll on the endpoint, not just the state.
+	ipAfter, macAfter := waitForEndpoint(t, ctx, cli2, id, harness.IPAcquisitionBudget)
 	t.Logf("after restart:  ip=%s mac=%s", ipAfter, macAfter)
 	if ipAfter != ipBefore {
 		t.Errorf("IP changed across daemon restart: before=%s after=%s", ipBefore, ipAfter)

--- a/test/integration/recovery_daemon_test.go
+++ b/test/integration/recovery_daemon_test.go
@@ -1,0 +1,242 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	docker "github.com/docker/docker/client"
+)
+
+// TestRecovery_DaemonRestart_PreservesContainer is the integration
+// counterpart to Phase D step 9 of the manual smoke test: bounce the
+// whole docker daemon (systemctl restart docker) while a plugin-managed
+// container is attached, and verify that
+//
+//   - the daemon comes back up (no hang on plugin re-enable — the
+//     historical upstream failure mode this fork modernized away from)
+//   - the container is still running (RestartPolicy=always so containerd
+//     restarts it once dockerd is back)
+//   - recoverEndpoints rebuilt our endpoint's dhcpManager
+//     (Plugin.Health.recovered_ok ≥ 1)
+//   - the IP and MAC are preserved across the restart
+//
+// **Do not parallelize.** systemctl restart docker drops every docker
+// connection on the host, including those of any other test running
+// concurrently. Per the rule documented in test/integration/README.md
+// the suite is serial; this test relies on that.
+//
+// **Side effects on the runner host.** This test stops every container
+// on the runner briefly (whatever `--restart=always` they have decides
+// whether they come back). Anything else running on the same docker
+// daemon will see ~5–15s of unavailability. The runner is configured
+// for this; on a shared dev box, run with care.
+func TestRecovery_DaemonRestart_PreservesContainer(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-daemon-restart-net"
+	ctrName := "dh-itest-daemon-restart-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	t.Cleanup(func() { _ = cli.Close() })
+
+	// We can't use harness.RunContainer because it doesn't take a
+	// RestartPolicy. Inlining keeps the harness API stable.
+	create, err := cli.ContainerCreate(ctx,
+		&container.Config{
+			Image:    harness.TestImage,
+			Cmd:      []string{"sleep", "infinity"},
+			Hostname: ctrName,
+		},
+		&container.HostConfig{
+			RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyAlways},
+		},
+		&network.NetworkingConfig{
+			EndpointsConfig: map[string]*network.EndpointSettings{netName: {}},
+		},
+		nil,
+		ctrName,
+	)
+	if err != nil {
+		t.Fatalf("ContainerCreate: %v", err)
+	}
+	id := create.ID
+	t.Cleanup(func() {
+		bg, bgCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer bgCancel()
+		// Use a fresh client because the one captured above may have
+		// been Close()'d by the t.Cleanup chain ordering.
+		bgCli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+		if err == nil {
+			defer bgCli.Close()
+			// Override RestartPolicy so the cleanup container
+			// doesn't auto-restart between Stop and Remove.
+			_, _ = bgCli.ContainerUpdate(bg, id, container.UpdateConfig{
+				RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyDisabled},
+			})
+			_ = bgCli.ContainerStop(bg, id, container.StopOptions{})
+			_ = bgCli.ContainerRemove(bg, id, container.RemoveOptions{Force: true})
+		}
+	})
+	if err := cli.ContainerStart(ctx, id, container.StartOptions{}); err != nil {
+		t.Fatalf("ContainerStart: %v", err)
+	}
+
+	ipBefore, macBefore := waitForEndpoint(t, ctx, cli, id, harness.IPAcquisitionBudget)
+	t.Logf("before restart: ip=%s mac=%s", ipBefore, macBefore)
+
+	t.Log("systemctl restart docker — runner host's docker daemon is going down briefly")
+	out, err := exec.CommandContext(ctx, "systemctl", "restart", "docker").CombinedOutput()
+	if err != nil {
+		t.Fatalf("systemctl restart docker: %v\n%s", err, out)
+	}
+
+	// The pre-restart cli's TCP connection is dead. Build a new one.
+	_ = cli.Close()
+	cli2, err := waitDaemonReady(ctx, 60*time.Second)
+	if err != nil {
+		t.Fatalf("daemon did not return: %v", err)
+	}
+	defer cli2.Close()
+
+	// containerd-shim keeps the container running across the daemon
+	// restart, but ContainerInspect briefly returns 'restarting' as
+	// dockerd reattaches. Poll until State.Running.
+	if err := waitContainerRunning(ctx, cli2, id, 30*time.Second); err != nil {
+		t.Fatalf("container not running after daemon restart: %v", err)
+	}
+
+	// Plugin.Health socket is replaced when the plugin process is
+	// respawned by docker. Poll until the new socket answers AND
+	// recovery has run for at least one endpoint.
+	deadline := time.Now().Add(30 * time.Second)
+	var healthAfter *harness.HealthResponse
+	for time.Now().Before(deadline) {
+		h, err := harness.PluginHealth(ctx, cli2)
+		if err == nil && h.RecoveredOK >= 1 {
+			healthAfter = h
+			break
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	if healthAfter == nil {
+		t.Fatalf("Plugin.Health.recovered_ok did not reach 1 within 30s after daemon restart")
+	}
+	t.Logf("after restart: recovered_ok=%d recovery_failed=%d", healthAfter.RecoveredOK, healthAfter.RecoveryFailed)
+	if healthAfter.RecoveryFailed != 0 {
+		t.Errorf("recovery_failed=%d (recovery saw at least one endpoint it could not rebuild)", healthAfter.RecoveryFailed)
+	}
+
+	ins, err := cli2.ContainerInspect(ctx, id)
+	if err != nil {
+		t.Fatalf("ContainerInspect after restart: %v", err)
+	}
+	var ipAfter, macAfter string
+	for _, ep := range ins.NetworkSettings.Networks {
+		if ep.IPAddress != "" {
+			ipAfter = ep.IPAddress
+			macAfter = ep.MacAddress
+		}
+	}
+	t.Logf("after restart:  ip=%s mac=%s", ipAfter, macAfter)
+	if ipAfter != ipBefore {
+		t.Errorf("IP changed across daemon restart: before=%s after=%s", ipBefore, ipAfter)
+	}
+	if macAfter != macBefore {
+		t.Errorf("MAC changed across daemon restart: before=%s after=%s", macBefore, macAfter)
+	}
+}
+
+// waitForEndpoint mirrors RunContainer's polling loop but works on
+// an already-started container.
+func waitForEndpoint(t *testing.T, ctx context.Context, cli *docker.Client, id string, budget time.Duration) (ipv4, mac string) {
+	t.Helper()
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		ins, err := cli.ContainerInspect(ctx, id)
+		if err != nil {
+			t.Fatalf("ContainerInspect: %v", err)
+		}
+		for _, ep := range ins.NetworkSettings.Networks {
+			if ep.IPAddress != "" {
+				return ep.IPAddress, ep.MacAddress
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("container did not get an IP within %v", budget)
+	return
+}
+
+// waitDaemonReady polls Ping on a fresh client until the daemon
+// responds. The daemon takes ~5–15s to come up after systemctl
+// restart docker; the budget here is generous to absorb a slow
+// disk warmup or a plugin that takes time to enable.
+func waitDaemonReady(ctx context.Context, budget time.Duration) (*docker.Client, error) {
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+		if err == nil {
+			pingCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+			_, perr := cli.Ping(pingCtx)
+			cancel()
+			if perr == nil {
+				return cli, nil
+			}
+			_ = cli.Close()
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return nil, context.DeadlineExceeded
+}
+
+// waitContainerRunning polls ContainerInspect until State.Running
+// reports true. Used after daemon restart, where containerd-shim
+// has the container alive but dockerd is briefly seeing it in the
+// 'restarting' state as it reattaches.
+func waitContainerRunning(ctx context.Context, cli *docker.Client, id string, budget time.Duration) error {
+	deadline := time.Now().Add(budget)
+	var lastState string
+	for time.Now().Before(deadline) {
+		ins, err := cli.ContainerInspect(ctx, id)
+		if err == nil && ins.State != nil {
+			if ins.State.Running {
+				return nil
+			}
+			lastState = ins.State.Status
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(300 * time.Millisecond):
+		}
+	}
+	return &timeoutError{op: "container running", state: lastState}
+}
+
+type timeoutError struct{ op, state string }
+
+func (e *timeoutError) Error() string {
+	if e.state == "" {
+		return e.op + " timed out"
+	}
+	return e.op + " timed out (last state: " + e.state + ")"
+}

--- a/test/integration/recovery_test.go
+++ b/test/integration/recovery_test.go
@@ -1,0 +1,137 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	"github.com/docker/docker/api/types"
+	docker "github.com/docker/docker/client"
+)
+
+// TestRecovery_PluginDisableEnable_PreservesEndpoint exercises the
+// recoverEndpoints code path: forcibly recycle the plugin while a
+// container is attached, then verify (a) Plugin.Health.recovered_ok
+// advanced past zero, and (b) the container's IP and MAC are
+// identical to what they were before the recycle.
+//
+// **Do not parallelize.** This test mutates daemon-global state by
+// disabling/enabling the plugin. Other tests running concurrently
+// would lose plugin RPC service mid-flight.
+//
+// Cleanup is defensive: the t.Cleanup re-enables the plugin even if
+// any assertion failed mid-cycle, so a panic between disable and
+// enable can't leave the runner host with the plugin stuck off
+// (which would block every subsequent test and any smoke testing on
+// the same host).
+func TestRecovery_PluginDisableEnable_PreservesEndpoint(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-recovery-net"
+	ctrName := "dh-itest-recovery-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+	id, ipBefore, macBefore := harness.RunContainer(t, ctx, netName, ctrName)
+	t.Logf("before recycle: ip=%s mac=%s", ipBefore, macBefore)
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	t.Cleanup(func() { _ = cli.Close() })
+
+	// Belt-and-braces re-enable: registered immediately so any panic
+	// or t.Fatal between here and the explicit enable still leaves
+	// the plugin enabled. Idempotent — already-enabled is fine.
+	t.Cleanup(func() {
+		bg, bgCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer bgCancel()
+		if err := cli.PluginEnable(bg, harness.PluginRef, types.PluginEnableOptions{Timeout: 30}); err != nil {
+			if !strings.Contains(err.Error(), "already enabled") {
+				t.Logf("WARN: cleanup PluginEnable: %v", err)
+			}
+		}
+	})
+
+	// Capture the recovered_ok counter before the recycle so we can
+	// detect a delta rather than absolute >=1 (other tests might
+	// have triggered recoveries earlier in the suite).
+	healthBefore, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("Plugin.Health (before): %v", err)
+	}
+	t.Logf("recovered_ok before: %d", healthBefore.RecoveredOK)
+
+	if err := cli.PluginDisable(ctx, harness.PluginRef, types.PluginDisableOptions{Force: true}); err != nil {
+		t.Fatalf("PluginDisable: %v", err)
+	}
+	if err := harness.WaitPluginEnabled(ctx, cli, false, 15*time.Second); err != nil {
+		t.Fatalf("plugin did not reach disabled state: %v", err)
+	}
+	t.Log("plugin disabled")
+
+	if err := cli.PluginEnable(ctx, harness.PluginRef, types.PluginEnableOptions{Timeout: 30}); err != nil {
+		t.Fatalf("PluginEnable: %v", err)
+	}
+	if err := harness.WaitPluginEnabled(ctx, cli, true, 30*time.Second); err != nil {
+		t.Fatalf("plugin did not re-enable: %v", err)
+	}
+	t.Log("plugin re-enabled")
+
+	// Plugin process is up; recoverEndpoints runs synchronously
+	// inside NewPlugin so by the time the socket accepts requests
+	// recovery is already complete. Poll briefly for socket
+	// readiness — Plugin.Enabled flips slightly before the socket is
+	// listening.
+	var healthAfter *harness.HealthResponse
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		h, err := harness.PluginHealth(ctx, cli)
+		if err == nil {
+			healthAfter = h
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if healthAfter == nil {
+		t.Fatalf("Plugin.Health (after) never became reachable")
+	}
+	t.Logf("recovered_ok after: %d", healthAfter.RecoveredOK)
+
+	if healthAfter.RecoveredOK <= healthBefore.RecoveredOK {
+		t.Errorf("recovered_ok did not advance: before=%d after=%d (recovery did not run for our endpoint)",
+			healthBefore.RecoveredOK, healthAfter.RecoveredOK)
+	}
+	if healthAfter.RecoveryFailed != 0 {
+		t.Errorf("recovery_failed=%d (recovery saw at least one endpoint it could not rebuild)", healthAfter.RecoveryFailed)
+	}
+
+	ins, err := cli.ContainerInspect(ctx, id)
+	if err != nil {
+		t.Fatalf("ContainerInspect: %v", err)
+	}
+	var ipAfter, macAfter string
+	for _, ep := range ins.NetworkSettings.Networks {
+		if ep.IPAddress != "" {
+			ipAfter = ep.IPAddress
+			macAfter = ep.MacAddress
+		}
+	}
+	if ipAfter != ipBefore {
+		t.Errorf("IP changed across plugin recycle: before=%s after=%s", ipBefore, ipAfter)
+	}
+	if macAfter != macBefore {
+		t.Errorf("MAC changed across plugin recycle: before=%s after=%s", macBefore, macAfter)
+	}
+}

--- a/test/integration/recovery_test.go
+++ b/test/integration/recovery_test.go
@@ -64,14 +64,12 @@ func TestRecovery_PluginDisableEnable_PreservesEndpoint(t *testing.T) {
 		}
 	})
 
-	// Capture the recovered_ok counter before the recycle so we can
-	// detect a delta rather than absolute >=1 (other tests might
-	// have triggered recoveries earlier in the suite).
-	healthBefore, err := harness.PluginHealth(ctx, cli)
-	if err != nil {
-		t.Fatalf("Plugin.Health (before): %v", err)
-	}
-	t.Logf("recovered_ok before: %d", healthBefore.RecoveredOK)
+	// We don't read recovered_ok before the recycle: PluginDisable
+	// kills the plugin process and PluginEnable starts a fresh one,
+	// so the counter we see after is from a brand-new instance with
+	// initial value zero. The before-snapshot would be from a stale
+	// process and isn't comparable. Asserting `after >= 1` is the
+	// right invariant.
 
 	if err := cli.PluginDisable(ctx, harness.PluginRef, types.PluginDisableOptions{Force: true}); err != nil {
 		t.Fatalf("PluginDisable: %v", err)
@@ -109,9 +107,9 @@ func TestRecovery_PluginDisableEnable_PreservesEndpoint(t *testing.T) {
 	}
 	t.Logf("recovered_ok after: %d", healthAfter.RecoveredOK)
 
-	if healthAfter.RecoveredOK <= healthBefore.RecoveredOK {
-		t.Errorf("recovered_ok did not advance: before=%d after=%d (recovery did not run for our endpoint)",
-			healthBefore.RecoveredOK, healthAfter.RecoveredOK)
+	if healthAfter.RecoveredOK < 1 {
+		t.Errorf("recovered_ok=%d (expected >=1; recovery did not pick up our endpoint after the recycle)",
+			healthAfter.RecoveredOK)
 	}
 	if healthAfter.RecoveryFailed != 0 {
 		t.Errorf("recovery_failed=%d (recovery saw at least one endpoint it could not rebuild)", healthAfter.RecoveryFailed)

--- a/test/integration/tombstone_restart_test.go
+++ b/test/integration/tombstone_restart_test.go
@@ -1,0 +1,85 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	"github.com/docker/docker/api/types/container"
+	docker "github.com/docker/docker/client"
+)
+
+// TestTombstoneRestart_PreservesMACAndIP guards the v0.5.x stability
+// guarantee that `docker restart <ctr>` keeps the same MAC and IP.
+//
+// Mechanism: on Leave the plugin writes a tombstone with the MAC and
+// last-known IP, keyed by (network, endpoint). On the subsequent
+// CreateEndpoint Docker hands the same endpoint ID back, so the
+// plugin reuses the tombstoned MAC for the new macvlan child and
+// asks udhcpc to renew the same IP. tombstoneTTL was bumped to 60s
+// in v0.6.1 (see #55) so a slow `systemctl restart docker` doesn't
+// drop the entry — but `docker restart <ctr>` itself completes in
+// well under that window.
+func TestTombstoneRestart_PreservesMACAndIP(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-tombstone-net"
+	ctrName := "dh-itest-tombstone-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+	id, ipBefore, macBefore := harness.RunContainer(t, ctx, netName, ctrName)
+	t.Logf("before restart: ip=%s mac=%s", ipBefore, macBefore)
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	if err := cli.ContainerRestart(ctx, id, container.StopOptions{}); err != nil {
+		t.Fatalf("ContainerRestart: %v", err)
+	}
+
+	// Re-poll inspect for the post-restart endpoint values; the
+	// endpoint is torn down and re-created so the IP can briefly
+	// be empty mid-restart.
+	deadline := time.Now().Add(harness.IPAcquisitionBudget)
+	var ipAfter, macAfter string
+	for time.Now().Before(deadline) {
+		ins, err := cli.ContainerInspect(ctx, id)
+		if err != nil {
+			t.Fatalf("ContainerInspect: %v", err)
+		}
+		for _, ep := range ins.NetworkSettings.Networks {
+			if ep.IPAddress != "" {
+				ipAfter = ep.IPAddress
+				macAfter = ep.MacAddress
+			}
+		}
+		if ipAfter != "" {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if ipAfter == "" {
+		t.Fatalf("container did not re-acquire an IP within %v after restart", harness.IPAcquisitionBudget)
+	}
+	t.Logf("after restart:  ip=%s mac=%s", ipAfter, macAfter)
+
+	if macAfter != macBefore {
+		t.Errorf("MAC changed across restart: before=%s after=%s (tombstone not honored)", macBefore, macAfter)
+	}
+	if ipAfter != ipBefore {
+		t.Errorf("IP changed across restart: before=%s after=%s (DHCP did not renew the cached lease)", ipBefore, ipAfter)
+	}
+}


### PR DESCRIPTION
**Draft** — Phase 1 of the live integration test harness (umbrella: #56). Will keep the PR draft while iterating; flip to ready when the suite covers everything in scope.

## Phase 1 (this commit)

First end-to-end test passes locally: \`sudo make integration-test\` runs a full macvlan-mode lifecycle, container gets a real DHCP lease from a per-suite dnsmasq fixture, MAC + IP match docker inspect.

### Architecture
- **DHCP server**: dnsmasq via host package (\`apt install dnsmasq\`).
- **Parent NIC**: veth pair, one end as the plugin's macvlan parent, the other carrying the DHCP server.
- **Privileges**: runner runs as root (CI); locally \`sudo make integration-test\`.
- **Isolation**: hybrid — fixture shared per \`go test\` invocation, plugin network + container per test.
- **CI**: self-hosted gpu1 runner; outside-collaborator approval gate enabled in repo settings.

### What this exercises (now at non-zero coverage from integration)
\`CreateNetwork\` (macvlan branch) → \`validateParentForChild\` → \`createParentAttachedEndpoint\` → \`dhcpManager.Start\` → \`Join\` → \`Leave\` → \`DeleteEndpoint\` (parent-attached cleanup) → \`DeleteNetwork\`. Coverage numbers will move once Phase 2 wires up the \`-cover\`-instrumented plugin binary and GOCOVERDIR harvesting.

## Phase 2 (next commits on this branch)
- ipvlan + bridge mode parity tests
- Recovery test (plugin disable + enable; daemon restart)
- Tombstone MAC stability across \`docker restart <ctr>\`
- Concurrency (N containers attach/detach simultaneously)
- Error paths (invalid mode, parent down, IPAM not null, etc.)
- Coverage harvesting from the plugin process
- \`RELEASE_NOTES.md\` v0.7.0 entry

Closes #56 (when Phase 2 is done)