### PR TITLE
Docs sync: README + docs/parent-attached-modes for v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 > current Docker. This fork modernises the toolchain (Go 1.25, docker SDK
 > v28, current Alpine), adds **macvlan** and **ipvlan** attachment modes,
 > fixes the daemon-restart deadlock, fixes a data race on the plugin's
-> internal state, and incorporates several open upstream PRs.
+> internal state, and incorporates several open upstream PRs. As of v0.7.0
+> every PR is gated on a live integration suite that drives real DHCP
+> exchanges through all three modes plus recovery, tombstone-stability,
+> and concurrency scenarios.
 >
 > See [`RELEASE_NOTES.md`](RELEASE_NOTES.md) for the full changelog and
 > credits, and [`docs/parent-attached-modes.md`](docs/parent-attached-modes.md)
@@ -13,7 +16,7 @@
 >
 > Install:
 > ```bash
-> docker plugin install ghcr.io/claymore666/docker-net-dhcp:v0.5.3
+> docker plugin install ghcr.io/claymore666/docker-net-dhcp:v0.7.0
 > ```
 >
 > All upstream usage below still applies — bridge mode is unchanged and
@@ -38,17 +41,17 @@ handy for home deployment.
 The plugin can be installed with the `docker plugin install` command:
 
 ```
-$ docker plugin install ghcr.io/claymore666/docker-net-dhcp:v0.5.3
-Plugin "ghcr.io/claymore666/docker-net-dhcp:v0.5.3" is requesting the following privileges:
+$ docker plugin install ghcr.io/claymore666/docker-net-dhcp:v0.7.0
+Plugin "ghcr.io/claymore666/docker-net-dhcp:v0.7.0" is requesting the following privileges:
  - network: [host]
  - host pid namespace: [true]
  - mount: [/var/run/docker.sock]
- - capabilities: [CAP_NET_ADMIN CAP_SYS_ADMIN CAP_SYS_PTRACE]
+ - capabilities: [CAP_NET_ADMIN CAP_SYS_ADMIN]
 Do you grant the above permissions? [y/N] y
-v0.5.3: Pulling from ghcr.io/claymore666/docker-net-dhcp
+v0.7.0: Pulling from ghcr.io/claymore666/docker-net-dhcp
 Digest: sha256:<some hash>
 <some id>: Complete
-Installed plugin ghcr.io/claymore666/docker-net-dhcp:v0.5.3
+Installed plugin ghcr.io/claymore666/docker-net-dhcp:v0.7.0
 $
 ```
 
@@ -86,13 +89,13 @@ $ sudo dhcpcd my-bridge
 Once the bridge is ready, you can create the network:
 
 ```
-$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.5.3 --ipam-driver null -o bridge=my-bridge my-dhcp-net
+$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.7.0 --ipam-driver null -o bridge=my-bridge my-dhcp-net
 <some network id>
 $
 
 # With IPv6 enabled
 # Although `docker network create` has a `--ipv6` flag, it doesn't work with the null IPAM driver
-$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.5.3 --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
+$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.7.0 --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
 <some network id>
 $
 ```
@@ -153,7 +156,7 @@ services:
       - dhcp
 networks:
   dhcp:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v0.5.3
+    driver: ghcr.io/claymore666/docker-net-dhcp:v0.7.0
     driver_opts:
       bridge: my-bridge
       ipv6: 'true'
@@ -182,7 +185,7 @@ Note:
 ## Debugging
 
 To read the plugin's log, do `cat /var/lib/docker/plugins/*/rootfs/var/log/net-dhcp.log` (as `root`). You can also use
-`docker plugin set ghcr.io/claymore666/docker-net-dhcp:v0.5.3 LOG_LEVEL=trace` to increase log verbosity.
+`docker plugin set ghcr.io/claymore666/docker-net-dhcp:v0.7.0 LOG_LEVEL=trace` to increase log verbosity.
 
 # Implementation
 

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -332,5 +332,5 @@ endpoint operation everything is back to disk-served.
 Override the location via the `STATE_DIR` env var on the plugin:
 
 ```bash
-docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v0.3.0 STATE_DIR=/some/other/path
+docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v0.7.0 STATE_DIR=/some/other/path
 ```


### PR DESCRIPTION
Forwards the post-release doc cleanup from #65 onto main so the README the GitHub repo home renders matches the released version. No code changes, no release-tag implications.