### PR TITLE
Coverage harvesting for the integration suite (#63)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,15 @@ name: Coverage
 # this at all).
 on:
   workflow_dispatch:
+  # TEMPORARY: smoke-test this workflow before merge. GitHub's
+  # workflow_dispatch API only sees workflows on the default
+  # branch, so a manual trigger from a feature branch isn't
+  # possible until the file lands on main. Reverted before merge
+  # to dev — if you see this `push:` trigger on dev or main, it's
+  # a bug, not a feature.
+  push:
+    branches:
+      - feat/coverage-harvesting
 
 permissions:
   contents: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,15 +15,6 @@ name: Coverage
 # this at all).
 on:
   workflow_dispatch:
-  # TEMPORARY: smoke-test this workflow before merge. GitHub's
-  # workflow_dispatch API only sees workflows on the default
-  # branch, so a manual trigger from a feature branch isn't
-  # possible until the file lands on main. Reverted before merge
-  # to dev — if you see this `push:` trigger on dev or main, it's
-  # a bug, not a feature.
-  push:
-    branches:
-      - feat/coverage-harvesting
 
 permissions:
   contents: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,124 @@
+name: Coverage
+
+# Integration coverage harvesting. Builds a cover-instrumented plugin
+# (`go build -cover -coverpkg=./...`), runs the full integration suite
+# against it, then flushes counter files via `docker plugin disable`
+# and reports per-package coverage + uploads an HTML report.
+#
+# Manual-only (`workflow_dispatch`) — coverage runs cost ~3-5 min on top
+# of the integration suite (cover plugin build + flush + report) and
+# don't gate PR merges. The production gate is `integration.yml`.
+#
+# Same self-hosted runner as integration.yml (gpu1), same security
+# posture (outside-collaborator approval required for forked PRs —
+# though only `workflow_dispatch` is wired here, so forks can't trigger
+# this at all).
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    runs-on: [self-hosted, gpu1]
+    timeout-minutes: 20
+    env:
+      COVER_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:golang-cover
+      COVER_DIR: /var/lib/dh-cover
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify Go toolchain
+        run: |
+          if ! command -v go >/dev/null; then
+            echo "go not in PATH on this runner."
+            echo "Run: sudo bash test/integration/install-go-runner.sh"
+            exit 1
+          fi
+          go version
+
+      - name: Cleanup orphans from previous runs
+        run: bash test/integration/cleanup-orphans.sh
+
+      # Wipe any counter/meta files from a previous coverage run so
+      # `go tool covdata` only sees data from this invocation. The
+      # mkdir is idempotent — first ever run creates it, subsequent
+      # runs no-op.
+      - name: Prepare coverage dir
+        run: |
+          mkdir -p "${COVER_DIR}"
+          rm -f "${COVER_DIR}"/cov*
+
+      # Build the instrumented plugin from the current checkout. We
+      # rebuild every run rather than caching the image: cover builds
+      # are PR-specific (the instrumented binary changes whenever any
+      # tracked .go file does), so a cache here would be a footgun.
+      - name: Build + install cover plugin
+        run: |
+          make plugin-cover
+          docker plugin rm -f "${COVER_PLUGIN_REF}" 2>/dev/null || true
+          docker plugin create "${COVER_PLUGIN_REF}" plugin-cover
+          docker plugin set "${COVER_PLUGIN_REF}" LOG_LEVEL=trace
+          docker plugin enable "${COVER_PLUGIN_REF}"
+
+      # The harness routes everything through INTEGRATION_PLUGIN_REF
+      # (default :golang). Pointing it at :golang-cover makes the
+      # whole suite drive the instrumented plugin.
+      - name: Run integration tests against cover plugin
+        env:
+          INTEGRATION_PLUGIN_REF: ${{ env.COVER_PLUGIN_REF }}
+        run: make integration-test
+
+      # Flush counter files. Go's binary coverage runtime only writes
+      # `covcounters.*` on graceful exit, which `docker plugin disable`
+      # triggers (SIGTERM → plugin shuts down → runtime flushes).
+      # Always-run so even a failing test gets partial coverage.
+      - name: Flush coverage counters
+        if: always()
+        run: |
+          docker plugin disable "${COVER_PLUGIN_REF}" || true
+          ls -la "${COVER_DIR}"
+
+      - name: Coverage summary
+        if: always()
+        run: |
+          if ! ls "${COVER_DIR}"/covcounters.* >/dev/null 2>&1; then
+            echo "No coverage counter files found — plugin may have crashed before flush."
+            exit 1
+          fi
+          echo "## Coverage by package" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          go tool covdata percent -i="${COVER_DIR}" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Generate coverage reports
+        if: always()
+        run: |
+          if ! ls "${COVER_DIR}"/covcounters.* >/dev/null 2>&1; then
+            echo "Skipping report generation — no counter files."
+            exit 0
+          fi
+          go tool covdata textfmt -i="${COVER_DIR}" -o coverage.out
+          go tool cover -html=coverage.out -o coverage.html
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ github.run_id }}
+          path: |
+            coverage.out
+            coverage.html
+          if-no-files-found: warn
+          retention-days: 30
+
+      # Tear down the cover plugin so a follow-up integration.yml run
+      # on the same runner doesn't trip over a stale :golang-cover
+      # reference. The production :golang plugin is untouched.
+      - name: Tear down cover plugin
+        if: always()
+        run: |
+          docker plugin disable "${COVER_PLUGIN_REF}" 2>/dev/null || true
+          docker plugin rm -f "${COVER_PLUGIN_REF}" 2>/dev/null || true
+          rm -f "${COVER_DIR}"/cov*

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /bin/*
 !/bin/.gitkeep
 /plugin/
+/plugin-cover/
 /multiarch/
 
 .vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
 FROM golang:1.25-alpine AS builder
 
+# COVER_FLAGS is empty for the production build and `-cover -coverpkg=./...`
+# for the instrumented build used by the coverage workflow. Keeping the
+# instrumentation behind a build arg means the production image is byte-
+# identical to the unparameterized build — no risk of accidentally shipping
+# a cover-instrumented binary.
+ARG COVER_FLAGS=
+
 WORKDIR /usr/local/src/docker-net-dhcp
 COPY go.* ./
 RUN go mod download
 
 COPY cmd/ ./cmd/
 COPY pkg/ ./pkg/
-RUN mkdir bin/ && go build -o bin/ ./cmd/...
+RUN mkdir bin/ && go build $COVER_FLAGS -o bin/ ./cmd/...
 
 
 FROM alpine:3.20.3@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@ PLATFORMS ?= linux/amd64,linux/arm64
 SOURCES = $(shell find pkg/ cmd/ -name '*.go')
 BINARY = bin/net-dhcp
 
-.PHONY: all debug build create enable disable pdebug push clean integration-test integration-cleanup
+PLUGIN_COVER_TAG ?= golang-cover
+
+.PHONY: all debug build create enable disable pdebug push clean integration-test integration-cleanup \
+        build-cover plugin-cover create-cover enable-cover disable-cover
 
 all: create enable
 
@@ -43,6 +46,38 @@ pdebug: create enable
 push: create
 	docker plugin push $(PLUGIN_NAME):$(PLUGIN_TAG)
 
+# Coverage-instrumented build path. Produces a parallel plugin tagged
+# :golang-cover with `go build -cover` instrumentation. On graceful
+# shutdown the runtime flushes counter files into /coverage inside the
+# plugin namespace, which is bind-mounted from the host's /var/lib/dh-cover
+# (must exist and be writable; create it once with `mkdir -p
+# /var/lib/dh-cover` before the first `make create-cover`).
+#
+# This path is for the integration coverage workflow only — production
+# installs continue to use `make create enable` / the unparameterized
+# image. The two tags coexist on the same host without conflicting.
+build-cover: $(SOURCES)
+	docker build --build-arg COVER_FLAGS="-cover -coverpkg=./..." -t $(PLUGIN_NAME):rootfs-cover .
+
+plugin-cover/rootfs: build-cover
+	mkdir -p plugin-cover/rootfs
+	docker create --name tmp-cover $(PLUGIN_NAME):rootfs-cover
+	docker export tmp-cover | tar xC plugin-cover/rootfs
+	docker rm -vf tmp-cover
+
+plugin-cover: plugin-cover/rootfs config-cover.json
+	cp config-cover.json $@/config.json
+
+create-cover: plugin-cover
+	docker plugin rm -f $(PLUGIN_NAME):$(PLUGIN_COVER_TAG) || true
+	docker plugin create $(PLUGIN_NAME):$(PLUGIN_COVER_TAG) $<
+	docker plugin set $(PLUGIN_NAME):$(PLUGIN_COVER_TAG) LOG_LEVEL=trace
+
+enable-cover:
+	docker plugin enable $(PLUGIN_NAME):$(PLUGIN_COVER_TAG)
+disable-cover:
+	docker plugin disable $(PLUGIN_NAME):$(PLUGIN_COVER_TAG)
+
 multiarch: $(SOURCES)
 	docker buildx build --platform=$(PLATFORMS) -o type=local,dest=$@ .
 
@@ -52,6 +87,7 @@ push-multiarch: multiarch config.json
 clean:
 	-rm -rf multiarch/
 	-rm -rf plugin/
+	-rm -rf plugin-cover/
 	-rm bin/*
 
 # Live integration tests. Need privileges (CAP_NET_ADMIN, mount/netns

--- a/config-cover.json
+++ b/config-cover.json
@@ -1,0 +1,74 @@
+{
+    "description": "Docker DHCP networking (host-bridge or macvlan attachment) — coverage-instrumented build",
+    "interface": {
+        "socket": "net-dhcp.sock",
+        "types": [
+            "docker.networkdriver/1.0"
+        ]
+    },
+    "entrypoint": ["/usr/sbin/net-dhcp", "-logfile", "/var/log/net-dhcp.log"],
+    "env": [
+        {
+            "description": "Log level",
+            "name": "LOG_LEVEL",
+            "value": "info",
+            "settable": [
+                "value"
+            ]
+        },
+        {
+            "description": "Timeout while awaiting container/sandbox readiness",
+            "name": "AWAIT_TIMEOUT",
+            "value": "10s",
+            "settable": [
+                "value"
+            ]
+        },
+        {
+            "description": "Directory where per-network options are persisted",
+            "name": "STATE_DIR",
+            "value": "/var/lib/net-dhcp",
+            "settable": [
+                "value"
+            ]
+        },
+        {
+            "description": "Directory where Go binary coverage counters are written on shutdown (cover build only)",
+            "name": "GOCOVERDIR",
+            "value": "/coverage",
+            "settable": [
+                "value"
+            ]
+        }
+    ],
+    "workdir": "/",
+    "network": {
+        "type": "host"
+    },
+    "pidhost": true,
+    "mounts": [
+        {
+            "source": "/var/run/docker.sock",
+            "destination": "/run/docker.sock",
+            "type": "bind",
+            "options": [
+                "bind"
+            ]
+        },
+        {
+            "source": "/var/lib/dh-cover",
+            "destination": "/coverage",
+            "type": "bind",
+            "options": [
+                "bind",
+                "rw"
+            ]
+        }
+    ],
+    "linux": {
+        "capabilities": [
+            "CAP_NET_ADMIN",
+            "CAP_SYS_ADMIN"
+        ]
+    }
+}

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -40,11 +40,13 @@ for the umbrella scope. Tests so far:
 - `lifecycle_bridge_test.go` — same, in bridge mode (uses the
   bridge fixture: separate Linux bridge + second dnsmasq on
   192.168.100/24).
-- `lifecycle_ipvlan_test.go` — same, in ipvlan-L2 mode. Currently
-  `t.Skip`'d because broadcast OFFER delivery to the slave doesn't
-  work when the parent is a veth (real LAN parents work — covered
-  by manual smoke testing). Tracked as
-  [#62](https://github.com/claymore666/docker-net-dhcp/issues/62).
+- `lifecycle_ipvlan_test.go` — same, in ipvlan-L2 mode. Active as
+  of v0.7.0 — earlier it was `t.Skip`'d on a veth-parent harness
+  bug (broadcast OFFER didn't reach the slave); resolved in
+  [#62](https://github.com/claymore666/docker-net-dhcp/issues/62)
+  by setting the BROADCAST flag in the udhcpc DISCOVER (`-B`) and
+  skipping the MAC-echo at Join time on ipvlan (the kernel rejects
+  MAC changes on slaves with `EOPNOTSUPP`).
 - `tombstone_restart_test.go` — `docker restart <ctr>` preserves
   MAC + IP via the tombstone mechanism.
 - `concurrency_test.go` — N containers attached simultaneously each
@@ -82,7 +84,9 @@ test.
 The same suite runs on a self-hosted runner for every PR, with the
 **outside-collaborator approval gate** turned on so external PRs
 don't get free root on the runner host. See
-`.github/workflows/integration.yml`.
+`.github/workflows/integration.yml`. A separate manual-only
+`.github/workflows/coverage.yml` runs the same suite against a
+cover-instrumented plugin — see "Coverage harvesting" below.
 
 The workflow assumes the Go toolchain is pre-installed on the
 runner — `actions/setup-go@v5` is skipped to save ~30s/run. If
@@ -140,12 +144,28 @@ answered first.
    leftover `dh-itest-*` interfaces, networks, and the `dnsmasq`
    process if it's still running.
 
-## ipvlan + veth
+## Coverage harvesting
 
-`TestLifecycleIPvlan_GoldenPath` is currently skipped because the
-DHCP `OFFER` (broadcast — see `--dhcp-broadcast` in the fixture)
-doesn't reach the ipvlan slave inside the container netns when the
-parent is a veth. Real hardware NIC parents work fine — that path
-is covered by manual LAN smoke testing. The harness limitation is
-tracked as #62; un-skipping the test once #62 is resolved is the
-acceptance criterion.
+A second workflow, `.github/workflows/coverage.yml`, runs the same
+suite against a `go build -cover -coverpkg=./...` instrumented
+plugin (tag `:golang-cover`) and reports per-package coverage plus
+an HTML report as a workflow artifact. Manual-only
+(`workflow_dispatch`) — coverage runs aren't a PR gate.
+
+Locally:
+
+```sh
+sudo mkdir -p /var/lib/dh-cover && sudo chmod 0777 /var/lib/dh-cover
+make plugin-cover create-cover enable-cover
+sudo INTEGRATION_PLUGIN_REF=ghcr.io/claymore666/docker-net-dhcp:golang-cover make integration-test
+make disable-cover    # flushes counter files
+go tool covdata percent -i=/var/lib/dh-cover
+go tool covdata textfmt -i=/var/lib/dh-cover -o coverage.out
+go tool cover -html=coverage.out -o coverage.html
+```
+
+The plugin runtime emits `covmeta.*` on startup and `covcounters.*`
+on graceful shutdown, so the `disable-cover` step is what actually
+flushes the counters. The cover plugin is a parallel install — it
+coexists with the production `:golang` tag; `make plugin-cover`
+uses an isolated `plugin-cover/` rootfs dir.


### PR DESCRIPTION
## Summary

Adds a parallel cover-instrumented plugin build (`go build -cover -coverpkg=./...`, tag `:golang-cover`) and a manual-only `.github/workflows/coverage.yml` that runs the integration suite against it, flushes counters on plugin disable, and uploads per-package coverage + an HTML report as an artifact.

Production builds are byte-identical to before — `Dockerfile` gains an `ARG COVER_FLAGS=` that's empty by default, so `make plugin` / `make create` are unchanged.

## What changed

- `Dockerfile` — `ARG COVER_FLAGS=` parameterizes the `go build` line.
- `config-cover.json` — adds `GOCOVERDIR=/coverage` env + writable bind mount `/var/lib/dh-cover → /coverage`.
- `Makefile` — `build-cover` / `plugin-cover` / `create-cover` / `enable-cover` / `disable-cover` targets backed by isolated `plugin-cover/` rootfs; production targets untouched.
- `.gitignore` — excludes `/plugin-cover/`.
- `.github/workflows/coverage.yml` — new workflow_dispatch-only job. Same self-hosted runner as integration.yml. Builds the cover plugin from source per run (cover builds are PR-specific, caching the image would be a footgun), runs the full suite with `INTEGRATION_PLUGIN_REF=:golang-cover`, disables the plugin to flush counters, then runs `go tool covdata percent` to the job summary and uploads `coverage.out` + `coverage.html`. Always-run cleanup tears the cover plugin down so a follow-up `integration.yml` run on the same runner doesn't trip on stale state.
- `test/integration/README.md` — adds a "Coverage harvesting" section with the local one-liner workflow; corrects the stale ipvlan-skipped note (test is active as of v0.7.0, #62 closed).

## Local verification

Phase 2 was run end-to-end on the maintainer host before opening this PR:

- Cover plugin builds with the `-cover` flags (binary emits `warning: GOCOVERDIR not set...` when run with no env, confirming instrumentation).
- `docker plugin create/enable :golang-cover` succeeds; inspect shows `GOCOVERDIR=/coverage` env and the bind mount wired.
- Plugin emits `covmeta.<hash>` immediately on enable (Go runtime writes metadata at startup).
- One `docker network create` + `network rm` exercises CreateNetwork.
- `docker plugin disable` flushes a `covcounters.<hash>.<pid>.<ns>` file.
- `go tool covdata percent` reports cmd/net-dhcp 82%, pkg/plugin 9.9%, pkg/util 17%, pkg/udhcpc 0% (DHCP not exercised by the smoke-only flow — expected).
- `go tool covdata textfmt` produces an 840-line gocover profile, `go tool cover -html` renders it.

The workflow itself will be smoke-tested via `workflow_dispatch` against this branch before merge.

Closes #63.

## Test plan

- [ ] `gh workflow run coverage.yml --ref feat/coverage-harvesting` — verify the new workflow renders, builds the cover plugin, runs the integration suite against it, flushes counters, and uploads the artifact.
- [ ] Open the resulting `coverage-<run_id>.zip` artifact and check `coverage.html` shows real per-line coverage data.
- [ ] On the runner: confirm `:golang-cover` is removed after the workflow finishes (cleanup step) so `integration.yml` reruns aren't affected.
- [ ] `integration.yml` continues to pass on this PR (regression check on the production build path).