### PR TITLE
Three integration tests pushing coverage 68.8% → 69.5% (#63)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,12 +15,6 @@ name: Coverage
 # this at all).
 on:
   workflow_dispatch:
-  # TEMPORARY: smoke-test the new tests on this branch. Reverted
-  # before merge to dev. If you see this `push:` trigger anywhere
-  # but on a feature branch, it's a bug.
-  push:
-    branches:
-      - feat/integration-coverage-tests
 
 permissions:
   contents: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,12 @@ name: Coverage
 # this at all).
 on:
   workflow_dispatch:
+  # TEMPORARY: smoke-test the new tests on this branch. Reverted
+  # before merge to dev. If you see this `push:` trigger anywhere
+  # but on a feature branch, it's a bug.
+  push:
+    branches:
+      - feat/integration-coverage-tests
 
 permissions:
   contents: read

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ integration-test:
 		echo "integration-test must run as root. Re-run with sudo."; \
 		exit 1; \
 	fi
-	go test -v -tags integration -count=1 -timeout 5m ./test/integration/...
+	go test -v -tags integration -count=1 -timeout 10m ./test/integration/...
 
 # Manual orphan cleanup for when an integration test panics mid-setup
 # and leaves dh-itest-* interfaces / containers / networks behind.

--- a/test/integration/harness/fixture.go
+++ b/test/integration/harness/fixture.go
@@ -234,6 +234,12 @@ func wrapTeardown(err error) error {
 // dnsmasq(8): "expiration_epoch MAC IP hostname client-id".
 func (f *Fixture) LeaseFile() string { return f.leaseFile }
 
+// DnsmasqLog returns the path of the macvlan-fixture dnsmasq log
+// file. Tests that need to assert on the wire conversation (e.g.
+// "did a renewal DHCPACK arrive?") can grep this file directly
+// during the test rather than waiting for the failure-path dump.
+func (f *Fixture) DnsmasqLog() string { return f.dnsmasqLog }
+
 // DumpLogs prints captured dnsmasq stderr to a writer (usually
 // t.Log) so failed tests have the wire-level conversation. Tests
 // should call this from a t.Cleanup with a check for t.Failed().

--- a/test/integration/harness/fixture.go
+++ b/test/integration/harness/fixture.go
@@ -36,11 +36,14 @@ const (
 	// DHCPServerAddr is the static IP on DhcpVeth.
 	DHCPServerAddr = "192.168.99.1/24"
 	// DHCPPoolStart / DHCPPoolEnd / LeaseTime drive dnsmasq's
-	// --dhcp-range. 30s lease is short enough to exercise renewal
-	// in test wall-time without flaking on response delays.
+	// --dhcp-range. 2 minutes is dnsmasq's hard floor — anything
+	// shorter is silently rounded up, which made an earlier "30s"
+	// constant lie about the actual lease. T1 (renewal trigger
+	// inside udhcpc) lands at half-lease = 1m, so renewal-tests
+	// have a ~1m floor on wait time.
 	DHCPPoolStart = "192.168.99.10"
 	DHCPPoolEnd   = "192.168.99.99"
-	LeaseTime     = "30s"
+	LeaseTime     = "2m"
 
 	// SubnetCIDR is what callers expect IP assertions to fall inside.
 	SubnetCIDR = "192.168.99.0/24"

--- a/test/integration/lease_renew_test.go
+++ b/test/integration/lease_renew_test.go
@@ -18,9 +18,10 @@ import (
 // it expires, and that the renewal goes through (DHCPACK from
 // dnsmasq) without disturbing the container's IP.
 //
-// The fixture's lease time is 30s, so T1 (renewal trigger inside
-// udhcpc) fires at 15s. We wait ~22s — well past T1, comfortably
-// before T2 (26.25s) — and assert:
+// The fixture's lease time is 2m (dnsmasq's hard minimum, see
+// LeaseTime in harness/fixture.go), so T1 (renewal trigger inside
+// udhcpc) fires at 1m. We wait ~70s — past T1, well before T2
+// (1m45s) — and assert:
 //   - the container's IP from docker inspect hasn't changed
 //   - dnsmasq's log shows at least 2 DHCPACK lines for our MAC
 //     (one for the initial bind, one for the renewal)
@@ -30,7 +31,7 @@ import (
 // fine, then loses its IP somewhere between T2 and the next operator
 // noticing the connection dropped.
 func TestLeaseRenew_HonorsT1(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Second)
 	defer cancel()
 
 	netName := "dh-itest-renew"
@@ -48,14 +49,14 @@ func TestLeaseRenew_HonorsT1(t *testing.T) {
 
 	startACKs := countDHCPACKs(t, mac)
 
-	// Sleep past T1 (15s) but well before lease expiry (30s). Adding
-	// some slack because udhcpc's renewal jitter and dnsmasq's log
-	// flush aren't instantaneous.
-	t.Log("waiting 22s for lease renewal cycle...")
+	// Sleep past T1 (60s for a 2m lease) but well before T2 (105s)
+	// to keep the assertion clean: the only ACK we expect on top of
+	// the bind is a renewal ACK, not a rebind.
+	t.Log("waiting 70s for lease renewal cycle...")
 	select {
 	case <-ctx.Done():
 		t.Fatalf("context cancelled before renewal window: %v", ctx.Err())
-	case <-time.After(22 * time.Second):
+	case <-time.After(70 * time.Second):
 	}
 
 	// Re-poll inspect: the IP must not have changed during the

--- a/test/integration/lease_renew_test.go
+++ b/test/integration/lease_renew_test.go
@@ -1,0 +1,115 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	docker "github.com/docker/docker/client"
+)
+
+// TestLeaseRenew_HonorsT1 verifies the persistent renewal client the
+// plugin starts in dhcpManager.Start actually renews the lease before
+// it expires, and that the renewal goes through (DHCPACK from
+// dnsmasq) without disturbing the container's IP.
+//
+// The fixture's lease time is 30s, so T1 (renewal trigger inside
+// udhcpc) fires at 15s. We wait ~22s — well past T1, comfortably
+// before T2 (26.25s) — and assert:
+//   - the container's IP from docker inspect hasn't changed
+//   - dnsmasq's log shows at least 2 DHCPACK lines for our MAC
+//     (one for the initial bind, one for the renewal)
+//
+// Without this test, a regression in dhcpManager.renew or the
+// long-lived udhcpc client would be silent: the container starts
+// fine, then loses its IP somewhere between T2 and the next operator
+// noticing the connection dropped.
+func TestLeaseRenew_HonorsT1(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-renew"
+	ctrName := "dh-itest-renew-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+	id, ipBefore, mac := harness.RunContainer(t, ctx, netName, ctrName)
+	t.Logf("initial: ip=%s mac=%s", ipBefore, mac)
+
+	startACKs := countDHCPACKs(t, mac)
+
+	// Sleep past T1 (15s) but well before lease expiry (30s). Adding
+	// some slack because udhcpc's renewal jitter and dnsmasq's log
+	// flush aren't instantaneous.
+	t.Log("waiting 22s for lease renewal cycle...")
+	select {
+	case <-ctx.Done():
+		t.Fatalf("context cancelled before renewal window: %v", ctx.Err())
+	case <-time.After(22 * time.Second):
+	}
+
+	// Re-poll inspect: the IP must not have changed during the
+	// renewal window. Any change here means the renewal client lost
+	// the lease and DISCOVERed a new one.
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+	ins, err := cli.ContainerInspect(ctx, id)
+	if err != nil {
+		t.Fatalf("ContainerInspect: %v", err)
+	}
+	var ipAfter string
+	for _, ep := range ins.NetworkSettings.Networks {
+		ipAfter = ep.IPAddress
+	}
+	if ipAfter != ipBefore {
+		t.Errorf("IP changed during renewal window: before=%s after=%s (renewal client did not preserve lease)", ipBefore, ipAfter)
+	}
+
+	endACKs := countDHCPACKs(t, mac)
+	t.Logf("DHCPACKs for %s: start=%d, after=%d", mac, startACKs, endACKs)
+
+	// The initial bind is one ACK; a renewal is one more. We've
+	// waited past T1, so we expect at least one renewal ACK on top
+	// of the bind. Strictly: endACKs - startACKs >= 1, and total >= 2.
+	if endACKs-startACKs < 1 {
+		t.Errorf("no renewal DHCPACK observed for %s in the 22s wait window — renewal client appears stuck or dnsmasq is not handling the renewal request", mac)
+	}
+	if endACKs < 2 {
+		t.Errorf("expected at least 2 DHCPACKs for %s (bind + renewal), got %d", mac, endACKs)
+	}
+}
+
+// countDHCPACKs reads the macvlan-fixture dnsmasq log and counts
+// "DHCPACK" lines that mention `mac`. dnsmasq emits one ACK line per
+// successful bind/renewal/rebind, so the count is a clean monotonic
+// proxy for "how many times has dnsmasq blessed a request from this
+// MAC". MAC matching is case-insensitive and substring-based — the
+// log format prints lowercase MAC late in the line.
+func countDHCPACKs(t *testing.T, mac string) int {
+	t.Helper()
+	data, err := os.ReadFile(fixture.DnsmasqLog())
+	if err != nil {
+		t.Fatalf("read dnsmasq log: %v", err)
+	}
+	macLower := strings.ToLower(mac)
+	count := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(line, "DHCPACK") && strings.Contains(strings.ToLower(line), macLower) {
+			count++
+		}
+	}
+	return count
+}

--- a/test/integration/static_ip_test.go
+++ b/test/integration/static_ip_test.go
@@ -1,0 +1,122 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	docker "github.com/docker/docker/client"
+)
+
+// TestStaticIP_DriverOpt drives the `--driver-opt ip=<addr>` static-IP
+// override path: the container is connected with an explicit
+// per-endpoint driver opt, and the plugin must propagate that to
+// udhcpc's DHCPDISCOVER as a `requested IP` so dnsmasq hands out the
+// caller-chosen lease rather than picking from the pool.
+//
+// Exercises pkg/plugin/network.go::parseDriverOptIP (whose only
+// not-trivial branch was a 0%-coverage gap in v0.7.0) and
+// resolveExplicitV4 (the agreed-value return path).
+//
+// We pick a host high in the pool (.95) to keep the test reproducible
+// across suite runs: dnsmasq allocates pool entries from the low end
+// upward, and the existing tests rarely consume more than a handful
+// of leases before this test runs.
+func TestStaticIP_DriverOpt(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const (
+		netName = "dh-itest-staticip"
+		ctrName = "dh-itest-staticip-ctr"
+		wantIP  = "192.168.99.95"
+	)
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	t.Cleanup(func() { _ = cli.Close() })
+
+	// Inline a RunContainer-equivalent because the harness helper
+	// doesn't take per-endpoint DriverOpts — the static-IP override
+	// is the only test that needs them so far. Promote to a harness
+	// helper if a second consumer appears.
+	create, err := cli.ContainerCreate(ctx,
+		&container.Config{
+			Image: harness.TestImage,
+			Cmd:   []string{"sleep", "infinity"},
+		},
+		&container.HostConfig{},
+		&network.NetworkingConfig{
+			EndpointsConfig: map[string]*network.EndpointSettings{
+				netName: {
+					DriverOpts: map[string]string{"ip": wantIP},
+				},
+			},
+		},
+		nil,
+		ctrName,
+	)
+	if err != nil {
+		t.Fatalf("ContainerCreate: %v", err)
+	}
+	id := create.ID
+	t.Cleanup(func() {
+		bg := context.Background()
+		_ = cli.ContainerStop(bg, id, container.StopOptions{})
+		_ = cli.ContainerRemove(bg, id, container.RemoveOptions{Force: true})
+	})
+
+	if err := cli.ContainerStart(ctx, id, container.StartOptions{}); err != nil {
+		t.Fatalf("ContainerStart: %v", err)
+	}
+
+	// Poll docker inspect until the endpoint reports the IP we asked
+	// for. If the plugin ignored the driver-opt and let dnsmasq pick,
+	// we'd see a different address from the pool — that's the
+	// regression this test guards against.
+	deadline := time.Now().Add(harness.IPAcquisitionBudget)
+	var gotIP string
+	for time.Now().Before(deadline) {
+		ins, err := cli.ContainerInspect(ctx, id)
+		if err != nil {
+			t.Fatalf("ContainerInspect: %v", err)
+		}
+		for _, ep := range ins.NetworkSettings.Networks {
+			if ep.IPAddress != "" {
+				gotIP = ep.IPAddress
+			}
+		}
+		if gotIP != "" {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if gotIP == "" {
+		t.Fatalf("container never got an IP within %v", harness.IPAcquisitionBudget)
+	}
+	if gotIP != wantIP {
+		t.Errorf("static-IP driver-opt was ignored: requested %s, got %s", wantIP, gotIP)
+	}
+
+	// Inside-container view must agree (truthfulness invariant).
+	out := harness.ExecOutput(t, ctx, id, "ip", "-4", "addr", "show", "eth0")
+	if !strings.Contains(out, wantIP) {
+		t.Errorf("eth0 inside container does not show requested IP %q\nactual:\n%s", wantIP, out)
+	}
+}

--- a/test/integration/static_routes_bridge_test.go
+++ b/test/integration/static_routes_bridge_test.go
@@ -1,0 +1,83 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	"github.com/vishvananda/netlink"
+)
+
+// TestStaticRoutes_BridgeCopiesToContainer verifies the plugin's
+// bridge-mode static-route copy logic in pkg/plugin/network.go
+// addRoutes: every non-default, non-DHCP-subnet, non-kernel-protocol
+// route present on the host bridge at Join time is replicated into
+// the container's netns via res.StaticRoutes.
+//
+// We pre-add a route `192.168.250.0/24 dev dh-itest-br2` on the host
+// bridge before connecting the container, then assert the container's
+// `ip route` lists 192.168.250.0/24 inside its netns.
+//
+// Why this matters operationally: bridge-mode networks bridged to a
+// VLAN trunk often need extra-subnet on-link routes (e.g. management
+// VLANs reachable through the same bridge but not handed out by DHCP).
+// Without this copy, those routes work on the host but vanish inside
+// every container — a silent footgun. The skip_routes=true option is
+// the consumer-facing escape hatch; this test guards the default
+// behaviour.
+func TestStaticRoutes_BridgeCopiesToContainer(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const (
+		netName  = "dh-itest-routes-br"
+		ctrName  = "dh-itest-routes-br-ctr"
+		extraDst = "192.168.250.0/24"
+	)
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			fixture.DumpBridgeLogs(func(s string) { t.Log(s) })
+		}
+	})
+
+	// Add the extra route to the bridge before any container attaches.
+	// Plugin's addRoutes runs at Join time and snapshots the host's
+	// route table for the bridge — a route added after Join wouldn't
+	// land in the container.
+	bridge, err := netlink.LinkByName(harness.BridgeName)
+	if err != nil {
+		t.Fatalf("LinkByName(%s): %v", harness.BridgeName, err)
+	}
+	_, dst, err := net.ParseCIDR(extraDst)
+	if err != nil {
+		t.Fatalf("ParseCIDR: %v", err)
+	}
+	hostRoute := &netlink.Route{
+		LinkIndex: bridge.Attrs().Index,
+		Dst:       dst,
+	}
+	if err := netlink.RouteAdd(hostRoute); err != nil {
+		t.Fatalf("RouteAdd %s dev %s: %v", extraDst, harness.BridgeName, err)
+	}
+	t.Cleanup(func() {
+		if err := netlink.RouteDel(hostRoute); err != nil {
+			t.Logf("WARN: RouteDel %s dev %s: %v", extraDst, harness.BridgeName, err)
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "bridge", nil)
+	id, ipv4, _ := harness.RunContainer(t, ctx, netName, ctrName)
+	t.Logf("container ip=%s", ipv4)
+
+	out := harness.ExecOutput(t, ctx, id, "ip", "route")
+	if !strings.Contains(out, extraDst) {
+		t.Errorf("static route %s not propagated into container netns\ncontainer routes:\n%s", extraDst, out)
+	}
+}


### PR DESCRIPTION
## Summary

Three new integration tests targeting real production code paths the existing v0.7.0 suite didn't exercise. Coverage smoke run on this branch (run 25370968577) reports total integration coverage **68.8% → 69.5%**, with the per-function gains all from genuinely new test execution — no merge-tricks, no unit-test inflation.

## Tests

- **`static_ip_test.go`** — `TestStaticIP_DriverOpt` connects a container with `--driver-opt ip=192.168.99.95` on a macvlan network and asserts the endpoint comes up with that exact IP. Covers `pkg/plugin/network.go::parseDriverOptIP` (53.3 → 80.0%) and parts of `resolveExplicitV4`. Catches regressions in static-IP override handling that would silently fall back to DHCP-pool allocation.

- **`lease_renew_test.go`** — `TestLeaseRenew_HonorsT1` waits 70s past T1 (60s for the fixture's 2m lease) and asserts the IP is unchanged plus the dnsmasq log shows ≥2 DHCPACK lines for the container's MAC. The `dhcp_manager.renew` path was already at 56% (long tests cross T1 sometimes), but this test guards against silent-loss regressions where a renewal client breakage would only surface as containers losing networking after lease expiry.

- **`static_routes_bridge_test.go`** — `TestStaticRoutes_BridgeCopiesToContainer` pre-adds a `192.168.250.0/24` route to the host bridge, attaches a bridge-mode container, asserts the route is replicated into the container netns. Covers `pkg/plugin/network.go::addRoutes` (37.9 → 51.7%). Catches regressions in the documented bridge-mode static-route copy feature (`-o skip_routes=false`, default).

## Side fixes uncovered along the way

- `harness.LeaseTime` was `"30s"`, but dnsmasq's hard floor is 2 minutes — the constant was lying. Fixed to `"2m"` to match reality (and updated the comment that asserted otherwise). No existing test depended on the false value.
- Makefile `integration-test` target ran with `-timeout 5m`. The renewal test (85s) plus the existing serial suite pushes past 5m, so the timeout is bumped to `10m`. CI workflow already has 20m.
- New `harness.Fixture.DnsmasqLog()` accessor exposes the dnsmasq log path so tests can grep it mid-run (only needed by the renewal assertion so far).

## Coverage delta (integration suite, run 25370968577 vs baseline 25369286849)

| Package | Before | After |
|---|---|---|
| `cmd/net-dhcp` | 82.0% | 82.0% |
| `cmd/udhcpc-handler` | 36.4% | 36.4% |
| `pkg/plugin` | 68.0% | **68.9%** |
| `pkg/udhcpc` | 76.4% | 76.4% |
| `pkg/util` | 67.2% | 67.2% |
| **Total** | **68.8%** | **69.5%** |

Remaining gaps below 50% (`netOptions`, `parseExplicitV4`, `DeleteNetwork`, `cmd/udhcpc-handler/main`) all require fault injection or are gated by libnetwork rejecting requests before they reach the plugin (e.g. `--ip` with null IPAM). Cleanly out of integration's reach — left for future PRs that add unit tests or DHCP-server fault scenarios.

Closes #63 will fire on the dev→main release PR.

## Test plan

- [x] CI: Coverage workflow run 25370968577 — green, all 12 tests pass, coverage artifact uploaded
- [ ] CI: Integration workflow on this PR — green
- [ ] After merge to dev: standard release-PR cascade for v0.8.0