### PR TITLE
Code-review fix sweep for v0.8.0

### DIFF
--- a/.github/workflows/apk-pin-check.yml
+++ b/.github/workflows/apk-pin-check.yml
@@ -1,0 +1,27 @@
+name: APK pin drift
+
+# Weekly check on the apk pins in the Dockerfile (busybox-extras,
+# iproute2). Surfaces an upgrade signal so a silent upstream change
+# in the udhcpc-shipping busybox doesn't land in plugin builds
+# without the maintainer noticing (I-13 in the 2026-05-05 review).
+#
+# Runs on a Sunday-morning UTC schedule, plus on-demand via the
+# Actions tab. Doesn't fail the workflow on drift — the report in
+# the run log is the actionable artefact.
+
+on:
+  schedule:
+    - cron: '7 6 * * 0'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check apk pins
+        run: bash scripts/check-apk-pins.sh

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -80,6 +80,19 @@ jobs:
           docker plugin disable "${COVER_PLUGIN_REF}" || true
           ls -la "${COVER_DIR}"
 
+      # Run the unit test suite with coverage so the workflow summary
+      # can report unit + integration + merged numbers (I-14 in the
+      # 2026-05-05 review). go test's `-cover -test.gocoverdir` writes
+      # the same binary-coverage format covdata understands, which
+      # lets us merge directly without converting through textfmt.
+      - name: Run unit tests with coverage
+        if: always()
+        run: |
+          mkdir -p coverage-unit
+          go test -count=1 -coverpkg=./... \
+              -args -test.gocoverdir="$PWD/coverage-unit" \
+              ./pkg/... ./cmd/...
+
       - name: Coverage summary
         if: always()
         run: |
@@ -87,10 +100,24 @@ jobs:
             echo "No coverage counter files found — plugin may have crashed before flush."
             exit 1
           fi
-          echo "## Coverage by package" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          go tool covdata percent -i="${COVER_DIR}" | tee -a "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          {
+              echo "## Coverage by package"
+              echo
+              echo "### Integration only"
+              echo '```'
+              go tool covdata percent -i="${COVER_DIR}"
+              echo '```'
+              if ls coverage-unit/covcounters.* >/dev/null 2>&1; then
+                  echo "### Unit only"
+                  echo '```'
+                  go tool covdata percent -i=coverage-unit
+                  echo '```'
+                  echo "### Merged (unit + integration)"
+                  echo '```'
+                  go tool covdata percent -i="${COVER_DIR}",coverage-unit
+                  echo '```'
+              fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Generate coverage reports
         if: always()
@@ -99,7 +126,13 @@ jobs:
             echo "Skipping report generation — no counter files."
             exit 0
           fi
+          # Per-source profiles: integration-only (back-compat), and
+          # merged when unit counters are present.
           go tool covdata textfmt -i="${COVER_DIR}" -o coverage.out
+          if ls coverage-unit/covcounters.* >/dev/null 2>&1; then
+              go tool covdata textfmt -i="${COVER_DIR}",coverage-unit -o coverage-merged.out
+              go tool cover -html=coverage-merged.out -o coverage-merged.html
+          fi
           go tool cover -html=coverage.out -o coverage.html
 
       - name: Upload coverage artifact
@@ -110,6 +143,8 @@ jobs:
           path: |
             coverage.out
             coverage.html
+            coverage-merged.out
+            coverage-merged.html
           if-no-files-found: warn
           retention-days: 30
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ __pycache__/
 
 # Local-only handoff brief — not part of the project
 CLAUDE.md
+
+# Local code-review reports — kept on disk for follow-up but not committed
+code-review-report.md

--- a/cmd/net-dhcp/main.go
+++ b/cmd/net-dhcp/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"flag"
+	"net/http"
 	"os"
 	"os/signal"
 	"sync"
@@ -117,7 +119,12 @@ func main() {
 
 	go func() {
 		log.Info("Starting server...")
-		if err := p.Listen(*bindSock); err != nil {
+		// http.Server.Serve returns http.ErrServerClosed on a clean
+		// Close — that's the success path on SIGTERM, not a failure.
+		// Without this guard the goroutine logs ERROR and os.Exit(1)s
+		// while the main goroutine is still finishing its own clean
+		// shutdown, racing the exit code to 1.
+		if err := p.Listen(*bindSock); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			fatalCleanup(err, "Failed to start plugin")
 		}
 	}()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devplayer0/docker-net-dhcp
 
-go 1.25.0
+go 1.25.9
 
 require (
 	github.com/docker/docker v28.4.0+incompatible

--- a/pkg/plugin/api_handlers_test.go
+++ b/pkg/plugin/api_handlers_test.go
@@ -322,6 +322,23 @@ func TestDecodeOpts_NilInput(t *testing.T) {
 	}
 }
 
+// TestDecodeOpts_NilUnderGenericKey pins the behaviour for the case
+// where the libnetwork payload has the generic key present but with a
+// nil value (rare but reachable via the docker API). decodeOpts must
+// return zero options without error — validateModeOptions then catches
+// the missing-bridge / missing-parent case downstream. Pinned by I-11
+// in the 2026-05-05 review.
+func TestDecodeOpts_NilUnderGenericKey(t *testing.T) {
+	var nilMap map[string]interface{}
+	opts, err := decodeOpts(nilMap)
+	if err != nil {
+		t.Fatalf("decode(nilMap): %v", err)
+	}
+	if opts.Mode != "" || opts.Bridge != "" || opts.Parent != "" {
+		t.Errorf("zero options expected, got %+v", opts)
+	}
+}
+
 // TestApiCreateNetwork_DecodeOptsError covers the error path where the
 // driver-opts payload itself is shaped wrong (a non-map under the
 // generic key). decodeOpts returns a wrapped mapstructure error which

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -40,6 +40,25 @@ const dhcpClientReapTimeout = 5 * time.Second
 // upstream DHCP server.
 const dhcpClientFinishTimeout = 5 * time.Second
 
+// closeNsHandle / closeNetHandle log close errors at Debug instead of
+// silently dropping them. Cleanup paths can't act on a Close failure
+// (we're already on an error path or shutting down), but a recurring
+// EBADF / EIO here is the breadcrumb a future netns-leak debugging
+// session will want.
+func closeNsHandle(h netns.NsHandle) {
+	if err := h.Close(); err != nil {
+		log.WithError(err).Debug("netns handle close failed")
+	}
+}
+func closeNetHandle(h *netlink.Handle) {
+	if h == nil {
+		return
+	}
+	// netlink.Handle.Close has no return value; the wrapper exists
+	// for symmetry with closeNsHandle so call sites read uniformly.
+	h.Close()
+}
+
 type dhcpManager struct {
 	docker  *docker.Client
 	joinReq JoinRequest
@@ -273,25 +292,13 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 					return
 				}
 				switch event.Type {
-				// TODO: We can't really allow the IP in the container to be deleted, it'll delete some of our previously
-				// copied routes. Should this be handled somehow?
-				//case "deconfig":
-				//	ip := m.LastIP
-				//	if v6 {
-				//		ip = m.LastIPv6
-				//	}
-
-				//	log.
-				//		WithFields(m.logFields(v6)).
-				//		WithField("ip", ip).
-				//		Info("udhcpc deconfiguring, deleting previously acquired IP")
-				//	if err := m.netHandle.AddrDel(m.ctrLink, ip); err != nil {
-				//		log.
-				//			WithError(err).
-				//			WithFields(m.logFields(v6)).
-				//			WithField("ip", ip).
-				//			Error("Failed to delete existing udhcpc address")
-				//	}
+				// "deconfig" is intentionally not handled. Deleting the
+				// container's IP from the kernel would also wipe the
+				// static routes Join copied off the host bridge, and
+				// there's no clean way to re-derive them without
+				// re-running the bridge route copy. Better to keep
+				// the stale address until the next bound/renew
+				// overwrites it.
 				case "bound":
 					// The persistent client's first DHCPACK can land
 					// on a different IP than CreateEndpoint's initial
@@ -441,7 +448,7 @@ func (m *dhcpManager) Start(ctx context.Context) (err error) {
 
 	m.netHandle, err = netlink.NewHandleAt(m.nsHandle)
 	if err != nil {
-		m.nsHandle.Close()
+		closeNsHandle(m.nsHandle)
 		return fmt.Errorf("failed to open netlink handle in sandbox namespace: %w", err)
 	}
 
@@ -464,8 +471,8 @@ func (m *dhcpManager) Start(ctx context.Context) (err error) {
 
 		return nil
 	}(); err != nil {
-		m.netHandle.Close()
-		m.nsHandle.Close()
+		closeNetHandle(m.netHandle)
+		closeNsHandle(m.nsHandle)
 		return err
 	}
 
@@ -486,12 +493,12 @@ func (m *dhcpManager) Stop() error {
 	// value emits a noisy EBADF.
 	defer func() {
 		if m.nsHandle.IsOpen() {
-			m.nsHandle.Close()
+			closeNsHandle(m.nsHandle)
 		}
 	}()
 	defer func() {
 		if m.netHandle != nil {
-			m.netHandle.Close()
+			closeNetHandle(m.netHandle)
 		}
 	}()
 

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -216,8 +216,18 @@ func (p *Plugin) DeleteNetwork(r DeleteNetworkRequest) error {
 	return nil
 }
 
+// vethPairNames derives the host-side and container-side veth names from
+// an endpoint ID. Docker EndpointIDs are 64 hex chars in production, but
+// recovery / malformed daemon responses can in principle hand us a
+// shorter ID — same defensive shape as shortID. The pair-uniqueness
+// guarantee is weakened in that case (two short IDs sharing a prefix
+// would collide), but the function won't panic.
 func vethPairNames(id string) (string, string) {
-	return "dh-" + id[:12], id[:12] + "-dh"
+	prefix := id
+	if len(id) > 12 {
+		prefix = id[:12]
+	}
+	return "dh-" + prefix, prefix + "-dh"
 }
 
 // parseExplicitV4 extracts the bare IPv4 address from an optional

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -30,8 +30,13 @@ import (
 // subLinkName returns the host-side child link name for an endpoint.
 // Mirrors the prefix used for the bridge-mode veth so existing log/diag
 // patterns still apply. Used for both macvlan and ipvlan children.
+// Defensive against short IDs (see vethPairNames) — never panics.
 func subLinkName(endpointID string) string {
-	return "dh-" + endpointID[:12]
+	prefix := endpointID
+	if len(endpointID) > 12 {
+		prefix = endpointID[:12]
+	}
+	return "dh-" + prefix
 }
 
 // validateParentForChild ensures the parent NIC exists, is up, and is

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -59,6 +59,14 @@ const initialDHCPHostnameLookupTimeout = 2 * time.Second
 // recovery_failed on /Plugin.Health.
 const recoveryBudget = 30 * time.Second
 
+// recoveryPerNetworkTimeout caps each individual NetworkInspect /
+// netOptions Docker round-trip during recovery. Without it (W-7 in
+// the 2026-05-05 review) one stuck Docker call could consume the
+// entire recoveryBudget and starve later networks of their chance
+// to recover. Tight on purpose — these are local-socket calls that
+// either return promptly or are wedged.
+const recoveryPerNetworkTimeout = 3 * time.Second
+
 // clientIDFromEndpoint derives a stable DHCP option-61 client identifier
 // from a Docker endpoint ID. Docker's endpoint IDs are 64 hex chars
 // (32 bytes). We take the first 8 bytes — long enough to be unique
@@ -83,12 +91,14 @@ func clientIDFromEndpoint(endpointID string) []byte {
 
 const defaultLeaseTimeout = 10 * time.Second
 
-// driverRegexp matches plugin references that this driver should treat as
-// "another instance of itself" when scanning for bridge conflicts. Upstream
-// pinned this to ghcr.io/devplayer0; we accept any registry namespace as
-// long as the image name and tag are present, so forks published under a
-// different namespace still cross-detect each other on the same host.
-var driverRegexp = regexp.MustCompile(`(^|/)docker-net-dhcp:.+$`)
+// driverRegexp matches plugin references that this driver should treat
+// as "another instance of itself" when scanning for bridge conflicts.
+// Pinned to known maintained namespaces (devplayer0 = upstream,
+// claymore666 = this fork) — broader matching would treat an attacker-
+// controlled image like `evil.example/docker-net-dhcp:bad` as ours and
+// surface spurious "Bridge already in use" errors. New forks that need
+// cross-detection should add their namespace here.
+var driverRegexp = regexp.MustCompile(`(^|/)(devplayer0|claymore666)/docker-net-dhcp:.+$`)
 
 // IsDHCPPlugin checks if a Docker network driver is an instance of this plugin
 func IsDHCPPlugin(driver string) bool {
@@ -381,7 +391,9 @@ func (p *Plugin) consumeTombstone(networkID, hostname string) (mac, ipv4, ipv6 s
 		log.WithError(err).Warn("Failed to load tombstones; treating as empty")
 		return "", "", "", false
 	}
+	preLen := len(ts)
 	ts = pruneTombstones(ts)
+	pruned := len(ts) != preLen
 	matchIdx := -1
 	matches := 0
 	for i, t := range ts {
@@ -398,12 +410,13 @@ func (p *Plugin) consumeTombstone(networkID, hostname string) (mac, ipv4, ipv6 s
 		matches++
 		matchIdx = i
 	}
-	// Always rewrite to persist the prune, even if we don't consume.
 	if matches != 1 {
 		// More than one match → ambiguous. Drop *all* matches so the
 		// next consumeTombstone for this network/hostname doesn't keep
 		// hitting the same poisoned set for the rest of the TTL window.
-		// Zero matches is harmless; the prune still gets persisted.
+		// Zero matches is harmless; the prune still gets persisted iff
+		// it changed something.
+		dirty := pruned
 		if matches > 1 {
 			kept := ts[:0]
 			for _, t := range ts {
@@ -417,9 +430,15 @@ func (p *Plugin) consumeTombstone(networkID, hostname string) (mac, ipv4, ipv6 s
 				kept = append(kept, t)
 			}
 			ts = kept
+			dirty = true
 		}
-		if err := saveTombstones(ts); err != nil {
-			log.WithError(err).Debug("Failed to persist pruned tombstones")
+		// Skip the rewrite when nothing changed (I-10 in the
+		// 2026-05-05 review): the common no-op consume on a quiet
+		// network used to fsync a file write per CreateEndpoint.
+		if dirty {
+			if err := saveTombstones(ts); err != nil {
+				log.WithError(err).Debug("Failed to persist pruned tombstones")
+			}
 		}
 		return "", "", "", false
 	}
@@ -446,29 +465,47 @@ func (p *Plugin) consumeTombstone(networkID, hostname string) (mac, ipv4, ipv6 s
 // so the upstream DHCP server can ACK the lease the container is
 // already using rather than handing out a fresh one.
 func (p *Plugin) recoverEndpoints(ctx context.Context) {
+	// recordSyncFailure bumps both the local counter (used for the
+	// summary log line) and the atomic surfaced on /Plugin.Health.
+	// The async Start failure path bumps p.recoveryFailed directly;
+	// without this, NetworkInspect / netOptions / recoverOneEndpoint
+	// failures would only show up in the log line and not on the
+	// health endpoint operators page on (W-2 in the 2026-05-05 review).
+	var recovered, failed int
+	recordSyncFailure := func() {
+		failed++
+		p.recoveryFailed.Add(1)
+	}
 	nets, err := p.docker.NetworkList(ctx, dNetwork.ListOptions{})
 	if err != nil {
 		log.WithError(err).Warn("recovery: failed to list networks; skipping")
+		// We don't know how many endpoints we missed; at least flip
+		// Healthy=false so an operator notices.
+		p.recoveryFailed.Add(1)
 		return
 	}
-	var recovered, failed int
 	for _, n := range nets {
 		if !IsDHCPPlugin(n.Driver) {
 			continue
 		}
+		// Per-network bounded ctx so a single hung NetworkInspect /
+		// netOptions doesn't consume the whole recoveryBudget.
+		netCtx, netCancel := context.WithTimeout(ctx, recoveryPerNetworkTimeout)
 		// Re-fetch with full container details (NetworkList is summary-only).
-		netInfo, err := p.docker.NetworkInspect(ctx, n.ID, dNetwork.InspectOptions{})
+		netInfo, err := p.docker.NetworkInspect(netCtx, n.ID, dNetwork.InspectOptions{})
 		if err != nil {
+			netCancel()
 			log.WithError(err).WithField("network", shortID(n.ID)).
 				Warn("recovery: NetworkInspect failed; skipping")
-			failed++
+			recordSyncFailure()
 			continue
 		}
-		opts, err := p.netOptions(ctx, n.ID)
+		opts, err := p.netOptions(netCtx, n.ID)
+		netCancel()
 		if err != nil {
 			log.WithError(err).WithField("network", shortID(n.ID)).
 				Warn("recovery: failed to load network options; skipping")
-			failed++
+			recordSyncFailure()
 			continue
 		}
 		for cid, info := range netInfo.Containers {
@@ -484,7 +521,7 @@ func (p *Plugin) recoverEndpoints(ctx context.Context) {
 					"network":  shortID(n.ID),
 					"endpoint": shortID(info.EndpointID),
 				}).Warn("recovery: endpoint recovery failed")
-				failed++
+				recordSyncFailure()
 				continue
 			}
 			recovered++
@@ -778,6 +815,14 @@ func (p *Plugin) Close() error {
 		}
 		// Bound wall time: we can't let one wedged udhcpc hold up the
 		// whole shutdown.
+		//
+		// Known leak (W-8 in the 2026-05-05 review): if the timeout
+		// fires before wg.Wait returns, the watcher goroutine and any
+		// stuck Stop() calls live on until the OS reaps the process.
+		// That's acceptable here because Close runs at process exit
+		// — but DO NOT copy this pattern into a long-lived caller
+		// (e.g. a future SIGHUP-driven re-attach). For long-lived use,
+		// pass a ctx into Stop and have it abort cleanly on cancel.
 		done := make(chan struct{})
 		go func() { wg.Wait(); close(done) }()
 		select {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -17,8 +17,14 @@ func TestIsDHCPPlugin(t *testing.T) {
 		{"ghcr.io/devplayer0/docker-net-dhcp:release-linux-amd64", true},
 		{"ghcr.io/claymore666/docker-net-dhcp:v0.4.0", true},
 		{"ghcr.io/claymore666/docker-net-dhcp:latest", true},
-		{"someregistry.example/team/docker-net-dhcp:1.0", true},
-		{"docker-net-dhcp:local", true},
+
+		// Foreign namespaces are deliberately rejected — see W-6 in the
+		// 2026-05-05 review. A broader regex would let a third-party
+		// image masquerade as an instance of this plugin and trigger
+		// spurious bridge-conflict errors.
+		{"someregistry.example/team/docker-net-dhcp:1.0", false},
+		{"docker-net-dhcp:local", false},
+		{"evil.example/docker-net-dhcp:bad", false},
 
 		{"bridge", false},
 		{"macvlan", false},

--- a/pkg/udhcpc/client.go
+++ b/pkg/udhcpc/client.go
@@ -7,8 +7,10 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"runtime"
 	"syscall"
@@ -161,7 +163,20 @@ func NewDHCPClient(iface string, opts *DHCPClientOptions) (*DHCPClient, error) {
 	return c, nil
 }
 
-// Start starts udhcpc(6)
+// Start starts udhcpc(6).
+//
+// Concurrency contract: when Opts.Namespace is non-empty, Start enters
+// the target netns by locking the calling goroutine to its OS thread,
+// switching netns, spawning the child, and switching back. It is *not*
+// re-entrant on the same goroutine (a nested Start on the same g would
+// double-LockOSThread). Concurrent Starts on *different* goroutines
+// are safe — each goroutine flips its own thread independently.
+//
+// On netns-restore failure the calling thread is deliberately leaked
+// (a second LockOSThread pins it so Go's runtime won't reuse it for
+// other goroutines). That's the safer choice than letting the wrong-
+// netns state leak into the runtime's thread pool — the OS scheduler
+// reaps the thread when the process exits, which is soon enough.
 func (c *DHCPClient) Start() (chan Event, error) {
 	if c.Opts.Namespace != "" {
 		// Lock the OS Thread so we don't accidentally switch namespaces
@@ -172,13 +187,21 @@ func (c *DHCPClient) Start() (chan Event, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to open current network namespace: %w", err)
 		}
-		defer origNS.Close()
+		defer func() {
+			if err := origNS.Close(); err != nil {
+				log.WithError(err).Debug("origNS close failed")
+			}
+		}()
 
 		ns, err := netns.GetFromPath(c.Opts.Namespace)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open network namespace `%v`: %w", c.Opts.Namespace, err)
 		}
-		defer ns.Close()
+		defer func() {
+			if err := ns.Close(); err != nil {
+				log.WithError(err).Debug("netns close failed")
+			}
+		}()
 
 		if err := netns.Set(ns); err != nil {
 			return nil, fmt.Errorf("failed to enter network namespace: %w", err)
@@ -232,12 +255,21 @@ func (c *DHCPClient) Start() (chan Event, error) {
 	return events, nil
 }
 
-// Finish sends SIGTERM to udhcpc(6) and waits for it to exit. SIGTERM will not
-// be sent if `Opts.Once` is set.
+// Finish sends SIGTERM to udhcpc(6) and waits for it to exit. SIGTERM
+// will not be sent if `Opts.Once` is set.
 func (c *DHCPClient) Finish(ctx context.Context) error {
 	// If only running to get an IP once, udhcpc will terminate on its own
 	if !c.Opts.Once {
 		if err := c.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+			// The process can self-exit between Start and here (NAK,
+			// parent NIC vanished, netns torn down). os.ErrProcessDone
+			// is the wrapped sentinel for that race; treat as success
+			// and let Wait reap so we don't leak a zombie.
+			if errors.Is(err, os.ErrProcessDone) {
+				log.WithFields(log.Fields{"v6": c.Opts.V6}).
+					Debug("udhcpc already exited before SIGTERM; reaping")
+				return c.Wait(ctx)
+			}
 			return fmt.Errorf("failed to send SIGTERM to udhcpc: %w", err)
 		}
 	}
@@ -268,10 +300,19 @@ func (c *DHCPClient) Wait(ctx context.Context) error {
 	}
 }
 
-// GetIP is a convenience function that runs udhcpc(6) once and returns the IP
-// info obtained. The caller's opts is not mutated — we work on a local copy
-// so a caller that reuses the options struct between persistent and one-shot
-// calls doesn't get its Once flag flipped on.
+// GetIP is a convenience function that runs udhcpc(6) once and returns
+// the IP info obtained. The caller's opts is not mutated — we work on a
+// local copy so a caller that reuses the options struct between persistent
+// and one-shot calls doesn't get its Once flag flipped on.
+//
+// Implementation note (W-5 in the 2026-05-05 review): the previous form
+// shared a `*Info` pointer between the events-collector goroutine and
+// the main goroutine without synchronisation, and busy-looped on the
+// closed events channel because the receive didn't check `ok`. The
+// `range events` loop here drains until the scanner closes the channel,
+// then hands the final lease back through `ch` — which is the
+// happens-before edge between the goroutine's last write and the main
+// goroutine's read.
 func GetIP(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, error) {
 	dummy := Info{}
 
@@ -287,30 +328,35 @@ func GetIP(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, er
 		return dummy, fmt.Errorf("failed to start DHCP client: %w", err)
 	}
 
-	var info *Info
-	done := make(chan struct{})
+	// ch carries the final lease seen, or stays unsent if no
+	// bound/renew event arrived before the scanner closed events.
+	// Buffered=1 so the goroutine never blocks on send.
+	ch := make(chan Info, 1)
 	go func() {
-		for {
-			select {
-			case event := <-events:
-				switch event.Type {
-				case "bound", "renew":
-					info = &event.Data
-				}
-			case <-done:
-				return
+		var last *Info
+		for event := range events {
+			if event.Type == "bound" || event.Type == "renew" {
+				v := event.Data
+				last = &v
 			}
 		}
+		if last != nil {
+			ch <- *last
+		}
+		close(ch)
 	}()
-	defer close(done)
 
 	if err := client.Finish(ctx); err != nil {
 		return dummy, err
 	}
 
-	if info == nil {
-		return dummy, util.ErrNoLease
+	select {
+	case info, ok := <-ch:
+		if !ok {
+			return dummy, util.ErrNoLease
+		}
+		return info, nil
+	case <-ctx.Done():
+		return dummy, ctx.Err()
 	}
-
-	return *info, nil
 }

--- a/pkg/util/json.go
+++ b/pkg/util/json.go
@@ -31,14 +31,31 @@ type jsonError struct {
 	Message string `json:"Err"`
 }
 
-// JSONErrResponse Sends an `error` as a JSON object with a `message` property
+// JSONErrResponse Sends an `error` as a JSON object with a `message`
+// property. Logs at a level matching the HTTP status:
+//
+//   - 5xx -> Error (we did something wrong)
+//   - 4xx -> Warn  (caller did something wrong; not actionable for us)
+//   - other -> Info
+//
+// A torrent of 4xx from a misconfigured client used to land at ERROR,
+// drowning real failures (I-12 in the 2026-05-05 review).
 func JSONErrResponse(w http.ResponseWriter, err error, statusCode int) {
-	log.WithError(err).Error("Error while processing request")
-
-	w.Header().Set("Content-Type", "application/problem+json")
 	if statusCode == 0 {
 		statusCode = ErrToStatus(err)
 	}
+
+	entry := log.WithError(err).WithField("status", statusCode)
+	switch {
+	case statusCode >= 500:
+		entry.Error("Error while processing request")
+	case statusCode >= 400:
+		entry.Warn("Caller error while processing request")
+	default:
+		entry.Info("Non-success response")
+	}
+
+	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(statusCode)
 
 	if encErr := json.NewEncoder(w).Encode(jsonError{err.Error()}); encErr != nil {

--- a/scripts/check-apk-pins.sh
+++ b/scripts/check-apk-pins.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Check the apk version pins in Dockerfile against the current Alpine
+# package index. Prints a diff and exits non-zero when a pin is behind
+# upstream — wire it into a weekly CI cron so an upgrade signal lands
+# on the maintainer's desk without anyone having to remember to look.
+#
+# Pins live in the form `pkg=ver-rN` inside the `apk add --no-cache`
+# block of Dockerfile. We extract the alpine base from the runtime
+# stage's FROM line so the check tracks whatever the Dockerfile
+# actually pins (no separate config to drift).
+#
+# Usage:
+#   bash scripts/check-apk-pins.sh                # human-readable report
+#   bash scripts/check-apk-pins.sh --strict       # exit 1 if any pin is behind
+#
+# Requires: docker, awk, sed.
+
+set -euo pipefail
+
+DOCKERFILE="${DOCKERFILE:-Dockerfile}"
+STRICT=0
+if [[ "${1:-}" == "--strict" ]]; then STRICT=1; fi
+
+# Pull the alpine base off the runtime FROM (the second FROM, after the
+# builder). Greedy match would also catch the golang stage; tail -1 keeps
+# us pinned to the runtime image.
+ALPINE_REF=$(awk '/^FROM alpine:/ {print $2}' "$DOCKERFILE" | tail -n1)
+if [[ -z "$ALPINE_REF" ]]; then
+    echo "could not find FROM alpine: line in $DOCKERFILE" >&2
+    exit 2
+fi
+
+# Pinned packages: lines like `        pkg=ver-rN \` inside the apk block.
+mapfile -t PINS < <(awk '
+    /apk add/ { in_apk = 1; next }
+    in_apk && /=/ {
+        line = $0
+        sub(/^[[:space:]]+/, "", line)
+        sub(/[[:space:]]*\\$/, "", line)
+        if (line ~ /=/) print line
+    }
+    in_apk && !/\\$/ { in_apk = 0 }
+' "$DOCKERFILE")
+
+if [[ "${#PINS[@]}" -eq 0 ]]; then
+    echo "no apk pins found in $DOCKERFILE — nothing to check" >&2
+    exit 0
+fi
+
+echo "Checking apk pins against $ALPINE_REF"
+echo
+
+# Run apk inside the alpine image once and ask for each pinned pkg.
+# `apk policy` lists installed/available versions; we grep for the head
+# of the indexed candidate. Cleaner than parsing the apk index by hand.
+LATEST=$(docker run --rm "$ALPINE_REF" sh -c '
+    apk update -q >/dev/null
+    for p in "$@"; do
+        name="${p%%=*}"
+        printf "%s\t" "$name"
+        apk policy "$name" 2>/dev/null | awk "/^[[:space:]]+[0-9]/ {print \$1; exit}"
+    done
+' -- "${PINS[@]}")
+
+drift=0
+while IFS=$'\t' read -r name avail; do
+    pinned=""
+    for p in "${PINS[@]}"; do
+        if [[ "${p%%=*}" == "$name" ]]; then pinned="${p#*=}"; fi
+    done
+    if [[ -z "$avail" ]]; then
+        printf "  %-20s pinned=%-15s available=?  (not found in index — bad pin?)\n" "$name" "$pinned"
+        drift=1
+        continue
+    fi
+    if [[ "$pinned" == "$avail" ]]; then
+        printf "  %-20s pinned=%-15s OK\n" "$name" "$pinned"
+    else
+        printf "  %-20s pinned=%-15s available=%s  ← upgrade candidate\n" "$name" "$pinned" "$avail"
+        drift=1
+    fi
+done <<< "$LATEST"
+
+echo
+if [[ $drift -eq 0 ]]; then
+    echo "All apk pins current."
+    exit 0
+fi
+echo "At least one pin is behind. Bump the affected lines in $DOCKERFILE,"
+echo "then verify the plugin still builds and integration tests pass on a"
+echo "scratch host before promoting."
+if [[ $STRICT -eq 1 ]]; then exit 1; fi
+exit 0

--- a/test/integration/harness/bridge.go
+++ b/test/integration/harness/bridge.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -130,10 +131,40 @@ func (f *Fixture) startBridge() error {
 	if err := f.bridgeDnsmasq.Start(); err != nil {
 		return fmt.Errorf("start bridge dnsmasq: %w", err)
 	}
-	// Bind takes <50ms in practice but allow a beat for the listen
-	// socket to come up.
-	time.Sleep(200 * time.Millisecond)
+	// Poll the bridge IP's UDP/67 until the bind shows up. We dial
+	// the bridge address rather than INADDR_ANY because the bridge
+	// dnsmasq is `--bind-interfaces`'d to the bridge — it doesn't
+	// take INADDR_ANY, so a parallel listen on 0.0.0.0:67 succeeds
+	// even after the bridge bind has happened. Same shape as
+	// waitDnsmasqReady; symmetric polling avoids the prior 200ms
+	// sleep flaking on slow boxes (I-4 in the 2026-05-05 review).
+	if err := waitBridgeDnsmasqReady(2 * time.Second); err != nil {
+		return fmt.Errorf("bridge dnsmasq did not bind: %w", err)
+	}
 	return nil
+}
+
+// waitBridgeDnsmasqReady polls UDP/67 on the bridge IP until dnsmasq
+// has bound it. Mirrors waitDnsmasqReady but targets the bridge's
+// L3 address (BridgeAddr without the /mask) so it doesn't conflict
+// with the macvlan-fixture dnsmasq that already owns INADDR_ANY:67
+// in this test process.
+func waitBridgeDnsmasqReady(budget time.Duration) error {
+	bridgeIP := net.ParseIP(strings.SplitN(BridgeAddr, "/", 2)[0])
+	if bridgeIP == nil {
+		return fmt.Errorf("invalid BridgeAddr %q", BridgeAddr)
+	}
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: bridgeIP, Port: 67})
+		if err != nil {
+			// Port is taken — dnsmasq has bound it.
+			return nil
+		}
+		_ = conn.Close()
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("bridge dnsmasq did not bind UDP/67 on %s within %v", bridgeIP, budget)
 }
 
 // stopBridge tears down whatever startBridge brought up. Idempotent

--- a/test/integration/harness/container.go
+++ b/test/integration/harness/container.go
@@ -4,7 +4,10 @@ package harness
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"strings"
 	"testing"
@@ -46,15 +49,30 @@ func EnsureImage(ctx context.Context) error {
 		return fmt.Errorf("ImagePull: %w", err)
 	}
 	defer rc.Close()
-	// Drain the stream so the pull completes synchronously.
-	buf := make([]byte, 4096)
+	// Decode each JSON line so a mid-stream {"errorDetail":...} is
+	// surfaced as a real error instead of a silent partial pull
+	// (I-6 in the 2026-05-05 review).
+	dec := json.NewDecoder(rc)
 	for {
-		_, err := rc.Read(buf)
-		if err != nil {
-			break
+		var msg struct {
+			Error       string `json:"error"`
+			ErrorDetail struct {
+				Message string `json:"message"`
+			} `json:"errorDetail"`
+		}
+		if err := dec.Decode(&msg); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("decode pull stream: %w", err)
+		}
+		if msg.Error != "" {
+			return fmt.Errorf("image pull: %s", msg.Error)
+		}
+		if msg.ErrorDetail.Message != "" {
+			return fmt.Errorf("image pull: %s", msg.ErrorDetail.Message)
 		}
 	}
-	return nil
 }
 
 // RunContainer starts a long-lived alpine container attached to the

--- a/test/integration/harness/fixture.go
+++ b/test/integration/harness/fixture.go
@@ -14,12 +14,12 @@
 package harness
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -275,5 +275,5 @@ func IsInPool(ip net.IP) bool {
 	return bytesGE(v4, start) && bytesLE(v4, end)
 }
 
-func bytesGE(a, b net.IP) bool { return strings.Compare(string(a), string(b)) >= 0 }
-func bytesLE(a, b net.IP) bool { return strings.Compare(string(a), string(b)) <= 0 }
+func bytesGE(a, b net.IP) bool { return bytes.Compare(a, b) >= 0 }
+func bytesLE(a, b net.IP) bool { return bytes.Compare(a, b) <= 0 }


### PR DESCRIPTION
## Summary

Applies fixes for the 22 findings filed against milestone v0.8.0 from the 2026-05-05 code-review pass (#69 — #90).

12 commits, organised by area. None of the changes are user-visible behavioural shifts on the documented driver options; the visible deltas are:

- Plugin exits 0 on a clean SIGTERM (was 1, plus a spurious ERROR log line).
- `/Plugin.Health.recovery_failed` now reflects synchronous recovery failures (NetworkInspect / netOptions / endpoint-prelude) in addition to the per-endpoint Start failures it already counted.
- `IsDHCPPlugin` no longer treats arbitrary `*/docker-net-dhcp:*` images as instances of this plugin — only the maintained namespaces (`devplayer0`, `claymore666`).
- 4xx responses log at WARN, not ERROR.
- `go.mod` directive bumped to `go 1.25.9`; govulncheck affected count drops 18 → 2 (the unfixed docker SDK ones).
- New weekly `APK pin drift` workflow + Coverage workflow now reports merged unit-plus-integration totals.

## Issues addressed

Warnings:
- W-1 #69 — go.mod directive 1.25.0 → 1.25.9.
- W-2 #70 — surface sync recovery failures to /Plugin.Health.
- W-3 #71 — filter http.ErrServerClosed in main goroutine.
- W-4 #72 — log netns / netlink / netns Close errors at Debug.
- W-5 #73 — close GetIP info race + busy-loop on EOF.
- W-6 #74 — tighten IsDHCPPlugin regex to known forks.
- W-7 #75 — per-network timeout in recovery loop.
- W-8 #76 — document Plugin.Close shutdown leak boundary.

Info:
- I-1 #77 — defer Close error logging in udhcpc (folded into W-4 commit).
- I-2 #78 — defensive prefix derivation in vethPairNames / subLinkName.
- I-3 #79 — tolerate os.ErrProcessDone in Finish.
- I-4 #80 — poll bridge UDP/67 instead of sleeping 200ms.
- I-5 #81 — bytes.Compare in pool checks.
- I-6 #82 — surface ImagePull errors instead of silent partial pulls.
- I-7 #83 — document DHCPClient.Start non-reentrancy contract.
- I-8 #84 — replace commented deconfig block with rationale (folded into I-9 commit).
- I-9 #85 — delete commented code; keep the rationale.
- I-10 #86 — skip tombstone rewrite when nothing changed.
- I-11 #87 — pin decodeOpts nil-map behaviour.
- I-12 #88 — match JSONErrResponse log level to HTTP status.
- I-13 #89 — weekly apk pin drift workflow.
- I-14 #90 — merge unit + integration coverage in the workflow summary.

Per the workflow contract these issues stay open through the dev cycle and get closed by the eventual v0.8.0 release PR.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./...` and `go vet -tags integration ./...` clean.
- [x] `gofmt -l .` clean.
- [x] `staticcheck ./...` clean.
- [x] `errcheck -ignoretests ./...` clean.
- [x] `go test -race -count=1 ./pkg/...` passes.
- [x] `govulncheck ./...` reports 2 affecting (was 18; remaining are unfixed docker SDK).
- [ ] Integration suite passes on the runner (W-2 / W-7 / I-4 / I-6 are the highest-touch changes for live tests).
- [ ] Coverage workflow run produces the merged section (I-14 needs one live run on the runner to validate the YAML).
- [ ] Weekly `APK pin drift` workflow self-test via workflow_dispatch.