### PR TITLE
Release v0.8.0

### DIFF
--- a/.github/workflows/apk-pin-check.yml
+++ b/.github/workflows/apk-pin-check.yml
@@ -1,0 +1,27 @@
+name: APK pin drift
+
+# Weekly check on the apk pins in the Dockerfile (busybox-extras,
+# iproute2). Surfaces an upgrade signal so a silent upstream change
+# in the udhcpc-shipping busybox doesn't land in plugin builds
+# without the maintainer noticing (I-13 in the 2026-05-05 review).
+#
+# Runs on a Sunday-morning UTC schedule, plus on-demand via the
+# Actions tab. Doesn't fail the workflow on drift — the report in
+# the run log is the actionable artefact.
+
+on:
+  schedule:
+    - cron: '7 6 * * 0'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check apk pins
+        run: bash scripts/check-apk-pins.sh

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,12 +15,6 @@ name: Coverage
 # this at all).
 on:
   workflow_dispatch:
-  # TEMPORARY: smoke-test the new tests on this branch. Reverted
-  # before merge to dev. If you see this `push:` trigger anywhere
-  # but on a feature branch, it's a bug.
-  push:
-    branches:
-      - feat/integration-coverage-tests
 
 permissions:
   contents: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,15 @@ name: Coverage
 # this at all).
 on:
   workflow_dispatch:
+  # TEMPORARY: smoke-test this workflow before merge. GitHub's
+  # workflow_dispatch API only sees workflows on the default
+  # branch, so a manual trigger from a feature branch isn't
+  # possible until the file lands on main. Reverted before merge
+  # to dev — if you see this `push:` trigger on dev or main, it's
+  # a bug, not a feature.
+  push:
+    branches:
+      - feat/coverage-harvesting
 
 permissions:
   contents: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -80,6 +80,19 @@ jobs:
           docker plugin disable "${COVER_PLUGIN_REF}" || true
           ls -la "${COVER_DIR}"
 
+      # Run the unit test suite with coverage so the workflow summary
+      # can report unit + integration + merged numbers (I-14 in the
+      # 2026-05-05 review). go test's `-cover -test.gocoverdir` writes
+      # the same binary-coverage format covdata understands, which
+      # lets us merge directly without converting through textfmt.
+      - name: Run unit tests with coverage
+        if: always()
+        run: |
+          mkdir -p coverage-unit
+          go test -count=1 -coverpkg=./... \
+              -args -test.gocoverdir="$PWD/coverage-unit" \
+              ./pkg/... ./cmd/...
+
       - name: Coverage summary
         if: always()
         run: |
@@ -87,10 +100,24 @@ jobs:
             echo "No coverage counter files found — plugin may have crashed before flush."
             exit 1
           fi
-          echo "## Coverage by package" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          go tool covdata percent -i="${COVER_DIR}" | tee -a "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          {
+              echo "## Coverage by package"
+              echo
+              echo "### Integration only"
+              echo '```'
+              go tool covdata percent -i="${COVER_DIR}"
+              echo '```'
+              if ls coverage-unit/covcounters.* >/dev/null 2>&1; then
+                  echo "### Unit only"
+                  echo '```'
+                  go tool covdata percent -i=coverage-unit
+                  echo '```'
+                  echo "### Merged (unit + integration)"
+                  echo '```'
+                  go tool covdata percent -i="${COVER_DIR}",coverage-unit
+                  echo '```'
+              fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Generate coverage reports
         if: always()
@@ -99,7 +126,13 @@ jobs:
             echo "Skipping report generation — no counter files."
             exit 0
           fi
+          # Per-source profiles: integration-only (back-compat), and
+          # merged when unit counters are present.
           go tool covdata textfmt -i="${COVER_DIR}" -o coverage.out
+          if ls coverage-unit/covcounters.* >/dev/null 2>&1; then
+              go tool covdata textfmt -i="${COVER_DIR}",coverage-unit -o coverage-merged.out
+              go tool cover -html=coverage-merged.out -o coverage-merged.html
+          fi
           go tool cover -html=coverage.out -o coverage.html
 
       - name: Upload coverage artifact
@@ -110,6 +143,8 @@ jobs:
           path: |
             coverage.out
             coverage.html
+            coverage-merged.out
+            coverage-merged.html
           if-no-files-found: warn
           retention-days: 30
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,12 @@ name: Coverage
 # this at all).
 on:
   workflow_dispatch:
+  # TEMPORARY: smoke-test the new tests on this branch. Reverted
+  # before merge to dev. If you see this `push:` trigger anywhere
+  # but on a feature branch, it's a bug.
+  push:
+    branches:
+      - feat/integration-coverage-tests
 
 permissions:
   contents: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,15 +15,6 @@ name: Coverage
 # this at all).
 on:
   workflow_dispatch:
-  # TEMPORARY: smoke-test this workflow before merge. GitHub's
-  # workflow_dispatch API only sees workflows on the default
-  # branch, so a manual trigger from a feature branch isn't
-  # possible until the file lands on main. Reverted before merge
-  # to dev — if you see this `push:` trigger on dev or main, it's
-  # a bug, not a feature.
-  push:
-    branches:
-      - feat/coverage-harvesting
 
 permissions:
   contents: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,124 @@
+name: Coverage
+
+# Integration coverage harvesting. Builds a cover-instrumented plugin
+# (`go build -cover -coverpkg=./...`), runs the full integration suite
+# against it, then flushes counter files via `docker plugin disable`
+# and reports per-package coverage + uploads an HTML report.
+#
+# Manual-only (`workflow_dispatch`) — coverage runs cost ~3-5 min on top
+# of the integration suite (cover plugin build + flush + report) and
+# don't gate PR merges. The production gate is `integration.yml`.
+#
+# Same self-hosted runner as integration.yml (gpu1), same security
+# posture (outside-collaborator approval required for forked PRs —
+# though only `workflow_dispatch` is wired here, so forks can't trigger
+# this at all).
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    runs-on: [self-hosted, gpu1]
+    timeout-minutes: 20
+    env:
+      COVER_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:golang-cover
+      COVER_DIR: /var/lib/dh-cover
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify Go toolchain
+        run: |
+          if ! command -v go >/dev/null; then
+            echo "go not in PATH on this runner."
+            echo "Run: sudo bash test/integration/install-go-runner.sh"
+            exit 1
+          fi
+          go version
+
+      - name: Cleanup orphans from previous runs
+        run: bash test/integration/cleanup-orphans.sh
+
+      # Wipe any counter/meta files from a previous coverage run so
+      # `go tool covdata` only sees data from this invocation. The
+      # mkdir is idempotent — first ever run creates it, subsequent
+      # runs no-op.
+      - name: Prepare coverage dir
+        run: |
+          mkdir -p "${COVER_DIR}"
+          rm -f "${COVER_DIR}"/cov*
+
+      # Build the instrumented plugin from the current checkout. We
+      # rebuild every run rather than caching the image: cover builds
+      # are PR-specific (the instrumented binary changes whenever any
+      # tracked .go file does), so a cache here would be a footgun.
+      - name: Build + install cover plugin
+        run: |
+          make plugin-cover
+          docker plugin rm -f "${COVER_PLUGIN_REF}" 2>/dev/null || true
+          docker plugin create "${COVER_PLUGIN_REF}" plugin-cover
+          docker plugin set "${COVER_PLUGIN_REF}" LOG_LEVEL=trace
+          docker plugin enable "${COVER_PLUGIN_REF}"
+
+      # The harness routes everything through INTEGRATION_PLUGIN_REF
+      # (default :golang). Pointing it at :golang-cover makes the
+      # whole suite drive the instrumented plugin.
+      - name: Run integration tests against cover plugin
+        env:
+          INTEGRATION_PLUGIN_REF: ${{ env.COVER_PLUGIN_REF }}
+        run: make integration-test
+
+      # Flush counter files. Go's binary coverage runtime only writes
+      # `covcounters.*` on graceful exit, which `docker plugin disable`
+      # triggers (SIGTERM → plugin shuts down → runtime flushes).
+      # Always-run so even a failing test gets partial coverage.
+      - name: Flush coverage counters
+        if: always()
+        run: |
+          docker plugin disable "${COVER_PLUGIN_REF}" || true
+          ls -la "${COVER_DIR}"
+
+      - name: Coverage summary
+        if: always()
+        run: |
+          if ! ls "${COVER_DIR}"/covcounters.* >/dev/null 2>&1; then
+            echo "No coverage counter files found — plugin may have crashed before flush."
+            exit 1
+          fi
+          echo "## Coverage by package" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          go tool covdata percent -i="${COVER_DIR}" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Generate coverage reports
+        if: always()
+        run: |
+          if ! ls "${COVER_DIR}"/covcounters.* >/dev/null 2>&1; then
+            echo "Skipping report generation — no counter files."
+            exit 0
+          fi
+          go tool covdata textfmt -i="${COVER_DIR}" -o coverage.out
+          go tool cover -html=coverage.out -o coverage.html
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ github.run_id }}
+          path: |
+            coverage.out
+            coverage.html
+          if-no-files-found: warn
+          retention-days: 30
+
+      # Tear down the cover plugin so a follow-up integration.yml run
+      # on the same runner doesn't trip over a stale :golang-cover
+      # reference. The production :golang plugin is untouched.
+      - name: Tear down cover plugin
+        if: always()
+        run: |
+          docker plugin disable "${COVER_PLUGIN_REF}" 2>/dev/null || true
+          docker plugin rm -f "${COVER_PLUGIN_REF}" 2>/dev/null || true
+          rm -f "${COVER_DIR}"/cov*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,9 +92,17 @@ jobs:
       # is built fresh and published with the resolved tag. The Make
       # default PLUGIN_NAME already points at GHCR — passing it
       # explicitly here keeps the workflow self-documenting.
+      #
+      # Each registry gets two pushes: the version tag AND `:latest`,
+      # so consumers can pin (`:v0.8.0`) or just track tip (`:latest`).
+      # docker plugin doesn't support tag aliasing the way regular
+      # images do — every tag is a separate push of the same rootfs.
+      # The Make `create` target rebuilds only the plugin handle, not
+      # the underlying rootfs image, so the second push is fast.
       - name: Push to GHCR
         run: |
           make PLUGIN_NAME="${GHCR_NAME}" PLUGIN_TAG="${{ steps.tag.outputs.tag }}" push
+          make PLUGIN_NAME="${GHCR_NAME}" PLUGIN_TAG="latest" push
 
       # Same plugin to Docker Hub when credentials are present. Make
       # rebuilds the rootfs with the Hub-prefixed name; the underlying
@@ -103,6 +111,7 @@ jobs:
         if: ${{ steps.hub-login.outcome == 'success' }}
         run: |
           make PLUGIN_NAME="${HUB_NAME}" PLUGIN_TAG="${{ steps.tag.outputs.tag }}" push
+          make PLUGIN_NAME="${HUB_NAME}" PLUGIN_TAG="latest" push
 
       # Convenience: print the install incantations operators will use,
       # straight into the workflow summary so the release page links
@@ -113,14 +122,18 @@ jobs:
           {
             echo "## Released ${{ steps.tag.outputs.tag }}"
             echo
+            echo "Each registry receives both \`:${{ steps.tag.outputs.tag }}\` (pin) and \`:latest\` (tip)."
+            echo
             echo "### Install from GHCR"
             echo '```'
             echo "docker plugin install ${GHCR_NAME}:${{ steps.tag.outputs.tag }}"
+            echo "docker plugin install ${GHCR_NAME}:latest"
             echo '```'
             if [ "${{ steps.hub-login.outcome }}" = "success" ]; then
               echo "### Install from Docker Hub"
               echo '```'
               echo "docker plugin install ${HUB_NAME}:${{ steps.tag.outputs.tag }}"
+              echo "docker plugin install ${HUB_NAME}:latest"
               echo '```'
             else
               echo "_Docker Hub push skipped — set DOCKERHUB_USERNAME / DOCKERHUB_TOKEN secrets to enable._"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,11 @@ jobs:
 
     env:
       # GHCR is always pushed. Hub repo only pushed when secrets are set.
+      # Hub uses the shorter `net-dhcp` name (matching upstream's
+      # convention there); GHCR keeps `docker-net-dhcp` to align with
+      # the existing tag history.
       GHCR_NAME: ghcr.io/claymore666/docker-net-dhcp
-      HUB_NAME: claymore666/docker-net-dhcp
+      HUB_NAME: claymore666/net-dhcp
 
     steps:
       - name: Resolve release tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+name: Release
+
+# Build and publish the plugin image on a vX.Y.Z tag push. Pushes to
+# GHCR (always — built-in token) and Docker Hub (when the credentials
+# secrets are configured). Dual-pushing keeps every release reachable
+# from both registries; the README points operators at GHCR but Docker
+# Hub is where most plugin discovery still happens.
+#
+# Trigger shapes:
+#   - `git tag v0.8.0 && git push --tags` → automatic
+#   - GitHub UI → "Run workflow" → enter tag → manual dry-run
+#
+# Required secrets (Settings → Secrets and variables → Actions):
+#   - DOCKERHUB_USERNAME — Docker Hub login (e.g. `claymore666`)
+#   - DOCKERHUB_TOKEN    — Docker Hub access token (NOT password)
+# If absent, the Hub step skips with a warning instead of failing.
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.8.0). Must already exist on the remote."
+        required: true
+
+permissions:
+  contents: read
+  packages: write   # GHCR push needs this on GITHUB_TOKEN
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      # GHCR is always pushed. Hub repo only pushed when secrets are set.
+      GHCR_NAME: ghcr.io/claymore666/docker-net-dhcp
+      HUB_NAME: claymore666/docker-net-dhcp
+
+    steps:
+      - name: Resolve release tag
+        id: tag
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "Tag $TAG does not look like vX.Y.Z; refusing." >&2
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Releasing tag: $TAG"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+          # Full history so RELEASE_NOTES.md credits / "since vX" greps
+          # behave the same as on a developer checkout.
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        id: hub-login
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Warn if Docker Hub credentials missing
+        if: ${{ steps.hub-login.outcome == 'skipped' }}
+        run: |
+          echo "::warning::DOCKERHUB_USERNAME / DOCKERHUB_TOKEN secrets not set — skipping Docker Hub push. GHCR push proceeds normally."
+
+      # Push to GHCR. `make push` chains create → push, so the plugin
+      # is built fresh and published with the resolved tag. The Make
+      # default PLUGIN_NAME already points at GHCR — passing it
+      # explicitly here keeps the workflow self-documenting.
+      - name: Push to GHCR
+        run: |
+          make PLUGIN_NAME="${GHCR_NAME}" PLUGIN_TAG="${{ steps.tag.outputs.tag }}" push
+
+      # Same plugin to Docker Hub when credentials are present. Make
+      # rebuilds the rootfs with the Hub-prefixed name; the underlying
+      # Docker image layer cache is reused so this is cheap.
+      - name: Push to Docker Hub
+        if: ${{ steps.hub-login.outcome == 'success' }}
+        run: |
+          make PLUGIN_NAME="${HUB_NAME}" PLUGIN_TAG="${{ steps.tag.outputs.tag }}" push
+
+      # Convenience: print the install incantations operators will use,
+      # straight into the workflow summary so the release page links
+      # them prominently.
+      - name: Workflow summary
+        if: always()
+        run: |
+          {
+            echo "## Released ${{ steps.tag.outputs.tag }}"
+            echo
+            echo "### Install from GHCR"
+            echo '```'
+            echo "docker plugin install ${GHCR_NAME}:${{ steps.tag.outputs.tag }}"
+            echo '```'
+            if [ "${{ steps.hub-login.outcome }}" = "success" ]; then
+              echo "### Install from Docker Hub"
+              echo '```'
+              echo "docker plugin install ${HUB_NAME}:${{ steps.tag.outputs.tag }}"
+              echo '```'
+            else
+              echo "_Docker Hub push skipped — set DOCKERHUB_USERNAME / DOCKERHUB_TOKEN secrets to enable._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,18 @@ CLAUDE.md
 
 # Local code-review reports — kept on disk for follow-up but not committed
 code-review-report.md
+
+# Credential-shaped files. The release workflow injects Docker Hub /
+# GHCR tokens via repo secrets, never via tracked files; this list
+# stops a stray local `.env` or test `.key` from being `git add .`'d
+# by accident. Add to it rather than removing if a tool needs another
+# extension.
+.env
+.env.*
+*.key
+*.pem
+*.p12
+*.pfx
+.netrc
+secrets/
+credentials/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /bin/*
 !/bin/.gitkeep
 /plugin/
+/plugin-cover/
 /multiarch/
 
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ __pycache__/
 
 # Local-only handoff brief — not part of the project
 CLAUDE.md
+
+# Local code-review reports — kept on disk for follow-up but not committed
+code-review-report.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
 FROM golang:1.25-alpine AS builder
 
+# COVER_FLAGS is empty for the production build and `-cover -coverpkg=./...`
+# for the instrumented build used by the coverage workflow. Keeping the
+# instrumentation behind a build arg means the production image is byte-
+# identical to the unparameterized build — no risk of accidentally shipping
+# a cover-instrumented binary.
+ARG COVER_FLAGS=
+
 WORKDIR /usr/local/src/docker-net-dhcp
 COPY go.* ./
 RUN go mod download
 
 COPY cmd/ ./cmd/
 COPY pkg/ ./pkg/
-RUN mkdir bin/ && go build -o bin/ ./cmd/...
+RUN mkdir bin/ && go build $COVER_FLAGS -o bin/ ./cmd/...
 
 
 FROM alpine:3.20.3@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@ PLATFORMS ?= linux/amd64,linux/arm64
 SOURCES = $(shell find pkg/ cmd/ -name '*.go')
 BINARY = bin/net-dhcp
 
-.PHONY: all debug build create enable disable pdebug push clean integration-test integration-cleanup
+PLUGIN_COVER_TAG ?= golang-cover
+
+.PHONY: all debug build create enable disable pdebug push clean integration-test integration-cleanup \
+        build-cover plugin-cover create-cover enable-cover disable-cover
 
 all: create enable
 
@@ -43,6 +46,38 @@ pdebug: create enable
 push: create
 	docker plugin push $(PLUGIN_NAME):$(PLUGIN_TAG)
 
+# Coverage-instrumented build path. Produces a parallel plugin tagged
+# :golang-cover with `go build -cover` instrumentation. On graceful
+# shutdown the runtime flushes counter files into /coverage inside the
+# plugin namespace, which is bind-mounted from the host's /var/lib/dh-cover
+# (must exist and be writable; create it once with `mkdir -p
+# /var/lib/dh-cover` before the first `make create-cover`).
+#
+# This path is for the integration coverage workflow only — production
+# installs continue to use `make create enable` / the unparameterized
+# image. The two tags coexist on the same host without conflicting.
+build-cover: $(SOURCES)
+	docker build --build-arg COVER_FLAGS="-cover -coverpkg=./..." -t $(PLUGIN_NAME):rootfs-cover .
+
+plugin-cover/rootfs: build-cover
+	mkdir -p plugin-cover/rootfs
+	docker create --name tmp-cover $(PLUGIN_NAME):rootfs-cover
+	docker export tmp-cover | tar xC plugin-cover/rootfs
+	docker rm -vf tmp-cover
+
+plugin-cover: plugin-cover/rootfs config-cover.json
+	cp config-cover.json $@/config.json
+
+create-cover: plugin-cover
+	docker plugin rm -f $(PLUGIN_NAME):$(PLUGIN_COVER_TAG) || true
+	docker plugin create $(PLUGIN_NAME):$(PLUGIN_COVER_TAG) $<
+	docker plugin set $(PLUGIN_NAME):$(PLUGIN_COVER_TAG) LOG_LEVEL=trace
+
+enable-cover:
+	docker plugin enable $(PLUGIN_NAME):$(PLUGIN_COVER_TAG)
+disable-cover:
+	docker plugin disable $(PLUGIN_NAME):$(PLUGIN_COVER_TAG)
+
 multiarch: $(SOURCES)
 	docker buildx build --platform=$(PLATFORMS) -o type=local,dest=$@ .
 
@@ -52,6 +87,7 @@ push-multiarch: multiarch config.json
 clean:
 	-rm -rf multiarch/
 	-rm -rf plugin/
+	-rm -rf plugin-cover/
 	-rm bin/*
 
 # Live integration tests. Need privileges (CAP_NET_ADMIN, mount/netns

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ integration-test:
 		echo "integration-test must run as root. Re-run with sudo."; \
 		exit 1; \
 	fi
-	go test -v -tags integration -count=1 -timeout 5m ./test/integration/...
+	go test -v -tags integration -count=1 -timeout 10m ./test/integration/...
 
 # Manual orphan cleanup for when an integration test panics mid-setup
 # and leaves dh-itest-* interfaces / containers / networks behind.

--- a/README.md
+++ b/README.md
@@ -63,9 +63,26 @@ This fork publishes semver-tagged plugin images on GitHub Container Registry: `g
 
 Currently published architectures: `linux/amd64` only. ARM builds (multi-arch via `scripts/push_multiarch_plugin.py`) are supported by the build pipeline but not currently published — open an issue if you need one.
 
-## Network creation
+## Attachment modes
 
-In order to create a Docker network using `net-dhcp`, you'll need a pre-configured bridge interface on the host. How you
+The plugin supports three attachment modes, selected by the `mode` driver option:
+
+| mode | parent | host changes required |
+| ---- | ------ | --------------------- |
+| `bridge` (default) | a Linux bridge you maintain (`-o bridge=<name>`) | yes — you bring the bridge |
+| `macvlan` | a host NIC (`-o parent=<iface>`) | none |
+| `ipvlan` (L2) | a host NIC (`-o parent=<iface>`) | none |
+
+The bridge-mode walkthrough below is the original upstream flow. For
+macvlan/ipvlan see [`docs/parent-attached-modes.md`](docs/parent-attached-modes.md) — those modes
+attach directly to a host NIC without a bridge and are the right pick
+when you don't want to reconfigure the host's networking. The doc also
+covers DHCP identity (hostname / option 60 / option 61), the
+`/Plugin.Health` endpoint, restart stability, and recovery.
+
+## Network creation (bridge mode)
+
+In order to create a Docker network in bridge mode, you'll need a pre-configured bridge interface on the host. How you
 set this up will depend on your system, but the following (manual) instructions should work on most Linux distros:
 
 ```
@@ -186,6 +203,18 @@ Note:
 
 To read the plugin's log, do `cat /var/lib/docker/plugins/*/rootfs/var/log/net-dhcp.log` (as `root`). You can also use
 `docker plugin set ghcr.io/claymore666/docker-net-dhcp:v0.7.0 LOG_LEVEL=trace` to increase log verbosity.
+
+`/Plugin.Health` exposes liveness and recovery counters as JSON on the plugin's UNIX socket — useful as a monitoring probe. See [`docs/parent-attached-modes.md`](docs/parent-attached-modes.md#health-endpoint) for the payload schema and a sample `curl` invocation.
+
+### Plugin env vars
+
+All three are `docker plugin set`-able and take effect after a `disable && enable` cycle:
+
+| name            | default              | meaning |
+| --------------- | -------------------- | ------- |
+| `LOG_LEVEL`     | `info`               | logrus level. `trace` is the most verbose. |
+| `AWAIT_TIMEOUT` | `10s`                | Cap on the per-endpoint polling helpers (sandbox / link rename / netns appearance). |
+| `STATE_DIR`     | `/var/lib/net-dhcp`  | Where per-network options and the tombstone file are persisted. |
 
 # Implementation
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 >
 > Install:
 > ```bash
-> docker plugin install ghcr.io/claymore666/docker-net-dhcp:v0.7.0
+> docker plugin install ghcr.io/claymore666/docker-net-dhcp:v0.8.0
 > ```
 >
 > All upstream usage below still applies — bridge mode is unchanged and
@@ -41,17 +41,17 @@ handy for home deployment.
 The plugin can be installed with the `docker plugin install` command:
 
 ```
-$ docker plugin install ghcr.io/claymore666/docker-net-dhcp:v0.7.0
-Plugin "ghcr.io/claymore666/docker-net-dhcp:v0.7.0" is requesting the following privileges:
+$ docker plugin install ghcr.io/claymore666/docker-net-dhcp:v0.8.0
+Plugin "ghcr.io/claymore666/docker-net-dhcp:v0.8.0" is requesting the following privileges:
  - network: [host]
  - host pid namespace: [true]
  - mount: [/var/run/docker.sock]
  - capabilities: [CAP_NET_ADMIN CAP_SYS_ADMIN]
 Do you grant the above permissions? [y/N] y
-v0.7.0: Pulling from ghcr.io/claymore666/docker-net-dhcp
+v0.8.0: Pulling from ghcr.io/claymore666/docker-net-dhcp
 Digest: sha256:<some hash>
 <some id>: Complete
-Installed plugin ghcr.io/claymore666/docker-net-dhcp:v0.7.0
+Installed plugin ghcr.io/claymore666/docker-net-dhcp:v0.8.0
 $
 ```
 
@@ -106,13 +106,13 @@ $ sudo dhcpcd my-bridge
 Once the bridge is ready, you can create the network:
 
 ```
-$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.7.0 --ipam-driver null -o bridge=my-bridge my-dhcp-net
+$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.8.0 --ipam-driver null -o bridge=my-bridge my-dhcp-net
 <some network id>
 $
 
 # With IPv6 enabled
 # Although `docker network create` has a `--ipv6` flag, it doesn't work with the null IPAM driver
-$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.7.0 --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
+$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.8.0 --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
 <some network id>
 $
 ```
@@ -173,7 +173,7 @@ services:
       - dhcp
 networks:
   dhcp:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v0.7.0
+    driver: ghcr.io/claymore666/docker-net-dhcp:v0.8.0
     driver_opts:
       bridge: my-bridge
       ipv6: 'true'
@@ -202,7 +202,7 @@ Note:
 ## Debugging
 
 To read the plugin's log, do `cat /var/lib/docker/plugins/*/rootfs/var/log/net-dhcp.log` (as `root`). You can also use
-`docker plugin set ghcr.io/claymore666/docker-net-dhcp:v0.7.0 LOG_LEVEL=trace` to increase log verbosity.
+`docker plugin set ghcr.io/claymore666/docker-net-dhcp:v0.8.0 LOG_LEVEL=trace` to increase log verbosity.
 
 `/Plugin.Health` exposes liveness and recovery counters as JSON on the plugin's UNIX socket — useful as a monitoring probe. See [`docs/parent-attached-modes.md`](docs/parent-attached-modes.md#health-endpoint) for the payload schema and a sample `curl` invocation.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,123 @@ vulnerable code path is reachable from the plugin process, so no
 action is required. Recorded here so future audits don't
 re-investigate. (Original report: third-pass code review, 2026-05-04.)
 
+## v0.8.0
+
+Code-review fix sweep + automated release pipeline. No new features —
+the change set is hardening + tooling. 23 issues closed (the 22
+findings from the 2026-05-05 review pass plus the doc audit).
+
+### Compatibility note
+
+`IsDHCPPlugin` now matches only `devplayer0/docker-net-dhcp:*` and
+`claymore666/docker-net-dhcp:*` (W-6, #74). The previous catch-all
+let any image whose name ended in `docker-net-dhcp:<tag>` claim a
+shared bridge — including third-party images that aren't actually
+this plugin. Forks publishing under another namespace need to add
+their namespace to `driverRegexp` in `pkg/plugin/plugin.go` to keep
+cross-detect working on the same host. No effect for installations
+using the upstream image or this fork's image.
+
+### Robustness
+
+- **Recovery counter** (W-2, #70) — `/Plugin.Health.recovery_failed`
+  now reflects synchronous failures (`NetworkInspect`, `netOptions`,
+  endpoint-prelude) in addition to the per-endpoint Start failures
+  it already counted. Operators paging on `recovery_failed > 0`
+  used to miss those classes.
+- **Per-network recovery timeout** (W-7, #75) — recovery's per-iter
+  Docker calls now use a 3s timeout each instead of sharing the
+  whole 30s recoveryBudget; one stuck `NetworkInspect` no longer
+  starves later networks.
+- **Clean shutdown exit code** (W-3, #71) — `cmd/net-dhcp/main.go`
+  filters `http.ErrServerClosed`, so plugin SIGTERM exits 0 instead
+  of 1 with a spurious ERROR log line.
+- **GetIP race + busy loop** (W-5, #73) — the events-collector
+  goroutine in `udhcpc.GetIP` now hands the final lease back over
+  a buffered channel (proper happens-before instead of a fragile
+  defer-close ordering), and the loop honours channel close
+  via `range` instead of busy-spinning on zero-value receives
+  after the scanner exits.
+- **udhcpc Finish on already-exited child** (I-3, #79) — `Finish`
+  now treats `os.ErrProcessDone` on `Signal` as success and lets
+  `Wait` reap, so a self-exited udhcpc doesn't leave a zombie.
+- **Defensive prefix derivation** (I-2, #78) — `vethPairNames` and
+  `subLinkName` no longer panic on short EndpointIDs; they match
+  `shortID`'s pattern. Production EndpointIDs are 64 hex so this
+  is unreachable today, but recovery on malformed daemon
+  responses is now safe.
+- **Close hygiene** (W-4 / I-1, #72 / #77) — `nsHandle` and netns
+  Close errors land at Debug instead of being silently ignored.
+
+### Logging and ergonomics
+
+- **JSONErrResponse log levels** (I-12, #88) — 5xx logs at Error,
+  4xx logs at Warn, others at Info. Caller-supplied bad input no
+  longer drowns real failures at ERROR.
+- **deconfig handler** (I-9 / I-8, #85 / #84) — the multi-line
+  commented-out deconfig block in `dhcpManager.setupClient` is
+  replaced by a one-paragraph rationale for why deconfig is
+  intentionally not handled (would wipe Join's copied static
+  routes). Git history preserves the original code.
+- **Tombstone prune-on-write** (I-10, #86) — `consumeTombstone`
+  skips the rewrite when the prune produced no change and no
+  consume happened. Saves an fsync per CreateEndpoint on quiet
+  networks.
+- **Plugin.Close shutdown leak boundary** (W-8, #76) — documented.
+  The WaitGroup watcher goroutine's leak on timeout is acceptable
+  for process-exit only; a "do not copy this pattern into
+  long-lived callers" banner now sits next to the code.
+
+### Toolchain
+
+- `go.mod` directive bumped 1.25.0 → 1.25.9 (W-1, #69). Drops
+  `govulncheck` affecting count from 18 → 2 (the remaining two
+  are upstream docker SDK vulns with no fix yet).
+
+### Test surface
+
+- Unit-test pin for `decodeOpts(nil)` behaviour (I-11, #87).
+- Bridge integration fixture polls UDP/67 instead of sleeping 200ms
+  (I-4, #80).
+- `EnsureImage` decodes the pull stream and surfaces errors instead
+  of silently swallowing partial pulls (I-6, #82).
+- Misc style fixes — `bytes.Compare` over string-converted `net.IP`
+  (I-5, #81), `DHCPClient.Start` doc comment on netns thread-locking
+  (I-7, #83).
+
+### CI
+
+- **Coverage** (#90 / I-14) — the manual `Coverage` workflow now runs
+  unit tests with binary-coverage instrumentation and merges them
+  with the integration counters in the workflow summary, plus an
+  HTML artefact for the merged profile. The integration-only output
+  remains for back-compat.
+- **APK pin drift** (#89 / I-13) — new weekly workflow (and ad-hoc
+  `scripts/check-apk-pins.sh`) compares the Dockerfile's pinned
+  `busybox-extras` and `iproute2` versions against the latest in
+  the alpine package index. Reports drift in the workflow log so
+  bumps land on the maintainer's desk without anyone having to
+  remember to look.
+- **Release pipeline** (#93) — new `release.yml` publishes to GHCR
+  (always) and Docker Hub (gated on secrets) on `vX.Y.Z` tag push.
+  Tagging stays a manual decision; the workflow only fires on a
+  tag that already exists.
+
+### Documentation
+
+- `docs/parent-attached-modes.md` updated to current code state
+  (#91): tombstone TTL is 60s (was documented as 10s, stale since
+  v0.6.1); `/Plugin.Health` payload now lists all seven fields
+  with semantics; new sections for DHCP identity (option 12 / 60
+  / 61, the latter previously misdocumented as ipvlan-only) and
+  plugin-restart recovery; env-var reference table covering
+  `LOG_LEVEL`, `AWAIT_TIMEOUT`, `STATE_DIR` (the second was
+  shipping since v0.4.x but never documented).
+- `README.md` gains an Attachment-modes summary with a pointer to
+  the parent-attached doc; the bridge-mode walkthrough is retitled
+  so a reader knows it's mode-specific; debugging section mentions
+  `/Plugin.Health` and the env-var knobs.
+
 ## v0.7.0
 
 Live integration test harness running on every PR via a self-hosted

--- a/cmd/net-dhcp/main.go
+++ b/cmd/net-dhcp/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"flag"
+	"net/http"
 	"os"
 	"os/signal"
 	"sync"
@@ -117,7 +119,12 @@ func main() {
 
 	go func() {
 		log.Info("Starting server...")
-		if err := p.Listen(*bindSock); err != nil {
+		// http.Server.Serve returns http.ErrServerClosed on a clean
+		// Close — that's the success path on SIGTERM, not a failure.
+		// Without this guard the goroutine logs ERROR and os.Exit(1)s
+		// while the main goroutine is still finishing its own clean
+		// shutdown, racing the exit code to 1.
+		if err := p.Listen(*bindSock); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			fatalCleanup(err, "Failed to start plugin")
 		}
 	}()

--- a/config-cover.json
+++ b/config-cover.json
@@ -1,0 +1,74 @@
+{
+    "description": "Docker DHCP networking (host-bridge or macvlan attachment) — coverage-instrumented build",
+    "interface": {
+        "socket": "net-dhcp.sock",
+        "types": [
+            "docker.networkdriver/1.0"
+        ]
+    },
+    "entrypoint": ["/usr/sbin/net-dhcp", "-logfile", "/var/log/net-dhcp.log"],
+    "env": [
+        {
+            "description": "Log level",
+            "name": "LOG_LEVEL",
+            "value": "info",
+            "settable": [
+                "value"
+            ]
+        },
+        {
+            "description": "Timeout while awaiting container/sandbox readiness",
+            "name": "AWAIT_TIMEOUT",
+            "value": "10s",
+            "settable": [
+                "value"
+            ]
+        },
+        {
+            "description": "Directory where per-network options are persisted",
+            "name": "STATE_DIR",
+            "value": "/var/lib/net-dhcp",
+            "settable": [
+                "value"
+            ]
+        },
+        {
+            "description": "Directory where Go binary coverage counters are written on shutdown (cover build only)",
+            "name": "GOCOVERDIR",
+            "value": "/coverage",
+            "settable": [
+                "value"
+            ]
+        }
+    ],
+    "workdir": "/",
+    "network": {
+        "type": "host"
+    },
+    "pidhost": true,
+    "mounts": [
+        {
+            "source": "/var/run/docker.sock",
+            "destination": "/run/docker.sock",
+            "type": "bind",
+            "options": [
+                "bind"
+            ]
+        },
+        {
+            "source": "/var/lib/dh-cover",
+            "destination": "/coverage",
+            "type": "bind",
+            "options": [
+                "bind",
+                "rw"
+            ]
+        }
+    ],
+    "linux": {
+        "capabilities": [
+            "CAP_NET_ADMIN",
+            "CAP_SYS_ADMIN"
+        ]
+    }
+}

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -413,7 +413,7 @@ endpoint operation everything is back to disk-served.
 Override the location via the `STATE_DIR` env var on the plugin:
 
 ```bash
-docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v0.7.0 STATE_DIR=/some/other/path
+docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v0.8.0 STATE_DIR=/some/other/path
 ```
 
 ## Plugin env vars

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -112,12 +112,12 @@ The host's NIC config (IP, routes, netplan/`systemd-networkd`,
 - **ipvlan-specific:** only L2 mode is supported. ipvlan L3 / L3S
   modes are not used because they'd break DHCP (DHCP requires L2
   broadcast).
-- **ipvlan-specific:** the plugin sends a DHCP option 61 client
-  identifier derived from the Docker endpoint ID, so DHCP servers
-  that key on client-id can correctly distinguish multiple ipvlan
-  children on the same parent. If your DHCP server keys solely on
-  MAC and ignores option 61, ipvlan won't work and you should use
-  `mode=macvlan` instead.
+- **ipvlan-specific:** if your DHCP server keys reservations solely
+  on MAC and ignores DHCP option 61 (client identifier), ipvlan
+  won't work as a stability mechanism — every ipvlan slave shares
+  the parent's MAC, so the server has no way to tell them apart.
+  Use `mode=macvlan` if your server is MAC-only. (See "DHCP
+  identity" below for what the plugin sends.)
 - **ipvlan-specific:** only one of macvlan or ipvlan can be active on
   a given parent NIC at a time. The kernel rejects mixing them with
   `EBUSY`. Use one mode per parent.
@@ -268,9 +268,12 @@ fragments the pool.
 
 The mechanism is a short-lived tombstone written at
 `DeleteEndpoint` and consumed at the next `CreateEndpoint` on the
-same network within 10 seconds. It carries the previous MAC and
+same network within 60 seconds. It carries the previous MAC and
 the most-recent leased IP. The next initial DISCOVER passes the
-IP to `udhcpc` as `-r ADDR` (a hint).
+IP to `udhcpc` as `-r ADDR` (a hint). The TTL is generous enough
+to cover both `docker restart <ctr>` (sub-second) and
+`systemctl restart docker` (typically 15–30 s while the daemon
+re-attaches all containers).
 
 - **MAC stability**: works always. `docker inspect` and the LAN
   see the same MAC across restarts.
@@ -284,9 +287,65 @@ IP to `udhcpc` as `-r ADDR` (a hint).
   zuweisen". Once set, every subsequent restart gets that IP.
 
 Concurrent restarts of multiple containers on the same network
-within the 10-second window fall back to fresh MACs to avoid
-swapping identities between containers. Sequential restarts (the
-typical case) always satisfy the rule.
+within the 60-second window fall back to fresh MACs to avoid
+swapping identities between containers. Tombstones also carry the
+container's hostname so that two restarts in flight can be
+told apart when the hostname is known on both sides; only when
+neither side knows the hostname does the network-wide
+"exactly one match" rule apply. Sequential restarts (the typical
+case) always satisfy the rule.
+
+## DHCP identity
+
+Every DHCP exchange the plugin runs on a container's behalf carries
+the same identity fields, regardless of attachment mode:
+
+- **Hostname (option 12)** — taken from the container's
+  `hostname` (Compose `hostname:`, `docker run --hostname`). DHCP
+  servers that auto-update DNS (`dnsmasq` with
+  `--dhcp-hostsfile`, the typical SOHO-router behaviour) will
+  publish the container under that name. Best-effort on the
+  initial DISCOVER (we wait up to 2 s for libnetwork to bind the
+  endpoint to a container ID); the persistent renewal client
+  always sends it.
+- **Vendor class (option 60)** — the literal string
+  `docker-net-dhcp`. Lets DHCP servers gate behaviour (e.g. a
+  separate pool for plugin-managed containers) without parsing
+  hostname conventions. v4 only — DHCPv6 has no equivalent.
+- **Client identifier (option 61)** — eight bytes derived from
+  the Docker endpoint ID, prefixed by the type byte 0
+  (per-client opaque, RFC 2132). Stable across container
+  restarts on the same network because the EndpointID is —
+  meaning DHCP servers that key reservations on option 61
+  (rather than MAC) keep handing the same lease back. This is
+  the mechanism that makes ipvlan stability work, since every
+  ipvlan slave shares the parent's MAC; for macvlan and bridge
+  it's a redundant safety net.
+
+## Plugin-restart recovery
+
+`docker plugin disable && enable`, plugin upgrade, and plugin
+crashes used to leave running containers on the plugin's networks
+without a renewal client — the lease would silently expire and
+the container would lose its IP.
+
+The plugin now walks Docker's network list at startup, finds the
+endpoints attached to plugin-served networks, and rebuilds an
+in-memory DHCP manager for each. The first `udhcpc` call uses
+`-r LAST_IP` so the upstream server ACKs the lease the container
+is already using rather than handing out a fresh address.
+
+Recovery runs synchronously inside `NewPlugin` before the plugin
+socket starts accepting requests, so a fresh `CreateEndpoint`
+arriving during enable can't race the recovery path. Per-endpoint
+results land on `/Plugin.Health` as `recovered_ok` / `recovery_failed`.
+
+The same recovery path also covers `systemctl restart docker` —
+the daemon brings every plugin back as part of its startup. In
+practice MAC/IP is preserved either via this path (when the
+daemon's graceful shutdown didn't get to call `Leave`) or via the
+tombstone path (when it did), and both produce the same
+user-visible outcome.
 
 ## Health endpoint
 
@@ -297,9 +356,31 @@ typical case) always satisfy the rule.
   "healthy": true,
   "uptime_seconds": 12345.6,
   "active_endpoints": 3,
-  "pending_hints": 0
+  "pending_hints": 0,
+  "recovered_ok": 0,
+  "recovery_failed": 0,
+  "tombstone_write_failures": 0
 }
 ```
+
+Field meanings:
+
+- `healthy` — `false` when at least one of `recovery_failed` or
+  `tombstone_write_failures` is non-zero. The plugin keeps serving
+  fresh attaches in either case, but `false` means an operator
+  should look: a recovery failure means a previously-attached
+  container is now running without lease renewal, and a tombstone
+  write failure means the next restart of some container will pick
+  a fresh MAC/IP rather than inheriting the previous one.
+- `active_endpoints` — count of DHCP managers currently registered
+  (post-`Join`, pre-`Leave`).
+- `pending_hints` — count of `joinHint` entries waiting to be
+  consumed by a `Join` (steady-state should be ~0).
+- `recovered_ok` / `recovery_failed` — counters bumped by the
+  plugin-restart recovery path (running endpoints rebuilt vs.
+  endpoints whose rebuild failed).
+- `tombstone_write_failures` — counter bumped on any
+  `addTombstone` save failure (disk full, EROFS, etc.).
 
 Sample call from a host shell:
 
@@ -334,3 +415,14 @@ Override the location via the `STATE_DIR` env var on the plugin:
 ```bash
 docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v0.7.0 STATE_DIR=/some/other/path
 ```
+
+## Plugin env vars
+
+All settable via `docker plugin set <ref> KEY=VALUE`. None require a
+plugin restart — `docker plugin disable && enable` picks them up.
+
+| name            | default            | meaning |
+| --------------- | ------------------ | ------- |
+| `LOG_LEVEL`     | `info`             | logrus level (`trace`, `debug`, `info`, `warn`, `error`). `trace` includes per-event udhcpc lines and full HTTP-RPC bodies. |
+| `AWAIT_TIMEOUT` | `10s`              | Cap on the polling helpers (waits for sandbox readiness, container hostname lookup, link rename, netns appearance). Bump if a slow Docker restore window starves the per-endpoint Start. |
+| `STATE_DIR`     | `/var/lib/net-dhcp` | Where per-network options and the tombstone file live. Override if you want them on a tmpfs or a different volume. |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devplayer0/docker-net-dhcp
 
-go 1.25.0
+go 1.25.9
 
 require (
 	github.com/docker/docker v28.4.0+incompatible

--- a/pkg/plugin/api_handlers_test.go
+++ b/pkg/plugin/api_handlers_test.go
@@ -322,6 +322,23 @@ func TestDecodeOpts_NilInput(t *testing.T) {
 	}
 }
 
+// TestDecodeOpts_NilUnderGenericKey pins the behaviour for the case
+// where the libnetwork payload has the generic key present but with a
+// nil value (rare but reachable via the docker API). decodeOpts must
+// return zero options without error — validateModeOptions then catches
+// the missing-bridge / missing-parent case downstream. Pinned by I-11
+// in the 2026-05-05 review.
+func TestDecodeOpts_NilUnderGenericKey(t *testing.T) {
+	var nilMap map[string]interface{}
+	opts, err := decodeOpts(nilMap)
+	if err != nil {
+		t.Fatalf("decode(nilMap): %v", err)
+	}
+	if opts.Mode != "" || opts.Bridge != "" || opts.Parent != "" {
+		t.Errorf("zero options expected, got %+v", opts)
+	}
+}
+
 // TestApiCreateNetwork_DecodeOptsError covers the error path where the
 // driver-opts payload itself is shaped wrong (a non-map under the
 // generic key). decodeOpts returns a wrapped mapstructure error which

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -40,6 +40,25 @@ const dhcpClientReapTimeout = 5 * time.Second
 // upstream DHCP server.
 const dhcpClientFinishTimeout = 5 * time.Second
 
+// closeNsHandle / closeNetHandle log close errors at Debug instead of
+// silently dropping them. Cleanup paths can't act on a Close failure
+// (we're already on an error path or shutting down), but a recurring
+// EBADF / EIO here is the breadcrumb a future netns-leak debugging
+// session will want.
+func closeNsHandle(h netns.NsHandle) {
+	if err := h.Close(); err != nil {
+		log.WithError(err).Debug("netns handle close failed")
+	}
+}
+func closeNetHandle(h *netlink.Handle) {
+	if h == nil {
+		return
+	}
+	// netlink.Handle.Close has no return value; the wrapper exists
+	// for symmetry with closeNsHandle so call sites read uniformly.
+	h.Close()
+}
+
 type dhcpManager struct {
 	docker  *docker.Client
 	joinReq JoinRequest
@@ -273,25 +292,13 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 					return
 				}
 				switch event.Type {
-				// TODO: We can't really allow the IP in the container to be deleted, it'll delete some of our previously
-				// copied routes. Should this be handled somehow?
-				//case "deconfig":
-				//	ip := m.LastIP
-				//	if v6 {
-				//		ip = m.LastIPv6
-				//	}
-
-				//	log.
-				//		WithFields(m.logFields(v6)).
-				//		WithField("ip", ip).
-				//		Info("udhcpc deconfiguring, deleting previously acquired IP")
-				//	if err := m.netHandle.AddrDel(m.ctrLink, ip); err != nil {
-				//		log.
-				//			WithError(err).
-				//			WithFields(m.logFields(v6)).
-				//			WithField("ip", ip).
-				//			Error("Failed to delete existing udhcpc address")
-				//	}
+				// "deconfig" is intentionally not handled. Deleting the
+				// container's IP from the kernel would also wipe the
+				// static routes Join copied off the host bridge, and
+				// there's no clean way to re-derive them without
+				// re-running the bridge route copy. Better to keep
+				// the stale address until the next bound/renew
+				// overwrites it.
 				case "bound":
 					// The persistent client's first DHCPACK can land
 					// on a different IP than CreateEndpoint's initial
@@ -441,7 +448,7 @@ func (m *dhcpManager) Start(ctx context.Context) (err error) {
 
 	m.netHandle, err = netlink.NewHandleAt(m.nsHandle)
 	if err != nil {
-		m.nsHandle.Close()
+		closeNsHandle(m.nsHandle)
 		return fmt.Errorf("failed to open netlink handle in sandbox namespace: %w", err)
 	}
 
@@ -464,8 +471,8 @@ func (m *dhcpManager) Start(ctx context.Context) (err error) {
 
 		return nil
 	}(); err != nil {
-		m.netHandle.Close()
-		m.nsHandle.Close()
+		closeNetHandle(m.netHandle)
+		closeNsHandle(m.nsHandle)
 		return err
 	}
 
@@ -486,12 +493,12 @@ func (m *dhcpManager) Stop() error {
 	// value emits a noisy EBADF.
 	defer func() {
 		if m.nsHandle.IsOpen() {
-			m.nsHandle.Close()
+			closeNsHandle(m.nsHandle)
 		}
 	}()
 	defer func() {
 		if m.netHandle != nil {
-			m.netHandle.Close()
+			closeNetHandle(m.netHandle)
 		}
 	}()
 

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -216,8 +216,18 @@ func (p *Plugin) DeleteNetwork(r DeleteNetworkRequest) error {
 	return nil
 }
 
+// vethPairNames derives the host-side and container-side veth names from
+// an endpoint ID. Docker EndpointIDs are 64 hex chars in production, but
+// recovery / malformed daemon responses can in principle hand us a
+// shorter ID — same defensive shape as shortID. The pair-uniqueness
+// guarantee is weakened in that case (two short IDs sharing a prefix
+// would collide), but the function won't panic.
 func vethPairNames(id string) (string, string) {
-	return "dh-" + id[:12], id[:12] + "-dh"
+	prefix := id
+	if len(id) > 12 {
+		prefix = id[:12]
+	}
+	return "dh-" + prefix, prefix + "-dh"
 }
 
 // parseExplicitV4 extracts the bare IPv4 address from an optional

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -30,8 +30,13 @@ import (
 // subLinkName returns the host-side child link name for an endpoint.
 // Mirrors the prefix used for the bridge-mode veth so existing log/diag
 // patterns still apply. Used for both macvlan and ipvlan children.
+// Defensive against short IDs (see vethPairNames) — never panics.
 func subLinkName(endpointID string) string {
-	return "dh-" + endpointID[:12]
+	prefix := endpointID
+	if len(endpointID) > 12 {
+		prefix = endpointID[:12]
+	}
+	return "dh-" + prefix
 }
 
 // validateParentForChild ensures the parent NIC exists, is up, and is

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -59,6 +59,14 @@ const initialDHCPHostnameLookupTimeout = 2 * time.Second
 // recovery_failed on /Plugin.Health.
 const recoveryBudget = 30 * time.Second
 
+// recoveryPerNetworkTimeout caps each individual NetworkInspect /
+// netOptions Docker round-trip during recovery. Without it (W-7 in
+// the 2026-05-05 review) one stuck Docker call could consume the
+// entire recoveryBudget and starve later networks of their chance
+// to recover. Tight on purpose — these are local-socket calls that
+// either return promptly or are wedged.
+const recoveryPerNetworkTimeout = 3 * time.Second
+
 // clientIDFromEndpoint derives a stable DHCP option-61 client identifier
 // from a Docker endpoint ID. Docker's endpoint IDs are 64 hex chars
 // (32 bytes). We take the first 8 bytes — long enough to be unique
@@ -83,12 +91,14 @@ func clientIDFromEndpoint(endpointID string) []byte {
 
 const defaultLeaseTimeout = 10 * time.Second
 
-// driverRegexp matches plugin references that this driver should treat as
-// "another instance of itself" when scanning for bridge conflicts. Upstream
-// pinned this to ghcr.io/devplayer0; we accept any registry namespace as
-// long as the image name and tag are present, so forks published under a
-// different namespace still cross-detect each other on the same host.
-var driverRegexp = regexp.MustCompile(`(^|/)docker-net-dhcp:.+$`)
+// driverRegexp matches plugin references that this driver should treat
+// as "another instance of itself" when scanning for bridge conflicts.
+// Pinned to known maintained namespaces (devplayer0 = upstream,
+// claymore666 = this fork) — broader matching would treat an attacker-
+// controlled image like `evil.example/docker-net-dhcp:bad` as ours and
+// surface spurious "Bridge already in use" errors. New forks that need
+// cross-detection should add their namespace here.
+var driverRegexp = regexp.MustCompile(`(^|/)(devplayer0|claymore666)/docker-net-dhcp:.+$`)
 
 // IsDHCPPlugin checks if a Docker network driver is an instance of this plugin
 func IsDHCPPlugin(driver string) bool {
@@ -381,7 +391,9 @@ func (p *Plugin) consumeTombstone(networkID, hostname string) (mac, ipv4, ipv6 s
 		log.WithError(err).Warn("Failed to load tombstones; treating as empty")
 		return "", "", "", false
 	}
+	preLen := len(ts)
 	ts = pruneTombstones(ts)
+	pruned := len(ts) != preLen
 	matchIdx := -1
 	matches := 0
 	for i, t := range ts {
@@ -398,12 +410,13 @@ func (p *Plugin) consumeTombstone(networkID, hostname string) (mac, ipv4, ipv6 s
 		matches++
 		matchIdx = i
 	}
-	// Always rewrite to persist the prune, even if we don't consume.
 	if matches != 1 {
 		// More than one match → ambiguous. Drop *all* matches so the
 		// next consumeTombstone for this network/hostname doesn't keep
 		// hitting the same poisoned set for the rest of the TTL window.
-		// Zero matches is harmless; the prune still gets persisted.
+		// Zero matches is harmless; the prune still gets persisted iff
+		// it changed something.
+		dirty := pruned
 		if matches > 1 {
 			kept := ts[:0]
 			for _, t := range ts {
@@ -417,9 +430,15 @@ func (p *Plugin) consumeTombstone(networkID, hostname string) (mac, ipv4, ipv6 s
 				kept = append(kept, t)
 			}
 			ts = kept
+			dirty = true
 		}
-		if err := saveTombstones(ts); err != nil {
-			log.WithError(err).Debug("Failed to persist pruned tombstones")
+		// Skip the rewrite when nothing changed (I-10 in the
+		// 2026-05-05 review): the common no-op consume on a quiet
+		// network used to fsync a file write per CreateEndpoint.
+		if dirty {
+			if err := saveTombstones(ts); err != nil {
+				log.WithError(err).Debug("Failed to persist pruned tombstones")
+			}
 		}
 		return "", "", "", false
 	}
@@ -446,29 +465,47 @@ func (p *Plugin) consumeTombstone(networkID, hostname string) (mac, ipv4, ipv6 s
 // so the upstream DHCP server can ACK the lease the container is
 // already using rather than handing out a fresh one.
 func (p *Plugin) recoverEndpoints(ctx context.Context) {
+	// recordSyncFailure bumps both the local counter (used for the
+	// summary log line) and the atomic surfaced on /Plugin.Health.
+	// The async Start failure path bumps p.recoveryFailed directly;
+	// without this, NetworkInspect / netOptions / recoverOneEndpoint
+	// failures would only show up in the log line and not on the
+	// health endpoint operators page on (W-2 in the 2026-05-05 review).
+	var recovered, failed int
+	recordSyncFailure := func() {
+		failed++
+		p.recoveryFailed.Add(1)
+	}
 	nets, err := p.docker.NetworkList(ctx, dNetwork.ListOptions{})
 	if err != nil {
 		log.WithError(err).Warn("recovery: failed to list networks; skipping")
+		// We don't know how many endpoints we missed; at least flip
+		// Healthy=false so an operator notices.
+		p.recoveryFailed.Add(1)
 		return
 	}
-	var recovered, failed int
 	for _, n := range nets {
 		if !IsDHCPPlugin(n.Driver) {
 			continue
 		}
+		// Per-network bounded ctx so a single hung NetworkInspect /
+		// netOptions doesn't consume the whole recoveryBudget.
+		netCtx, netCancel := context.WithTimeout(ctx, recoveryPerNetworkTimeout)
 		// Re-fetch with full container details (NetworkList is summary-only).
-		netInfo, err := p.docker.NetworkInspect(ctx, n.ID, dNetwork.InspectOptions{})
+		netInfo, err := p.docker.NetworkInspect(netCtx, n.ID, dNetwork.InspectOptions{})
 		if err != nil {
+			netCancel()
 			log.WithError(err).WithField("network", shortID(n.ID)).
 				Warn("recovery: NetworkInspect failed; skipping")
-			failed++
+			recordSyncFailure()
 			continue
 		}
-		opts, err := p.netOptions(ctx, n.ID)
+		opts, err := p.netOptions(netCtx, n.ID)
+		netCancel()
 		if err != nil {
 			log.WithError(err).WithField("network", shortID(n.ID)).
 				Warn("recovery: failed to load network options; skipping")
-			failed++
+			recordSyncFailure()
 			continue
 		}
 		for cid, info := range netInfo.Containers {
@@ -484,7 +521,7 @@ func (p *Plugin) recoverEndpoints(ctx context.Context) {
 					"network":  shortID(n.ID),
 					"endpoint": shortID(info.EndpointID),
 				}).Warn("recovery: endpoint recovery failed")
-				failed++
+				recordSyncFailure()
 				continue
 			}
 			recovered++
@@ -778,6 +815,14 @@ func (p *Plugin) Close() error {
 		}
 		// Bound wall time: we can't let one wedged udhcpc hold up the
 		// whole shutdown.
+		//
+		// Known leak (W-8 in the 2026-05-05 review): if the timeout
+		// fires before wg.Wait returns, the watcher goroutine and any
+		// stuck Stop() calls live on until the OS reaps the process.
+		// That's acceptable here because Close runs at process exit
+		// — but DO NOT copy this pattern into a long-lived caller
+		// (e.g. a future SIGHUP-driven re-attach). For long-lived use,
+		// pass a ctx into Stop and have it abort cleanly on cancel.
 		done := make(chan struct{})
 		go func() { wg.Wait(); close(done) }()
 		select {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -17,8 +17,14 @@ func TestIsDHCPPlugin(t *testing.T) {
 		{"ghcr.io/devplayer0/docker-net-dhcp:release-linux-amd64", true},
 		{"ghcr.io/claymore666/docker-net-dhcp:v0.4.0", true},
 		{"ghcr.io/claymore666/docker-net-dhcp:latest", true},
-		{"someregistry.example/team/docker-net-dhcp:1.0", true},
-		{"docker-net-dhcp:local", true},
+
+		// Foreign namespaces are deliberately rejected — see W-6 in the
+		// 2026-05-05 review. A broader regex would let a third-party
+		// image masquerade as an instance of this plugin and trigger
+		// spurious bridge-conflict errors.
+		{"someregistry.example/team/docker-net-dhcp:1.0", false},
+		{"docker-net-dhcp:local", false},
+		{"evil.example/docker-net-dhcp:bad", false},
 
 		{"bridge", false},
 		{"macvlan", false},

--- a/pkg/udhcpc/client.go
+++ b/pkg/udhcpc/client.go
@@ -7,8 +7,10 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"runtime"
 	"syscall"
@@ -161,7 +163,20 @@ func NewDHCPClient(iface string, opts *DHCPClientOptions) (*DHCPClient, error) {
 	return c, nil
 }
 
-// Start starts udhcpc(6)
+// Start starts udhcpc(6).
+//
+// Concurrency contract: when Opts.Namespace is non-empty, Start enters
+// the target netns by locking the calling goroutine to its OS thread,
+// switching netns, spawning the child, and switching back. It is *not*
+// re-entrant on the same goroutine (a nested Start on the same g would
+// double-LockOSThread). Concurrent Starts on *different* goroutines
+// are safe — each goroutine flips its own thread independently.
+//
+// On netns-restore failure the calling thread is deliberately leaked
+// (a second LockOSThread pins it so Go's runtime won't reuse it for
+// other goroutines). That's the safer choice than letting the wrong-
+// netns state leak into the runtime's thread pool — the OS scheduler
+// reaps the thread when the process exits, which is soon enough.
 func (c *DHCPClient) Start() (chan Event, error) {
 	if c.Opts.Namespace != "" {
 		// Lock the OS Thread so we don't accidentally switch namespaces
@@ -172,13 +187,21 @@ func (c *DHCPClient) Start() (chan Event, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to open current network namespace: %w", err)
 		}
-		defer origNS.Close()
+		defer func() {
+			if err := origNS.Close(); err != nil {
+				log.WithError(err).Debug("origNS close failed")
+			}
+		}()
 
 		ns, err := netns.GetFromPath(c.Opts.Namespace)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open network namespace `%v`: %w", c.Opts.Namespace, err)
 		}
-		defer ns.Close()
+		defer func() {
+			if err := ns.Close(); err != nil {
+				log.WithError(err).Debug("netns close failed")
+			}
+		}()
 
 		if err := netns.Set(ns); err != nil {
 			return nil, fmt.Errorf("failed to enter network namespace: %w", err)
@@ -232,12 +255,21 @@ func (c *DHCPClient) Start() (chan Event, error) {
 	return events, nil
 }
 
-// Finish sends SIGTERM to udhcpc(6) and waits for it to exit. SIGTERM will not
-// be sent if `Opts.Once` is set.
+// Finish sends SIGTERM to udhcpc(6) and waits for it to exit. SIGTERM
+// will not be sent if `Opts.Once` is set.
 func (c *DHCPClient) Finish(ctx context.Context) error {
 	// If only running to get an IP once, udhcpc will terminate on its own
 	if !c.Opts.Once {
 		if err := c.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+			// The process can self-exit between Start and here (NAK,
+			// parent NIC vanished, netns torn down). os.ErrProcessDone
+			// is the wrapped sentinel for that race; treat as success
+			// and let Wait reap so we don't leak a zombie.
+			if errors.Is(err, os.ErrProcessDone) {
+				log.WithFields(log.Fields{"v6": c.Opts.V6}).
+					Debug("udhcpc already exited before SIGTERM; reaping")
+				return c.Wait(ctx)
+			}
 			return fmt.Errorf("failed to send SIGTERM to udhcpc: %w", err)
 		}
 	}
@@ -268,10 +300,19 @@ func (c *DHCPClient) Wait(ctx context.Context) error {
 	}
 }
 
-// GetIP is a convenience function that runs udhcpc(6) once and returns the IP
-// info obtained. The caller's opts is not mutated — we work on a local copy
-// so a caller that reuses the options struct between persistent and one-shot
-// calls doesn't get its Once flag flipped on.
+// GetIP is a convenience function that runs udhcpc(6) once and returns
+// the IP info obtained. The caller's opts is not mutated — we work on a
+// local copy so a caller that reuses the options struct between persistent
+// and one-shot calls doesn't get its Once flag flipped on.
+//
+// Implementation note (W-5 in the 2026-05-05 review): the previous form
+// shared a `*Info` pointer between the events-collector goroutine and
+// the main goroutine without synchronisation, and busy-looped on the
+// closed events channel because the receive didn't check `ok`. The
+// `range events` loop here drains until the scanner closes the channel,
+// then hands the final lease back through `ch` — which is the
+// happens-before edge between the goroutine's last write and the main
+// goroutine's read.
 func GetIP(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, error) {
 	dummy := Info{}
 
@@ -287,30 +328,35 @@ func GetIP(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, er
 		return dummy, fmt.Errorf("failed to start DHCP client: %w", err)
 	}
 
-	var info *Info
-	done := make(chan struct{})
+	// ch carries the final lease seen, or stays unsent if no
+	// bound/renew event arrived before the scanner closed events.
+	// Buffered=1 so the goroutine never blocks on send.
+	ch := make(chan Info, 1)
 	go func() {
-		for {
-			select {
-			case event := <-events:
-				switch event.Type {
-				case "bound", "renew":
-					info = &event.Data
-				}
-			case <-done:
-				return
+		var last *Info
+		for event := range events {
+			if event.Type == "bound" || event.Type == "renew" {
+				v := event.Data
+				last = &v
 			}
 		}
+		if last != nil {
+			ch <- *last
+		}
+		close(ch)
 	}()
-	defer close(done)
 
 	if err := client.Finish(ctx); err != nil {
 		return dummy, err
 	}
 
-	if info == nil {
-		return dummy, util.ErrNoLease
+	select {
+	case info, ok := <-ch:
+		if !ok {
+			return dummy, util.ErrNoLease
+		}
+		return info, nil
+	case <-ctx.Done():
+		return dummy, ctx.Err()
 	}
-
-	return *info, nil
 }

--- a/pkg/util/json.go
+++ b/pkg/util/json.go
@@ -31,14 +31,31 @@ type jsonError struct {
 	Message string `json:"Err"`
 }
 
-// JSONErrResponse Sends an `error` as a JSON object with a `message` property
+// JSONErrResponse Sends an `error` as a JSON object with a `message`
+// property. Logs at a level matching the HTTP status:
+//
+//   - 5xx -> Error (we did something wrong)
+//   - 4xx -> Warn  (caller did something wrong; not actionable for us)
+//   - other -> Info
+//
+// A torrent of 4xx from a misconfigured client used to land at ERROR,
+// drowning real failures (I-12 in the 2026-05-05 review).
 func JSONErrResponse(w http.ResponseWriter, err error, statusCode int) {
-	log.WithError(err).Error("Error while processing request")
-
-	w.Header().Set("Content-Type", "application/problem+json")
 	if statusCode == 0 {
 		statusCode = ErrToStatus(err)
 	}
+
+	entry := log.WithError(err).WithField("status", statusCode)
+	switch {
+	case statusCode >= 500:
+		entry.Error("Error while processing request")
+	case statusCode >= 400:
+		entry.Warn("Caller error while processing request")
+	default:
+		entry.Info("Non-success response")
+	}
+
+	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(statusCode)
 
 	if encErr := json.NewEncoder(w).Encode(jsonError{err.Error()}); encErr != nil {

--- a/scripts/check-apk-pins.sh
+++ b/scripts/check-apk-pins.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Check the apk version pins in Dockerfile against the current Alpine
+# package index. Prints a diff and exits non-zero when a pin is behind
+# upstream — wire it into a weekly CI cron so an upgrade signal lands
+# on the maintainer's desk without anyone having to remember to look.
+#
+# Pins live in the form `pkg=ver-rN` inside the `apk add --no-cache`
+# block of Dockerfile. We extract the alpine base from the runtime
+# stage's FROM line so the check tracks whatever the Dockerfile
+# actually pins (no separate config to drift).
+#
+# Usage:
+#   bash scripts/check-apk-pins.sh                # human-readable report
+#   bash scripts/check-apk-pins.sh --strict       # exit 1 if any pin is behind
+#
+# Requires: docker, awk, sed.
+
+set -euo pipefail
+
+DOCKERFILE="${DOCKERFILE:-Dockerfile}"
+STRICT=0
+if [[ "${1:-}" == "--strict" ]]; then STRICT=1; fi
+
+# Pull the alpine base off the runtime FROM (the second FROM, after the
+# builder). Greedy match would also catch the golang stage; tail -1 keeps
+# us pinned to the runtime image.
+ALPINE_REF=$(awk '/^FROM alpine:/ {print $2}' "$DOCKERFILE" | tail -n1)
+if [[ -z "$ALPINE_REF" ]]; then
+    echo "could not find FROM alpine: line in $DOCKERFILE" >&2
+    exit 2
+fi
+
+# Pinned packages: lines like `        pkg=ver-rN \` inside the apk block.
+mapfile -t PINS < <(awk '
+    /apk add/ { in_apk = 1; next }
+    in_apk && /=/ {
+        line = $0
+        sub(/^[[:space:]]+/, "", line)
+        sub(/[[:space:]]*\\$/, "", line)
+        if (line ~ /=/) print line
+    }
+    in_apk && !/\\$/ { in_apk = 0 }
+' "$DOCKERFILE")
+
+if [[ "${#PINS[@]}" -eq 0 ]]; then
+    echo "no apk pins found in $DOCKERFILE — nothing to check" >&2
+    exit 0
+fi
+
+echo "Checking apk pins against $ALPINE_REF"
+echo
+
+# Run apk inside the alpine image once and ask for each pinned pkg.
+# `apk policy` lists installed/available versions; we grep for the head
+# of the indexed candidate. Cleaner than parsing the apk index by hand.
+LATEST=$(docker run --rm "$ALPINE_REF" sh -c '
+    apk update -q >/dev/null
+    for p in "$@"; do
+        name="${p%%=*}"
+        printf "%s\t" "$name"
+        apk policy "$name" 2>/dev/null | awk "/^[[:space:]]+[0-9]/ {print \$1; exit}"
+    done
+' -- "${PINS[@]}")
+
+drift=0
+while IFS=$'\t' read -r name avail; do
+    pinned=""
+    for p in "${PINS[@]}"; do
+        if [[ "${p%%=*}" == "$name" ]]; then pinned="${p#*=}"; fi
+    done
+    if [[ -z "$avail" ]]; then
+        printf "  %-20s pinned=%-15s available=?  (not found in index — bad pin?)\n" "$name" "$pinned"
+        drift=1
+        continue
+    fi
+    if [[ "$pinned" == "$avail" ]]; then
+        printf "  %-20s pinned=%-15s OK\n" "$name" "$pinned"
+    else
+        printf "  %-20s pinned=%-15s available=%s  ← upgrade candidate\n" "$name" "$pinned" "$avail"
+        drift=1
+    fi
+done <<< "$LATEST"
+
+echo
+if [[ $drift -eq 0 ]]; then
+    echo "All apk pins current."
+    exit 0
+fi
+echo "At least one pin is behind. Bump the affected lines in $DOCKERFILE,"
+echo "then verify the plugin still builds and integration tests pass on a"
+echo "scratch host before promoting."
+if [[ $STRICT -eq 1 ]]; then exit 1; fi
+exit 0

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -40,11 +40,13 @@ for the umbrella scope. Tests so far:
 - `lifecycle_bridge_test.go` — same, in bridge mode (uses the
   bridge fixture: separate Linux bridge + second dnsmasq on
   192.168.100/24).
-- `lifecycle_ipvlan_test.go` — same, in ipvlan-L2 mode. Currently
-  `t.Skip`'d because broadcast OFFER delivery to the slave doesn't
-  work when the parent is a veth (real LAN parents work — covered
-  by manual smoke testing). Tracked as
-  [#62](https://github.com/claymore666/docker-net-dhcp/issues/62).
+- `lifecycle_ipvlan_test.go` — same, in ipvlan-L2 mode. Active as
+  of v0.7.0 — earlier it was `t.Skip`'d on a veth-parent harness
+  bug (broadcast OFFER didn't reach the slave); resolved in
+  [#62](https://github.com/claymore666/docker-net-dhcp/issues/62)
+  by setting the BROADCAST flag in the udhcpc DISCOVER (`-B`) and
+  skipping the MAC-echo at Join time on ipvlan (the kernel rejects
+  MAC changes on slaves with `EOPNOTSUPP`).
 - `tombstone_restart_test.go` — `docker restart <ctr>` preserves
   MAC + IP via the tombstone mechanism.
 - `concurrency_test.go` — N containers attached simultaneously each
@@ -82,7 +84,9 @@ test.
 The same suite runs on a self-hosted runner for every PR, with the
 **outside-collaborator approval gate** turned on so external PRs
 don't get free root on the runner host. See
-`.github/workflows/integration.yml`.
+`.github/workflows/integration.yml`. A separate manual-only
+`.github/workflows/coverage.yml` runs the same suite against a
+cover-instrumented plugin — see "Coverage harvesting" below.
 
 The workflow assumes the Go toolchain is pre-installed on the
 runner — `actions/setup-go@v5` is skipped to save ~30s/run. If
@@ -140,12 +144,28 @@ answered first.
    leftover `dh-itest-*` interfaces, networks, and the `dnsmasq`
    process if it's still running.
 
-## ipvlan + veth
+## Coverage harvesting
 
-`TestLifecycleIPvlan_GoldenPath` is currently skipped because the
-DHCP `OFFER` (broadcast — see `--dhcp-broadcast` in the fixture)
-doesn't reach the ipvlan slave inside the container netns when the
-parent is a veth. Real hardware NIC parents work fine — that path
-is covered by manual LAN smoke testing. The harness limitation is
-tracked as #62; un-skipping the test once #62 is resolved is the
-acceptance criterion.
+A second workflow, `.github/workflows/coverage.yml`, runs the same
+suite against a `go build -cover -coverpkg=./...` instrumented
+plugin (tag `:golang-cover`) and reports per-package coverage plus
+an HTML report as a workflow artifact. Manual-only
+(`workflow_dispatch`) — coverage runs aren't a PR gate.
+
+Locally:
+
+```sh
+sudo mkdir -p /var/lib/dh-cover && sudo chmod 0777 /var/lib/dh-cover
+make plugin-cover create-cover enable-cover
+sudo INTEGRATION_PLUGIN_REF=ghcr.io/claymore666/docker-net-dhcp:golang-cover make integration-test
+make disable-cover    # flushes counter files
+go tool covdata percent -i=/var/lib/dh-cover
+go tool covdata textfmt -i=/var/lib/dh-cover -o coverage.out
+go tool cover -html=coverage.out -o coverage.html
+```
+
+The plugin runtime emits `covmeta.*` on startup and `covcounters.*`
+on graceful shutdown, so the `disable-cover` step is what actually
+flushes the counters. The cover plugin is a parallel install — it
+coexists with the production `:golang` tag; `make plugin-cover`
+uses an isolated `plugin-cover/` rootfs dir.

--- a/test/integration/harness/bridge.go
+++ b/test/integration/harness/bridge.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -130,10 +131,40 @@ func (f *Fixture) startBridge() error {
 	if err := f.bridgeDnsmasq.Start(); err != nil {
 		return fmt.Errorf("start bridge dnsmasq: %w", err)
 	}
-	// Bind takes <50ms in practice but allow a beat for the listen
-	// socket to come up.
-	time.Sleep(200 * time.Millisecond)
+	// Poll the bridge IP's UDP/67 until the bind shows up. We dial
+	// the bridge address rather than INADDR_ANY because the bridge
+	// dnsmasq is `--bind-interfaces`'d to the bridge — it doesn't
+	// take INADDR_ANY, so a parallel listen on 0.0.0.0:67 succeeds
+	// even after the bridge bind has happened. Same shape as
+	// waitDnsmasqReady; symmetric polling avoids the prior 200ms
+	// sleep flaking on slow boxes (I-4 in the 2026-05-05 review).
+	if err := waitBridgeDnsmasqReady(2 * time.Second); err != nil {
+		return fmt.Errorf("bridge dnsmasq did not bind: %w", err)
+	}
 	return nil
+}
+
+// waitBridgeDnsmasqReady polls UDP/67 on the bridge IP until dnsmasq
+// has bound it. Mirrors waitDnsmasqReady but targets the bridge's
+// L3 address (BridgeAddr without the /mask) so it doesn't conflict
+// with the macvlan-fixture dnsmasq that already owns INADDR_ANY:67
+// in this test process.
+func waitBridgeDnsmasqReady(budget time.Duration) error {
+	bridgeIP := net.ParseIP(strings.SplitN(BridgeAddr, "/", 2)[0])
+	if bridgeIP == nil {
+		return fmt.Errorf("invalid BridgeAddr %q", BridgeAddr)
+	}
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: bridgeIP, Port: 67})
+		if err != nil {
+			// Port is taken — dnsmasq has bound it.
+			return nil
+		}
+		_ = conn.Close()
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("bridge dnsmasq did not bind UDP/67 on %s within %v", bridgeIP, budget)
 }
 
 // stopBridge tears down whatever startBridge brought up. Idempotent

--- a/test/integration/harness/container.go
+++ b/test/integration/harness/container.go
@@ -4,7 +4,10 @@ package harness
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"strings"
 	"testing"
@@ -46,15 +49,30 @@ func EnsureImage(ctx context.Context) error {
 		return fmt.Errorf("ImagePull: %w", err)
 	}
 	defer rc.Close()
-	// Drain the stream so the pull completes synchronously.
-	buf := make([]byte, 4096)
+	// Decode each JSON line so a mid-stream {"errorDetail":...} is
+	// surfaced as a real error instead of a silent partial pull
+	// (I-6 in the 2026-05-05 review).
+	dec := json.NewDecoder(rc)
 	for {
-		_, err := rc.Read(buf)
-		if err != nil {
-			break
+		var msg struct {
+			Error       string `json:"error"`
+			ErrorDetail struct {
+				Message string `json:"message"`
+			} `json:"errorDetail"`
+		}
+		if err := dec.Decode(&msg); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("decode pull stream: %w", err)
+		}
+		if msg.Error != "" {
+			return fmt.Errorf("image pull: %s", msg.Error)
+		}
+		if msg.ErrorDetail.Message != "" {
+			return fmt.Errorf("image pull: %s", msg.ErrorDetail.Message)
 		}
 	}
-	return nil
 }
 
 // RunContainer starts a long-lived alpine container attached to the

--- a/test/integration/harness/fixture.go
+++ b/test/integration/harness/fixture.go
@@ -14,12 +14,12 @@
 package harness
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -275,5 +275,5 @@ func IsInPool(ip net.IP) bool {
 	return bytesGE(v4, start) && bytesLE(v4, end)
 }
 
-func bytesGE(a, b net.IP) bool { return strings.Compare(string(a), string(b)) >= 0 }
-func bytesLE(a, b net.IP) bool { return strings.Compare(string(a), string(b)) <= 0 }
+func bytesGE(a, b net.IP) bool { return bytes.Compare(a, b) >= 0 }
+func bytesLE(a, b net.IP) bool { return bytes.Compare(a, b) <= 0 }

--- a/test/integration/harness/fixture.go
+++ b/test/integration/harness/fixture.go
@@ -234,6 +234,12 @@ func wrapTeardown(err error) error {
 // dnsmasq(8): "expiration_epoch MAC IP hostname client-id".
 func (f *Fixture) LeaseFile() string { return f.leaseFile }
 
+// DnsmasqLog returns the path of the macvlan-fixture dnsmasq log
+// file. Tests that need to assert on the wire conversation (e.g.
+// "did a renewal DHCPACK arrive?") can grep this file directly
+// during the test rather than waiting for the failure-path dump.
+func (f *Fixture) DnsmasqLog() string { return f.dnsmasqLog }
+
 // DumpLogs prints captured dnsmasq stderr to a writer (usually
 // t.Log) so failed tests have the wire-level conversation. Tests
 // should call this from a t.Cleanup with a check for t.Failed().

--- a/test/integration/harness/fixture.go
+++ b/test/integration/harness/fixture.go
@@ -36,11 +36,14 @@ const (
 	// DHCPServerAddr is the static IP on DhcpVeth.
 	DHCPServerAddr = "192.168.99.1/24"
 	// DHCPPoolStart / DHCPPoolEnd / LeaseTime drive dnsmasq's
-	// --dhcp-range. 30s lease is short enough to exercise renewal
-	// in test wall-time without flaking on response delays.
+	// --dhcp-range. 2 minutes is dnsmasq's hard floor — anything
+	// shorter is silently rounded up, which made an earlier "30s"
+	// constant lie about the actual lease. T1 (renewal trigger
+	// inside udhcpc) lands at half-lease = 1m, so renewal-tests
+	// have a ~1m floor on wait time.
 	DHCPPoolStart = "192.168.99.10"
 	DHCPPoolEnd   = "192.168.99.99"
-	LeaseTime     = "30s"
+	LeaseTime     = "2m"
 
 	// SubnetCIDR is what callers expect IP assertions to fall inside.
 	SubnetCIDR = "192.168.99.0/24"

--- a/test/integration/lease_renew_test.go
+++ b/test/integration/lease_renew_test.go
@@ -18,9 +18,10 @@ import (
 // it expires, and that the renewal goes through (DHCPACK from
 // dnsmasq) without disturbing the container's IP.
 //
-// The fixture's lease time is 30s, so T1 (renewal trigger inside
-// udhcpc) fires at 15s. We wait ~22s — well past T1, comfortably
-// before T2 (26.25s) — and assert:
+// The fixture's lease time is 2m (dnsmasq's hard minimum, see
+// LeaseTime in harness/fixture.go), so T1 (renewal trigger inside
+// udhcpc) fires at 1m. We wait ~70s — past T1, well before T2
+// (1m45s) — and assert:
 //   - the container's IP from docker inspect hasn't changed
 //   - dnsmasq's log shows at least 2 DHCPACK lines for our MAC
 //     (one for the initial bind, one for the renewal)
@@ -30,7 +31,7 @@ import (
 // fine, then loses its IP somewhere between T2 and the next operator
 // noticing the connection dropped.
 func TestLeaseRenew_HonorsT1(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Second)
 	defer cancel()
 
 	netName := "dh-itest-renew"
@@ -48,14 +49,14 @@ func TestLeaseRenew_HonorsT1(t *testing.T) {
 
 	startACKs := countDHCPACKs(t, mac)
 
-	// Sleep past T1 (15s) but well before lease expiry (30s). Adding
-	// some slack because udhcpc's renewal jitter and dnsmasq's log
-	// flush aren't instantaneous.
-	t.Log("waiting 22s for lease renewal cycle...")
+	// Sleep past T1 (60s for a 2m lease) but well before T2 (105s)
+	// to keep the assertion clean: the only ACK we expect on top of
+	// the bind is a renewal ACK, not a rebind.
+	t.Log("waiting 70s for lease renewal cycle...")
 	select {
 	case <-ctx.Done():
 		t.Fatalf("context cancelled before renewal window: %v", ctx.Err())
-	case <-time.After(22 * time.Second):
+	case <-time.After(70 * time.Second):
 	}
 
 	// Re-poll inspect: the IP must not have changed during the

--- a/test/integration/lease_renew_test.go
+++ b/test/integration/lease_renew_test.go
@@ -1,0 +1,115 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	docker "github.com/docker/docker/client"
+)
+
+// TestLeaseRenew_HonorsT1 verifies the persistent renewal client the
+// plugin starts in dhcpManager.Start actually renews the lease before
+// it expires, and that the renewal goes through (DHCPACK from
+// dnsmasq) without disturbing the container's IP.
+//
+// The fixture's lease time is 30s, so T1 (renewal trigger inside
+// udhcpc) fires at 15s. We wait ~22s — well past T1, comfortably
+// before T2 (26.25s) — and assert:
+//   - the container's IP from docker inspect hasn't changed
+//   - dnsmasq's log shows at least 2 DHCPACK lines for our MAC
+//     (one for the initial bind, one for the renewal)
+//
+// Without this test, a regression in dhcpManager.renew or the
+// long-lived udhcpc client would be silent: the container starts
+// fine, then loses its IP somewhere between T2 and the next operator
+// noticing the connection dropped.
+func TestLeaseRenew_HonorsT1(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-renew"
+	ctrName := "dh-itest-renew-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+	id, ipBefore, mac := harness.RunContainer(t, ctx, netName, ctrName)
+	t.Logf("initial: ip=%s mac=%s", ipBefore, mac)
+
+	startACKs := countDHCPACKs(t, mac)
+
+	// Sleep past T1 (15s) but well before lease expiry (30s). Adding
+	// some slack because udhcpc's renewal jitter and dnsmasq's log
+	// flush aren't instantaneous.
+	t.Log("waiting 22s for lease renewal cycle...")
+	select {
+	case <-ctx.Done():
+		t.Fatalf("context cancelled before renewal window: %v", ctx.Err())
+	case <-time.After(22 * time.Second):
+	}
+
+	// Re-poll inspect: the IP must not have changed during the
+	// renewal window. Any change here means the renewal client lost
+	// the lease and DISCOVERed a new one.
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+	ins, err := cli.ContainerInspect(ctx, id)
+	if err != nil {
+		t.Fatalf("ContainerInspect: %v", err)
+	}
+	var ipAfter string
+	for _, ep := range ins.NetworkSettings.Networks {
+		ipAfter = ep.IPAddress
+	}
+	if ipAfter != ipBefore {
+		t.Errorf("IP changed during renewal window: before=%s after=%s (renewal client did not preserve lease)", ipBefore, ipAfter)
+	}
+
+	endACKs := countDHCPACKs(t, mac)
+	t.Logf("DHCPACKs for %s: start=%d, after=%d", mac, startACKs, endACKs)
+
+	// The initial bind is one ACK; a renewal is one more. We've
+	// waited past T1, so we expect at least one renewal ACK on top
+	// of the bind. Strictly: endACKs - startACKs >= 1, and total >= 2.
+	if endACKs-startACKs < 1 {
+		t.Errorf("no renewal DHCPACK observed for %s in the 22s wait window — renewal client appears stuck or dnsmasq is not handling the renewal request", mac)
+	}
+	if endACKs < 2 {
+		t.Errorf("expected at least 2 DHCPACKs for %s (bind + renewal), got %d", mac, endACKs)
+	}
+}
+
+// countDHCPACKs reads the macvlan-fixture dnsmasq log and counts
+// "DHCPACK" lines that mention `mac`. dnsmasq emits one ACK line per
+// successful bind/renewal/rebind, so the count is a clean monotonic
+// proxy for "how many times has dnsmasq blessed a request from this
+// MAC". MAC matching is case-insensitive and substring-based — the
+// log format prints lowercase MAC late in the line.
+func countDHCPACKs(t *testing.T, mac string) int {
+	t.Helper()
+	data, err := os.ReadFile(fixture.DnsmasqLog())
+	if err != nil {
+		t.Fatalf("read dnsmasq log: %v", err)
+	}
+	macLower := strings.ToLower(mac)
+	count := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(line, "DHCPACK") && strings.Contains(strings.ToLower(line), macLower) {
+			count++
+		}
+	}
+	return count
+}

--- a/test/integration/static_ip_test.go
+++ b/test/integration/static_ip_test.go
@@ -1,0 +1,122 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	docker "github.com/docker/docker/client"
+)
+
+// TestStaticIP_DriverOpt drives the `--driver-opt ip=<addr>` static-IP
+// override path: the container is connected with an explicit
+// per-endpoint driver opt, and the plugin must propagate that to
+// udhcpc's DHCPDISCOVER as a `requested IP` so dnsmasq hands out the
+// caller-chosen lease rather than picking from the pool.
+//
+// Exercises pkg/plugin/network.go::parseDriverOptIP (whose only
+// not-trivial branch was a 0%-coverage gap in v0.7.0) and
+// resolveExplicitV4 (the agreed-value return path).
+//
+// We pick a host high in the pool (.95) to keep the test reproducible
+// across suite runs: dnsmasq allocates pool entries from the low end
+// upward, and the existing tests rarely consume more than a handful
+// of leases before this test runs.
+func TestStaticIP_DriverOpt(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const (
+		netName = "dh-itest-staticip"
+		ctrName = "dh-itest-staticip-ctr"
+		wantIP  = "192.168.99.95"
+	)
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	t.Cleanup(func() { _ = cli.Close() })
+
+	// Inline a RunContainer-equivalent because the harness helper
+	// doesn't take per-endpoint DriverOpts — the static-IP override
+	// is the only test that needs them so far. Promote to a harness
+	// helper if a second consumer appears.
+	create, err := cli.ContainerCreate(ctx,
+		&container.Config{
+			Image: harness.TestImage,
+			Cmd:   []string{"sleep", "infinity"},
+		},
+		&container.HostConfig{},
+		&network.NetworkingConfig{
+			EndpointsConfig: map[string]*network.EndpointSettings{
+				netName: {
+					DriverOpts: map[string]string{"ip": wantIP},
+				},
+			},
+		},
+		nil,
+		ctrName,
+	)
+	if err != nil {
+		t.Fatalf("ContainerCreate: %v", err)
+	}
+	id := create.ID
+	t.Cleanup(func() {
+		bg := context.Background()
+		_ = cli.ContainerStop(bg, id, container.StopOptions{})
+		_ = cli.ContainerRemove(bg, id, container.RemoveOptions{Force: true})
+	})
+
+	if err := cli.ContainerStart(ctx, id, container.StartOptions{}); err != nil {
+		t.Fatalf("ContainerStart: %v", err)
+	}
+
+	// Poll docker inspect until the endpoint reports the IP we asked
+	// for. If the plugin ignored the driver-opt and let dnsmasq pick,
+	// we'd see a different address from the pool — that's the
+	// regression this test guards against.
+	deadline := time.Now().Add(harness.IPAcquisitionBudget)
+	var gotIP string
+	for time.Now().Before(deadline) {
+		ins, err := cli.ContainerInspect(ctx, id)
+		if err != nil {
+			t.Fatalf("ContainerInspect: %v", err)
+		}
+		for _, ep := range ins.NetworkSettings.Networks {
+			if ep.IPAddress != "" {
+				gotIP = ep.IPAddress
+			}
+		}
+		if gotIP != "" {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if gotIP == "" {
+		t.Fatalf("container never got an IP within %v", harness.IPAcquisitionBudget)
+	}
+	if gotIP != wantIP {
+		t.Errorf("static-IP driver-opt was ignored: requested %s, got %s", wantIP, gotIP)
+	}
+
+	// Inside-container view must agree (truthfulness invariant).
+	out := harness.ExecOutput(t, ctx, id, "ip", "-4", "addr", "show", "eth0")
+	if !strings.Contains(out, wantIP) {
+		t.Errorf("eth0 inside container does not show requested IP %q\nactual:\n%s", wantIP, out)
+	}
+}

--- a/test/integration/static_routes_bridge_test.go
+++ b/test/integration/static_routes_bridge_test.go
@@ -1,0 +1,83 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	"github.com/vishvananda/netlink"
+)
+
+// TestStaticRoutes_BridgeCopiesToContainer verifies the plugin's
+// bridge-mode static-route copy logic in pkg/plugin/network.go
+// addRoutes: every non-default, non-DHCP-subnet, non-kernel-protocol
+// route present on the host bridge at Join time is replicated into
+// the container's netns via res.StaticRoutes.
+//
+// We pre-add a route `192.168.250.0/24 dev dh-itest-br2` on the host
+// bridge before connecting the container, then assert the container's
+// `ip route` lists 192.168.250.0/24 inside its netns.
+//
+// Why this matters operationally: bridge-mode networks bridged to a
+// VLAN trunk often need extra-subnet on-link routes (e.g. management
+// VLANs reachable through the same bridge but not handed out by DHCP).
+// Without this copy, those routes work on the host but vanish inside
+// every container — a silent footgun. The skip_routes=true option is
+// the consumer-facing escape hatch; this test guards the default
+// behaviour.
+func TestStaticRoutes_BridgeCopiesToContainer(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const (
+		netName  = "dh-itest-routes-br"
+		ctrName  = "dh-itest-routes-br-ctr"
+		extraDst = "192.168.250.0/24"
+	)
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			fixture.DumpBridgeLogs(func(s string) { t.Log(s) })
+		}
+	})
+
+	// Add the extra route to the bridge before any container attaches.
+	// Plugin's addRoutes runs at Join time and snapshots the host's
+	// route table for the bridge — a route added after Join wouldn't
+	// land in the container.
+	bridge, err := netlink.LinkByName(harness.BridgeName)
+	if err != nil {
+		t.Fatalf("LinkByName(%s): %v", harness.BridgeName, err)
+	}
+	_, dst, err := net.ParseCIDR(extraDst)
+	if err != nil {
+		t.Fatalf("ParseCIDR: %v", err)
+	}
+	hostRoute := &netlink.Route{
+		LinkIndex: bridge.Attrs().Index,
+		Dst:       dst,
+	}
+	if err := netlink.RouteAdd(hostRoute); err != nil {
+		t.Fatalf("RouteAdd %s dev %s: %v", extraDst, harness.BridgeName, err)
+	}
+	t.Cleanup(func() {
+		if err := netlink.RouteDel(hostRoute); err != nil {
+			t.Logf("WARN: RouteDel %s dev %s: %v", extraDst, harness.BridgeName, err)
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "bridge", nil)
+	id, ipv4, _ := harness.RunContainer(t, ctx, netName, ctrName)
+	t.Logf("container ip=%s", ipv4)
+
+	out := harness.ExecOutput(t, ctx, id, "ip", "route")
+	if !strings.Contains(out, extraDst) {
+		t.Errorf("static route %s not propagated into container netns\ncontainer routes:\n%s", extraDst, out)
+	}
+}


### PR DESCRIPTION
## Summary

v0.8.0 release: code-review fix sweep (22 findings closed) + the doc audit (1) + the new release pipeline.

No new features. Hardening, tooling, and docs. See `RELEASE_NOTES.md` for the full breakdown.

### Operator-visible compatibility note

`IsDHCPPlugin` now matches only `devplayer0/docker-net-dhcp:*` and `claymore666/docker-net-dhcp:*`. Forks publishing under another namespace need to add theirs to `driverRegexp` in `pkg/plugin/plugin.go` to keep cross-detect working on the same host. No effect for the upstream image or this fork's image.

## Closes

Code-review findings:
- Closes #69 (W-1: go.mod 1.25.0 → 1.25.9)
- Closes #70 (W-2: recovery counter)
- Closes #71 (W-3: ErrServerClosed clean shutdown)
- Closes #72 (W-4: Close errcheck)
- Closes #73 (W-5: GetIP race)
- Closes #74 (W-6: IsDHCPPlugin regex tightening)
- Closes #75 (W-7: per-network recovery timeout)
- Closes #76 (W-8: Plugin.Close shutdown leak doc)
- Closes #77 (I-1: udhcpc Close defer hygiene)
- Closes #78 (I-2: defensive prefix derivation)
- Closes #79 (I-3: udhcpc Finish on already-exited child)
- Closes #80 (I-4: bridge fixture polling)
- Closes #81 (I-5: bytes.Compare)
- Closes #82 (I-6: pull-stream errors)
- Closes #83 (I-7: Start non-reentrancy doc)
- Closes #84 (I-8: deconfig design note)
- Closes #85 (I-9: commented code cleanup)
- Closes #86 (I-10: tombstone prune-on-write)
- Closes #87 (I-11: decodeOpts nil test)
- Closes #88 (I-12: log levels)
- Closes #89 (I-13: apk pin drift workflow)
- Closes #90 (I-14: merged coverage)

Doc audit:
- Closes #91 (markdown audit + feature coverage)

Coverage harvesting umbrella:
- Closes #63 (coverage harvesting for the integration suite)

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./...` and `go vet -tags integration ./...` clean.
- [x] `gofmt -l .` clean.
- [x] `staticcheck ./...` clean.
- [x] `errcheck -ignoretests ./...` clean.
- [x] `go test -race -count=1 ./pkg/...` passes.
- [x] `govulncheck ./...` reports 2 affecting (was 18 pre-bump; remaining are upstream docker SDK with no fix).
- [x] Integration suite passed on the runner (per-PR gates on #92).
- [ ] Tag `v0.8.0` after merge → release.yml publishes to GHCR (and Docker Hub if secrets configured).