### PR TITLE
Hotfix: release.yml secrets context in step-level if

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,12 @@ jobs:
       # the existing tag history.
       GHCR_NAME: ghcr.io/claymore666/docker-net-dhcp
       HUB_NAME: claymore666/net-dhcp
+      # Materialize the Docker Hub secrets-presence check at job level
+      # so steps can gate on env (allowed) rather than on the secrets
+      # context directly (rejected at parse time inside step-level
+      # `if:` expressions). Resolves to the literal string "true" or
+      # "false" — compare with `== 'true'` downstream.
+      HAS_HUB_CREDS: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
 
     steps:
       - name: Resolve release tag
@@ -77,14 +83,14 @@ jobs:
 
       - name: Log in to Docker Hub
         id: hub-login
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
+        if: env.HAS_HUB_CREDS == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Warn if Docker Hub credentials missing
-        if: ${{ steps.hub-login.outcome == 'skipped' }}
+        if: env.HAS_HUB_CREDS != 'true'
         run: |
           echo "::warning::DOCKERHUB_USERNAME / DOCKERHUB_TOKEN secrets not set — skipping Docker Hub push. GHCR push proceeds normally."
 
@@ -108,7 +114,7 @@ jobs:
       # rebuilds the rootfs with the Hub-prefixed name; the underlying
       # Docker image layer cache is reused so this is cheap.
       - name: Push to Docker Hub
-        if: ${{ steps.hub-login.outcome == 'success' }}
+        if: env.HAS_HUB_CREDS == 'true'
         run: |
           make PLUGIN_NAME="${HUB_NAME}" PLUGIN_TAG="${{ steps.tag.outputs.tag }}" push
           make PLUGIN_NAME="${HUB_NAME}" PLUGIN_TAG="latest" push
@@ -129,7 +135,7 @@ jobs:
             echo "docker plugin install ${GHCR_NAME}:${{ steps.tag.outputs.tag }}"
             echo "docker plugin install ${GHCR_NAME}:latest"
             echo '```'
-            if [ "${{ steps.hub-login.outcome }}" = "success" ]; then
+            if [ "${HAS_HUB_CREDS}" = "true" ]; then
               echo "### Install from Docker Hub"
               echo '```'
               echo "docker plugin install ${HUB_NAME}:${{ steps.tag.outputs.tag }}"


### PR DESCRIPTION
## Summary

The release workflow's step-level \`if: \${{ secrets.X != '' && secrets.Y != '' }}\` was rejected at parse time:

> Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != ''

GitHub Actions parses every workflow on every push (including branch pushes that don't match the trigger), so this surfaced as silent "failed" runs with no jobs on every dev/main push since #93 merged. **Critically, the v0.8.0 tag push didn't trigger release.yml** — the publish never happened.

## Fix

Materialize the secrets-presence check at job level via env (secrets context IS allowed at job-level env), then gate the Docker Hub steps on \`env.HAS_HUB_CREDS == 'true'\`. Behaviour identical: Hub steps skip cleanly when secrets are absent, GHCR always runs.

## Verification

- \`yaml.safe_load\` accepts the file.
- \`gh workflow run release.yml -f tag=v0.8.0\` previously returned HTTP 422 with the parser error; with this change the dispatch will be accepted.

## Follow-up

After this lands on main: \`gh workflow run release.yml -f tag=v0.8.0 --ref main\` to publish v0.8.0 from the existing tag (no need to re-tag — the tag is already on main, the workflow just needs a valid file to act on it). Then cherry-pick this commit to dev so dev and main stay in sync.

## Test plan

- [x] yaml lints clean.
- [x] No \`secrets.\` references left in step-level \`if:\` expressions (only job-level env and \`with:\` blocks, both allowed).
- [ ] On merge: workflow_dispatch with tag=v0.8.0 runs end-to-end and publishes to GHCR.