### PR TITLE
T2-4: DHCP-wire counters on Plugin.Health

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,8 +29,8 @@ re-investigate. (Original report: third-pass code review, 2026-05-04.)
 ## v0.9.0
 
 DHCP-helper polish: option propagation, parent-attached parity,
-truthfulness counter. Four issues from v0.9.0's Tier 1 closed
-(#100, #101, #102, #104).
+truthfulness counter, DHCP-wire health metrics. Tier 1 (#100,
+#101, #102, #104) plus T2-4 (#107) closed.
 
 ### New driver-opts (opt-in, default off for backwards compatibility)
 
@@ -67,6 +67,16 @@ truthfulness counter. Four issues from v0.9.0's Tier 1 closed
   opened. A deeper fix (forced container restart on lease change,
   or out-of-band docker-socket update) is deferred — see #104 for
   the design discussion.
+- **DHCP-wire counters** (#107) — four new fields on
+  `Plugin.Health`: `leases_obtained`, `leases_renewed`,
+  `dhcp_timeouts`, `lease_release_failures`. Bumped from the
+  persistent client's event loop (`bound`, `renew`, `leasefail`)
+  and from `dhcpManager.Stop`'s `client.Finish` failure branch.
+  Operators alerting on DHCP-side regression no longer have to
+  scrape dnsmasq logs server-side or run the plugin at trace
+  level. Naming intentionally drops the Prometheus `_total`
+  suffix to stay consistent with the existing `Plugin.Health`
+  fields (`recovered_ok`, `tombstone_write_failures`, etc.).
 
 ### Compatibility note
 

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -417,6 +417,9 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 					// hand out a fresh address per DISCOVER even for
 					// the same MAC). Reuse the renew path so LastIP
 					// reflects what's actually in the kernel.
+					if m.plugin != nil {
+						m.plugin.leasesObtained.Add(1)
+					}
 					if err := m.renew(v6, event.Data); err != nil {
 						log.
 							WithError(err).
@@ -429,6 +432,9 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 						WithFields(m.logFields(v6)).
 						Debug("udhcpc renew")
 
+					if m.plugin != nil {
+						m.plugin.leasesRenewed.Add(1)
+					}
 					if err := m.renew(v6, event.Data); err != nil {
 						log.
 							WithError(err).
@@ -438,6 +444,9 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 							Error("Failed to execute IP renewal")
 					}
 				case "leasefail":
+					if m.plugin != nil {
+						m.plugin.dhcpTimeouts.Add(1)
+					}
 					log.WithFields(m.logFields(v6)).Warn("udhcpc failed to get a lease")
 				case "nak":
 					log.WithFields(m.logFields(v6)).Warn("udhcpc client received NAK")
@@ -616,10 +625,21 @@ func (m *dhcpManager) Stop() error {
 	close(m.stopChan)
 
 	if err := <-m.errChan; err != nil {
+		// SIGTERM -> DHCPRELEASE -> exit didn't complete cleanly. The
+		// upstream server may now be holding a phantom lease against
+		// this MAC until its own expiry. Bump so operators can alert
+		// on a pattern of releases failing — typically points at
+		// upstream reachability problems mid-teardown.
+		if m.plugin != nil {
+			m.plugin.leaseReleaseFailures.Add(1)
+		}
 		return fmt.Errorf("failed shut down DHCP client: %w", err)
 	}
 	if m.opts.IPv6 {
 		if err := <-m.errChanV6; err != nil {
+			if m.plugin != nil {
+				m.plugin.leaseReleaseFailures.Add(1)
+			}
 			return fmt.Errorf("failed shut down DHCPv6 client: %w", err)
 		}
 	}

--- a/pkg/plugin/endpoints.go
+++ b/pkg/plugin/endpoints.go
@@ -249,6 +249,16 @@ type HealthResponse struct {
 	// truthfulness-gap discussion), but worth alerting on for
 	// long-running containers.
 	LeaseChanged int32 `json:"lease_changed"`
+
+	// DHCP-wire counters (T2-4). Naming intentionally drops the
+	// Prometheus `_total` suffix to stay consistent with the
+	// existing fields above; the issue's proposal listed them with
+	// `_total` for documentation clarity but the wire field is the
+	// shorter form.
+	LeasesObtained       int32 `json:"leases_obtained"`
+	LeasesRenewed        int32 `json:"leases_renewed"`
+	DHCPTimeouts         int32 `json:"dhcp_timeouts"`
+	LeaseReleaseFailures int32 `json:"lease_release_failures"`
 }
 
 func (p *Plugin) apiHealth(w http.ResponseWriter, r *http.Request) {
@@ -272,5 +282,9 @@ func (p *Plugin) apiHealth(w http.ResponseWriter, r *http.Request) {
 		RecoveryFailed:         failed,
 		TombstoneWriteFailures: tsFails,
 		LeaseChanged:           p.leaseChanged.Load(),
+		LeasesObtained:         p.leasesObtained.Load(),
+		LeasesRenewed:          p.leasesRenewed.Load(),
+		DHCPTimeouts:           p.dhcpTimeouts.Load(),
+		LeaseReleaseFailures:   p.leaseReleaseFailures.Load(),
 	}, http.StatusOK)
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -228,6 +228,25 @@ type Plugin struct {
 	// docker-socket update) lands. See issue #104 for the design
 	// discussion deferred from v0.9.0.
 	leaseChanged atomic.Int32
+
+	// leasesObtained / leasesRenewed / dhcpTimeouts / leaseReleaseFailures
+	// expose DHCP-wire-level counters via /Plugin.Health (T2-4). They
+	// complement the lease_changed signal and let operators alert on
+	// regressions in the DHCP exchange itself without scraping dnsmasq
+	// logs server-side or running the plugin at trace level. Bumped
+	// from dhcpManager:
+	//   - leasesObtained: udhcpc "bound" event — first successful
+	//     DHCPACK on either initial bind or after a NAK / lease loss
+	//   - leasesRenewed: udhcpc "renew" event — a renewal DHCPACK
+	//   - dhcpTimeouts: udhcpc "leasefail" event — discovery / renewal
+	//     hit udhcpc's internal timeout without an OFFER or ACK
+	//   - leaseReleaseFailures: client.Finish returned an error in
+	//     Stop, meaning the SIGTERM-driven DHCPRELEASE didn't complete
+	//     cleanly (timeout, exit code, or pipe closure)
+	leasesObtained       atomic.Int32
+	leasesRenewed        atomic.Int32
+	dhcpTimeouts         atomic.Int32
+	leaseReleaseFailures atomic.Int32
 }
 
 // storeJoinHint records the state collected during CreateEndpoint so

--- a/test/integration/harness/health.go
+++ b/test/integration/harness/health.go
@@ -27,6 +27,10 @@ type HealthResponse struct {
 	RecoveryFailed         int32   `json:"recovery_failed"`
 	TombstoneWriteFailures int32   `json:"tombstone_write_failures"`
 	LeaseChanged           int32   `json:"lease_changed"`
+	LeasesObtained         int32   `json:"leases_obtained"`
+	LeasesRenewed          int32   `json:"leases_renewed"`
+	DHCPTimeouts           int32   `json:"dhcp_timeouts"`
+	LeaseReleaseFailures   int32   `json:"lease_release_failures"`
 }
 
 // PluginSocketPath returns the absolute path to PluginRef's UNIX

--- a/test/integration/health_counters_test.go
+++ b/test/integration/health_counters_test.go
@@ -1,0 +1,123 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	docker "github.com/docker/docker/client"
+)
+
+// TestHealthCounters_ObtainedAndReleased pins the v0.9.0 / T2-4
+// wiring: a clean container lifecycle (create → bound → release →
+// remove) advances /Plugin.Health.leases_obtained by at least one
+// and leaves lease_release_failures unchanged.
+//
+// Inlining ContainerCreate/Start/Stop/Remove instead of using
+// harness.RunContainer because Run defers cleanup via t.Cleanup,
+// which fires after the test body returns — we need the release
+// to happen WITHIN the test so we can take the post-release health
+// snapshot before the assertion.
+func TestHealthCounters_ObtainedAndReleased(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-health-counters"
+	ctrName := "dh-itest-health-counters-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	before, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("Plugin.Health (before): %v", err)
+	}
+	t.Logf("before: leases_obtained=%d leases_renewed=%d dhcp_timeouts=%d lease_release_failures=%d",
+		before.LeasesObtained, before.LeasesRenewed, before.DHCPTimeouts, before.LeaseReleaseFailures)
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+
+	create, err := cli.ContainerCreate(ctx,
+		&container.Config{
+			Image:    harness.TestImage,
+			Cmd:      []string{"sleep", "infinity"},
+			Hostname: ctrName,
+		},
+		&container.HostConfig{},
+		&network.NetworkingConfig{
+			EndpointsConfig: map[string]*network.EndpointSettings{netName: {}},
+		},
+		nil,
+		ctrName,
+	)
+	if err != nil {
+		t.Fatalf("ContainerCreate: %v", err)
+	}
+	id := create.ID
+	t.Cleanup(func() {
+		bg := context.Background()
+		_ = cli.ContainerRemove(bg, id, container.RemoveOptions{Force: true})
+	})
+
+	if err := cli.ContainerStart(ctx, id, container.StartOptions{}); err != nil {
+		t.Fatalf("ContainerStart: %v", err)
+	}
+
+	// Wait for the persistent client's `bound` event — that's what
+	// bumps leases_obtained. CreateEndpoint's initial DISCOVER runs
+	// a one-shot udhcpc that doesn't go through the event handler;
+	// the persistent client started in Join is what we're testing.
+	deadline := time.Now().Add(harness.IPAcquisitionBudget + 5*time.Second)
+	var afterStart *harness.HealthResponse
+	for time.Now().Before(deadline) {
+		h, err := harness.PluginHealth(ctx, cli)
+		if err == nil && h.LeasesObtained > before.LeasesObtained {
+			afterStart = h
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if afterStart == nil {
+		last, _ := harness.PluginHealth(ctx, cli)
+		t.Fatalf("leases_obtained did not advance within %v (before=%d, last seen=%+v)",
+			harness.IPAcquisitionBudget+5*time.Second, before.LeasesObtained, last)
+	}
+	t.Logf("after start: leases_obtained=%d (advanced by %d)",
+		afterStart.LeasesObtained, afterStart.LeasesObtained-before.LeasesObtained)
+
+	// Drive the explicit teardown: ContainerStop -> Leave ->
+	// dhcpManager.Stop -> SIGTERM -> DHCPRELEASE. A clean release
+	// must NOT bump lease_release_failures.
+	if err := cli.ContainerStop(ctx, id, container.StopOptions{}); err != nil {
+		t.Fatalf("ContainerStop: %v", err)
+	}
+	if err := cli.ContainerRemove(ctx, id, container.RemoveOptions{Force: false}); err != nil {
+		t.Fatalf("ContainerRemove: %v", err)
+	}
+
+	after, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("Plugin.Health (after): %v", err)
+	}
+	t.Logf("after teardown: lease_release_failures=%d", after.LeaseReleaseFailures)
+
+	if after.LeaseReleaseFailures != before.LeaseReleaseFailures {
+		t.Errorf("lease_release_failures advanced on a clean teardown: before=%d after=%d",
+			before.LeaseReleaseFailures, after.LeaseReleaseFailures)
+	}
+}


### PR DESCRIPTION
## Summary

Adds four DHCP-wire counters to `/Plugin.Health` alongside the existing `lease_changed` signal:

- `leases_obtained` — udhcpc `bound` event (initial bind or post-NAK re-bind from the persistent client)
- `leases_renewed` — udhcpc `renew` event
- `dhcp_timeouts` — udhcpc `leasefail` event (no OFFER / no ACK in budget)
- `lease_release_failures` — `dhcpManager.Stop`'s `client.Finish` returned an error (SIGTERM → DHCPRELEASE → exit didn't complete cleanly)

Operators alerting on DHCP-side regression no longer have to scrape dnsmasq logs server-side or run the plugin at trace level.

## Naming note

The issue's proposal listed `_total` Prometheus-style suffixes (`leases_obtained_total`, etc.). I dropped the suffix to stay consistent with the existing `Plugin.Health` fields — `recovered_ok`, `tombstone_write_failures`, `lease_changed` all use the shorter form. Mixed naming would be more confusing than the lost convention. Documented in RELEASE_NOTES.

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] Existing unit test `TestRenew_LeaseChangedCounter` still passes (counter wiring uses the same `Plugin` back-reference path)
- [x] New integration test `TestHealthCounters_ObtainedAndReleased`: snapshots `Plugin.Health` before, runs a container, polls until `leases_obtained` advances, drives explicit `ContainerStop`+`ContainerRemove`, asserts `lease_release_failures` did not advance on the clean teardown
- [ ] Full integration suite on the self-hosted runner (CI)

Closes #107.