### PR TITLE
T2-3: configurable DHCP client-id and vendor class

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,8 +29,9 @@ re-investigate. (Original report: third-pass code review, 2026-05-04.)
 ## v0.9.0
 
 DHCP-helper polish: option propagation, parent-attached parity,
-truthfulness counter, DHCP-wire health metrics. Tier 1 (#100,
-#101, #102, #104) plus T2-4 (#107) closed.
+truthfulness counter, DHCP-wire health metrics, configurable
+client-id and vendor class. Tier 1 (#100, #101, #102, #104)
+plus T2-3 (#106) and T2-4 (#107) closed.
 
 ### New driver-opts (opt-in, default off for backwards compatibility)
 
@@ -46,6 +47,21 @@ truthfulness counter, DHCP-wire health metrics. Tier 1 (#100,
   by default because some networks advertise non-standard MTUs for
   reasons unrelated to host capability; opt-in keeps the behaviour
   change visible.
+- **`client_id=<string>`** (#106) — overrides the endpoint-derived
+  DHCP option 61 (Client Identifier) for every endpoint on this
+  network. Bytes go on the wire prefixed with type byte `0x00`
+  (RFC 2132 opaque). Default empty leaves the per-endpoint stable
+  id in place, which is what makes per-container reservations
+  work upstream — operators only set this when class-based DHCP
+  policy demands a known client-id.
+- **`vendor_class=<string>`** (#106) — overrides the default
+  DHCP option 60 (Vendor Class Identifier) value of
+  `docker-net-dhcp`. Lets DHCP servers using class-based policy
+  (Cisco / Aruba / etc.) differentiate net-dhcp containers from
+  other clients on the same LAN, e.g. to issue a different gateway
+  or option set to containers tagged with a known vendor string.
+  Default empty falls back to the historical `docker-net-dhcp`
+  string. v6 unaffected — udhcpc6 doesn't accept the option.
 
 ### Behaviour change (default flipped — see compatibility note)
 

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -351,7 +351,9 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 		Broadcast: m.opts.effectiveMode() == ModeIPvlan,
 		// Same client-id the initial DISCOVER used in CreateEndpoint,
 		// so renewals are seen as the same client by the server.
-		ClientID: clientIDFromEndpoint(m.joinReq.EndpointID),
+		// Honours the operator's client_id override when set.
+		ClientID:    resolveClientID(m.opts, m.joinReq.EndpointID),
+		VendorClass: m.opts.VendorClass,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DHCP%v client: %w", v6Str, err)

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -486,7 +486,7 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 		if opts.LeaseTimeout != 0 {
 			timeout = opts.LeaseTimeout
 		}
-		clientID := clientIDFromEndpoint(r.EndpointID)
+		clientID := resolveClientID(opts, r.EndpointID)
 		initialIP := func(v6 bool) error {
 			v6str := ""
 			if v6 {
@@ -497,9 +497,10 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 			defer cancel()
 
 			clientOpts := &udhcpc.DHCPClientOptions{
-				V6:       v6,
-				Hostname: hostname,
-				ClientID: clientID,
+				V6:          v6,
+				Hostname:    hostname,
+				ClientID:    clientID,
+				VendorClass: opts.VendorClass,
 			}
 			// RequestedIP is v4-only in udhcpc; passing it for v6
 			// would be silently ignored anyway, but keep it explicit.

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -183,7 +183,8 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 		// children can be told apart even though they all share the
 		// parent's MAC). hostname was resolved earlier for tombstone
 		// matching and is reused for the DHCP option 12 hint here.
-		clientID := clientIDFromEndpoint(r.EndpointID)
+		// Operator-supplied client_id overrides the derived value.
+		clientID := resolveClientID(opts, r.EndpointID)
 
 		runDHCP := func(v6 bool) error {
 			v6str := ""
@@ -195,10 +196,11 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 			defer cancel()
 
 			clientOpts := &udhcpc.DHCPClientOptions{
-				V6:        v6,
-				Hostname:  hostname,
-				ClientID:  clientID,
-				Broadcast: mode == ModeIPvlan,
+				V6:          v6,
+				Hostname:    hostname,
+				ClientID:    clientID,
+				VendorClass: opts.VendorClass,
+				Broadcast:   mode == ModeIPvlan,
 			}
 			if !v6 {
 				clientOpts.RequestedIP = requestedIP

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -89,6 +89,19 @@ func clientIDFromEndpoint(endpointID string) []byte {
 	return b
 }
 
+// resolveClientID picks the option-61 payload for a fresh DHCP
+// exchange. Operator-supplied opts.ClientID wins when non-empty
+// (treated as opaque ASCII bytes; the udhcpc client adds the
+// type-byte 0x00 wrapper on the wire). Otherwise we fall back to
+// the endpoint-derived stable id, which is what makes per-container
+// reservations work upstream.
+func resolveClientID(opts DHCPNetworkOptions, endpointID string) []byte {
+	if opts.ClientID != "" {
+		return []byte(opts.ClientID)
+	}
+	return clientIDFromEndpoint(endpointID)
+}
+
 const defaultLeaseTimeout = 10 * time.Second
 
 // driverRegexp matches plugin references that this driver should treat
@@ -135,6 +148,28 @@ type DHCPNetworkOptions struct {
 	// fragments) and silently re-MTU'ing a container could surprise an
 	// operator. Opt-in keeps the behaviour change visible.
 	PropagateMTU bool `mapstructure:"propagate_mtu"`
+	// ClientID, when non-empty, overrides the endpoint-derived DHCP
+	// option 61 (Client Identifier) for every endpoint on this
+	// network. Bytes go on the wire prefixed with type byte 0x00
+	// (RFC 2132 opaque). Default empty = use the stable
+	// per-endpoint id derived from the Docker endpoint ID, which is
+	// what makes per-container reservations work upstream.
+	//
+	// Operator caveat: a static ClientID across containers means the
+	// upstream DHCP server can't differentiate them — each new
+	// container will appear to be the same logical client and may
+	// receive the same lease. Typically only useful when paired with
+	// VendorClass to drive class-based policy that doesn't depend on
+	// per-client identity.
+	ClientID string `mapstructure:"client_id"`
+	// VendorClass, when non-empty, overrides the default DHCP option
+	// 60 (Vendor Class Identifier) value of "docker-net-dhcp" for
+	// every endpoint on this network. Lets DHCP servers using
+	// class-based policy (Cisco / Aruba / etc.) differentiate
+	// net-dhcp containers from other clients on the same LAN —
+	// for example to issue a different gateway or option set to
+	// containers tagged with a known vendor string.
+	VendorClass string `mapstructure:"vendor_class"`
 }
 
 // effectiveMode returns Mode with the empty default normalized to ModeBridge.

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -226,6 +226,38 @@ func TestClientIDFromEndpoint(t *testing.T) {
 	}
 }
 
+// TestResolveClientID pins the v0.9.0 / T2-3 override semantics:
+// operator-supplied opts.ClientID wins over the endpoint-derived
+// stable id, and an empty override falls back to derivation.
+func TestResolveClientID(t *testing.T) {
+	const eid = "0123456789abcdef0123456789abcdef"
+
+	t.Run("override wins", func(t *testing.T) {
+		got := resolveClientID(DHCPNetworkOptions{ClientID: "my-class-id"}, eid)
+		if string(got) != "my-class-id" {
+			t.Errorf("override: got %q, want %q", got, "my-class-id")
+		}
+	})
+
+	t.Run("empty override falls back to derived", func(t *testing.T) {
+		got := resolveClientID(DHCPNetworkOptions{}, eid)
+		want := clientIDFromEndpoint(eid)
+		if string(got) != string(want) {
+			t.Errorf("fallback: got %x, want %x", got, want)
+		}
+	})
+
+	t.Run("override with empty endpoint still works", func(t *testing.T) {
+		// Even if the endpoint id is too short to derive from, an
+		// explicit override should still be honoured. Prevents a
+		// regression where the fallback path swallowed the override.
+		got := resolveClientID(DHCPNetworkOptions{ClientID: "static"}, "")
+		if string(got) != "static" {
+			t.Errorf("override+empty eid: got %q, want %q", got, "static")
+		}
+	})
+}
+
 // TestListen_RemovesStaleSocket covers the I-9 fix: Listen must
 // best-effort unlink any leftover socket file before binding so a
 // previous unclean shutdown doesn't EADDRINUSE the new one. Driving

--- a/pkg/udhcpc/client.go
+++ b/pkg/udhcpc/client.go
@@ -53,6 +53,13 @@ type DHCPClientOptions struct {
 	// stable bytes make sense (typically a hash of the Docker EndpointID).
 	ClientID []byte
 
+	// VendorClass, when non-empty, overrides the default vendor class
+	// identifier (option 60) sent in DHCP requests. Empty falls back
+	// to the package-level VendorID constant ("docker-net-dhcp"), which
+	// is what every callsite used pre-T2-3. Has no effect for V6 — udhcpc6
+	// doesn't accept the -V flag.
+	VendorClass string
+
 	// Broadcast (v4 only) makes udhcpc set the BROADCAST flag in the
 	// DHCPDISCOVER, telling the server to send the OFFER as L2
 	// broadcast rather than unicast to chaddr. Required for ipvlan-L2:
@@ -151,7 +158,11 @@ func NewDHCPClient(iface string, opts *DHCPClientOptions) (*DHCPClient, error) {
 
 	// Vendor ID string option is not available for udhcpc6
 	if !opts.V6 {
-		c.cmd.Args = append(c.cmd.Args, "-V", VendorID)
+		vendor := opts.VendorClass
+		if vendor == "" {
+			vendor = VendorID
+		}
+		c.cmd.Args = append(c.cmd.Args, "-V", vendor)
 	}
 
 	// DHCP option 61 (client identifier). Format on the wire is

--- a/pkg/udhcpc/client_args_test.go
+++ b/pkg/udhcpc/client_args_test.go
@@ -74,6 +74,34 @@ func TestNewDHCPClient_VendorIDv4Only(t *testing.T) {
 	}
 }
 
+// TestNewDHCPClient_VendorClassOverride covers the v0.9.0 / T2-3
+// driver-opt: when DHCPClientOptions.VendorClass is set, that value
+// is sent as -V instead of the package default. Empty VendorClass
+// falls back to VendorID.
+func TestNewDHCPClient_VendorClassOverride(t *testing.T) {
+	custom := "my-corp-vlan"
+
+	c, err := NewDHCPClient("eth0", &DHCPClientOptions{VendorClass: custom})
+	if err != nil {
+		t.Fatalf("NewDHCPClient: %v", err)
+	}
+	if !hasArg(c.cmd.Args, "-V") || !hasArg(c.cmd.Args, custom) {
+		t.Errorf("v4 client with VendorClass=%q should set -V %s; args: %v", custom, custom, c.cmd.Args)
+	}
+	if hasArg(c.cmd.Args, VendorID) {
+		t.Errorf("VendorClass override leaked default %q into args: %v", VendorID, c.cmd.Args)
+	}
+
+	// v6 still must not receive -V even with an override (udhcpc6 rejects it).
+	c6, err := NewDHCPClient("eth0", &DHCPClientOptions{V6: true, VendorClass: custom})
+	if err != nil {
+		t.Fatalf("NewDHCPClient v6: %v", err)
+	}
+	if hasArg(c6.cmd.Args, "-V") {
+		t.Errorf("v6 client must not set -V even with VendorClass override; args: %v", c6.cmd.Args)
+	}
+}
+
 // TestNewDHCPClient_BinarySelection asserts the v4/v6 client process
 // path lookup. Wrong binary name = silent fail-to-spawn; this test
 // catches a refactor that swapped the constants.


### PR DESCRIPTION
## Summary

Two new driver-opts on `docker network create`:

- **`client_id=<string>`** — overrides the endpoint-derived DHCP option 61 (Client Identifier) for every endpoint on this network. Bytes go on the wire prefixed with type byte `0x00` (RFC 2132 opaque). Default empty leaves the per-endpoint stable id derived from the Docker endpoint ID, which is what makes per-container reservations work upstream.
- **`vendor_class=<string>`** — overrides the default DHCP option 60 (Vendor Class Identifier) value of `docker-net-dhcp`. Lets DHCP servers using class-based policy differentiate net-dhcp containers from other clients on the LAN. Default empty falls back to the historical value. v6 unaffected — udhcpc6 doesn't accept `-V`.

## Wiring

Both opts thread through every DHCP-touching path:

- `CreateEndpoint` (initial DISCOVER) in `network.go` and `parent_attached.go`
- `Join` → persistent client in `dhcp_manager.go`
- `recoverEndpoint` (post-restart manager rebuild) — same `opts` flows through

A single `resolveClientID(opts, endpointID)` helper picks the override when set, otherwise falls back to the existing `clientIDFromEndpoint` derivation. `udhcpc.DHCPClientOptions.VendorClass` lets callers override the package-level `VendorID` constant; empty falls back to the constant so existing call sites are untouched.

## Operator caveat (documented in CLAUDE.md / release notes)

A static `client_id` across containers means the DHCP server can't differentiate them — every new container appears to be the same logical client and may receive the same lease. Typically only useful when paired with `vendor_class` to drive class-based policy that doesn't depend on per-client identity.

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] `TestResolveClientID` — override wins, empty falls back to derivation, override + empty endpoint id still honoured
- [x] `TestNewDHCPClient_VendorClassOverride` — v4 sends `-V <custom>`, the default `docker-net-dhcp` does not leak when override is set, v6 still receives no `-V`
- [x] Existing `TestNewDHCPClient_VendorIDv4Only` / `TestClientIDFromEndpoint` still pass
- [ ] Full integration suite on the self-hosted runner (CI)

Closes #106.