### PR TITLE
T2-5: pre-flight DHCP probe at network create time

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,9 +30,9 @@ re-investigate. (Original report: third-pass code review, 2026-05-04.)
 
 DHCP-helper polish: option propagation, parent-attached parity,
 truthfulness counter, DHCP-wire health metrics, configurable
-client-id and vendor class, NTP / search-list / TFTP capture.
-Tier 1 (#100, #101, #102, #104) plus T2-2 (#105), T2-3 (#106)
-and T2-4 (#107) closed.
+client-id and vendor class, NTP / search-list / TFTP capture,
+pre-flight DHCP probe. Tier 1 (#100, #101, #102, #104) plus
+T2-2 (#105), T2-3 (#106), T2-4 (#107) and T2-5 (#108) closed.
 
 ### New driver-opts (opt-in, default off for backwards compatibility)
 
@@ -63,6 +63,17 @@ and T2-4 (#107) closed.
   or option set to containers tagged with a known vendor string.
   Default empty falls back to the historical `docker-net-dhcp`
   string. v6 unaffected — udhcpc6 doesn't accept the option.
+- **`validate_dhcp=true`** (#108) — pre-flight DHCP probe at
+  `docker network create` time. Creates a temporary macvlan child
+  on the parent NIC with a random locally-administered MAC, runs
+  one-shot udhcpc with a 5-second budget, and rejects the network
+  with `no DHCP OFFER on <parent> within 5s` if no server answers.
+  Catches misconfigurations (parent isolated, firewall blocking
+  UDP/67-68, broken VLAN) at create time rather than the first
+  `docker run`. macvlan / ipvlan modes only — bridge mode rejects
+  the opt with a clear error. Cost: one transient lease in the
+  upstream pool per probe (busybox udhcpc has no DISCOVER-only
+  mode); the lease times out naturally.
 
 ### Additional captured DHCP options (#105)
 

--- a/pkg/plugin/dhcp_probe.go
+++ b/pkg/plugin/dhcp_probe.go
@@ -1,0 +1,151 @@
+package plugin
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+
+	"github.com/devplayer0/docker-net-dhcp/pkg/udhcpc"
+	"github.com/devplayer0/docker-net-dhcp/pkg/util"
+)
+
+// preflightProbeBudget caps how long the validate_dhcp probe waits
+// for an OFFER + ACK from the upstream server before declaring the
+// parent NIC unreachable. Five seconds is enough for a healthy LAN
+// (Fritz.Box-class servers respond in under 100ms) plus retry once
+// at udhcpc's default ~3s discover timeout. Tight on purpose: the
+// operator is blocked in `docker network create` while it runs.
+const preflightProbeBudget = 5 * time.Second
+
+// runDHCPProbe verifies that the parent NIC can reach a working DHCP
+// server on the local segment. Implements the validate_dhcp=true
+// driver-opt path:
+//
+//  1. Generate a random locally-administered MAC and a unique probe
+//     link name so the DISCOVER doesn't collide with any stable
+//     upstream reservation, and concurrent probes on the same host
+//     don't fight for the link name.
+//  2. Create a temporary macvlan child of the parent NIC in the host
+//     netns (mode bridge — same submode the production endpoint
+//     uses, so the probe path matches the real path as closely as
+//     possible). ipvlan callers also get macvlan here: ipvlan slaves
+//     share the parent MAC, which would clash with the random probe
+//     MAC, and the probe goal (verifying DHCP reachability of the
+//     parent) is mode-agnostic.
+//  3. Bring it up and run udhcpc.GetIP one-shot with the probe budget.
+//     Busybox has no DISCOVER-only flag; we accept the full DORA and
+//     let the upstream server briefly hold a lease that times out
+//     naturally (no -R sent). The cost is one transient pool entry
+//     per `docker network create -o validate_dhcp=true`.
+//  4. Tear down the macvlan child unconditionally on return.
+//
+// On success returns nil. On failure wraps the underlying error
+// (link-create failed, udhcpc timeout, malformed lease, etc.) with
+// a parent-aware prefix so the operator's docker CLI surfaces a
+// clear "no DHCP OFFER on <parent> within 5s" message instead of
+// the generic CreateNetwork failure shape.
+func runDHCPProbe(ctx context.Context, parent string) error {
+	if parent == "" {
+		return errors.New("validate_dhcp: parent NIC name is empty")
+	}
+	if _, err := netlink.LinkByName(parent); err != nil {
+		return fmt.Errorf("validate_dhcp: parent %q not found: %w", parent, err)
+	}
+
+	probeName, err := newProbeLinkName()
+	if err != nil {
+		return fmt.Errorf("validate_dhcp: name generation: %w", err)
+	}
+	probeMAC, err := newProbeMAC()
+	if err != nil {
+		return fmt.Errorf("validate_dhcp: MAC generation: %w", err)
+	}
+
+	parentLink, err := netlink.LinkByName(parent)
+	if err != nil {
+		return fmt.Errorf("validate_dhcp: relookup parent: %w", err)
+	}
+	la := netlink.NewLinkAttrs()
+	la.Name = probeName
+	la.ParentIndex = parentLink.Attrs().Index
+	la.HardwareAddr = probeMAC
+	probeLink := &netlink.Macvlan{LinkAttrs: la, Mode: netlink.MACVLAN_MODE_BRIDGE}
+
+	if err := netlink.LinkAdd(probeLink); err != nil {
+		return fmt.Errorf("validate_dhcp: create probe macvlan on %q: %w", parent, err)
+	}
+	defer func() {
+		// Best-effort: a failed Del here only leaves a temporary
+		// link the operator can remove with `ip link del`. Logging
+		// at warn so it doesn't silently leak names across runs.
+		if err := netlink.LinkDel(probeLink); err != nil {
+			log.WithError(err).WithField("link", probeName).Warn("validate_dhcp probe link cleanup failed")
+		}
+	}()
+
+	if err := netlink.LinkSetUp(probeLink); err != nil {
+		return fmt.Errorf("validate_dhcp: bring probe link up: %w", err)
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, preflightProbeBudget)
+	defer cancel()
+
+	info, err := udhcpc.GetIP(probeCtx, probeName, &udhcpc.DHCPClientOptions{
+		// Hostname intentionally empty — the probe shouldn't
+		// register any name in the upstream's lease table.
+		// VendorClass / ClientID likewise omitted: the goal is
+		// "is anyone listening?" not "would my real client get a
+		// lease?" — keeping the probe identity-neutral avoids
+		// false negatives when class-based policy denies the
+		// probe but would accept the real container.
+	})
+	if err != nil {
+		if errors.Is(err, util.ErrNoLease) || errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("no DHCP OFFER on %q within %v — parent NIC may be isolated, firewalled (UDP/67-68), or VLAN-tagged wrong", parent, preflightProbeBudget)
+		}
+		return fmt.Errorf("validate_dhcp probe on %q: %w", parent, err)
+	}
+
+	log.
+		WithField("parent", parent).
+		WithField("probe_ip", info.IP).
+		WithField("probe_gateway", info.Gateway).
+		Info("validate_dhcp probe succeeded — DHCP server reachable")
+	return nil
+}
+
+// newProbeLinkName returns a per-probe link name unique enough to
+// avoid collision with concurrent probes on the same host. 6 hex
+// chars after the "dh-probe-" prefix == 3 random bytes (16M-space).
+// Collision odds are negligible at the volume `docker network create`
+// runs. Total length 15 == IFNAMSIZ-1 (Linux's max printable interface
+// name); a longer suffix here would have the kernel refuse LinkAdd.
+func newProbeLinkName() (string, error) {
+	var b [3]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return "dh-probe-" + hex.EncodeToString(b[:]), nil
+}
+
+// newProbeMAC returns a random locally-administered unicast MAC
+// (LAA bit set, multicast bit clear). Avoids collision with any
+// stable upstream reservation: a real device's MAC almost certainly
+// has the LAA bit clear (manufacturer-assigned), so anything in this
+// space is recognisably "ephemeral / synthesised" to network admins
+// who notice it in dnsmasq logs.
+func newProbeMAC() (net.HardwareAddr, error) {
+	mac := make(net.HardwareAddr, 6)
+	if _, err := rand.Read(mac); err != nil {
+		return nil, err
+	}
+	mac[0] = (mac[0] | 0x02) & 0xfe // set LAA bit, clear multicast bit
+	return mac, nil
+}

--- a/pkg/plugin/dhcp_probe_test.go
+++ b/pkg/plugin/dhcp_probe_test.go
@@ -1,0 +1,63 @@
+package plugin
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNewProbeMAC pins the LAA + unicast bit semantics. Stable
+// even though the rest of the bytes are random — the constraint is
+// what avoids collision with any manufacturer-assigned MAC on the
+// upstream's reservation table.
+func TestNewProbeMAC(t *testing.T) {
+	mac, err := newProbeMAC()
+	if err != nil {
+		t.Fatalf("newProbeMAC: %v", err)
+	}
+	if len(mac) != 6 {
+		t.Fatalf("MAC length = %d, want 6", len(mac))
+	}
+	if mac[0]&0x02 != 0x02 {
+		t.Errorf("LAA bit not set on first byte (%#x); upstream may treat this as a manufacturer MAC", mac[0])
+	}
+	if mac[0]&0x01 != 0x00 {
+		t.Errorf("multicast bit set on first byte (%#x); not a valid unicast address", mac[0])
+	}
+
+	// Two consecutive calls must produce different MACs (else the
+	// rand source is broken and probes on different runs would
+	// collide in the dnsmasq lease table).
+	m2, err := newProbeMAC()
+	if err != nil {
+		t.Fatalf("newProbeMAC #2: %v", err)
+	}
+	if mac.String() == m2.String() {
+		t.Errorf("two consecutive newProbeMAC calls returned identical MAC %s — randomness broken", mac)
+	}
+}
+
+// TestNewProbeLinkName guards uniqueness + the dh-probe- prefix that
+// makes orphans easy to spot in `ip link` output if a probe ever
+// fails to clean up.
+func TestNewProbeLinkName(t *testing.T) {
+	a, err := newProbeLinkName()
+	if err != nil {
+		t.Fatalf("newProbeLinkName: %v", err)
+	}
+	if !strings.HasPrefix(a, "dh-probe-") {
+		t.Errorf("missing prefix; got %q", a)
+	}
+	// Linux's IFNAMSIZ is 16 (including null terminator) → max 15
+	// printable chars. dh-probe- (9) + 8 hex = 17. We're 2 over the
+	// limit and need to rely on the kernel truncating, OR we use a
+	// shorter random suffix. Pin the length here so a refactor
+	// doesn't regress past the limit silently.
+	if len(a) > 15 {
+		t.Errorf("link name %q exceeds Linux IFNAMSIZ-1 (15) — kernel will refuse it", a)
+	}
+
+	b, _ := newProbeLinkName()
+	if a == b {
+		t.Errorf("two consecutive newProbeLinkName calls returned identical name %q — randomness broken", a)
+	}
+}

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"sync"
+	"time"
 
 	dNetwork "github.com/docker/docker/api/types/network"
 	"github.com/mitchellh/mapstructure"
@@ -59,6 +60,15 @@ func validateModeOptions(opts DHCPNetworkOptions) error {
 		if opts.Parent != "" {
 			return fmt.Errorf("%w: parent cannot be set in mode=bridge", util.ErrModeMismatch)
 		}
+		// validate_dhcp on bridge mode is a v0.9.0 carve-out: the
+		// probe semantics differ (parent is an existing bridge, not
+		// a NIC) and adding the bridge-mode probe path adds scope
+		// without a clear consumer. Reject loudly so an operator
+		// who set the opt understands it doesn't apply here, instead
+		// of silently no-op'ing and missing a real misconfig.
+		if opts.ValidateDHCP {
+			return fmt.Errorf("%w: validate_dhcp is not supported in mode=bridge", util.ErrModeMismatch)
+		}
 	default:
 		return fmt.Errorf("%w: %q", util.ErrInvalidMode, opts.Mode)
 	}
@@ -89,15 +99,29 @@ func (p *Plugin) CreateNetwork(r CreateNetworkRequest) error {
 		if _, err := validateParentForChild(opts.Parent); err != nil {
 			return err
 		}
+		// Pre-flight DHCP probe (T2-5). Runs before saveOptions so
+		// a network that fails the probe leaves no on-disk state
+		// behind — the operator's `docker network create` fails
+		// cleanly and they can re-issue once the upstream is fixed.
+		// Default off; opt-in via -o validate_dhcp=true.
+		if opts.ValidateDHCP {
+			ctx, cancel := context.WithTimeout(context.Background(), preflightProbeBudget+5*time.Second)
+			err := runDHCPProbe(ctx, opts.Parent)
+			cancel()
+			if err != nil {
+				return err
+			}
+		}
 		if err := saveOptions(r.NetworkID, opts); err != nil {
 			log.WithError(err).WithField("network", r.NetworkID).
 				Warn("Failed to persist options; daemon-restart may need API fallback")
 		}
 		log.WithFields(log.Fields{
-			"network": r.NetworkID,
-			"mode":    mode,
-			"parent":  opts.Parent,
-			"ipv6":    opts.IPv6,
+			"network":       r.NetworkID,
+			"mode":          mode,
+			"parent":        opts.Parent,
+			"ipv6":          opts.IPv6,
+			"validate_dhcp": opts.ValidateDHCP,
 		}).Info("Network created")
 		return nil
 	}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -170,6 +170,26 @@ type DHCPNetworkOptions struct {
 	// for example to issue a different gateway or option set to
 	// containers tagged with a known vendor string.
 	VendorClass string `mapstructure:"vendor_class"`
+	// ValidateDHCP, when true, makes CreateNetwork run a one-shot
+	// DHCP probe on the parent NIC before the network is created,
+	// failing fast with a clear error if no DHCP server answers
+	// within the budget (see preflightProbeBudget). Catches
+	// misconfigurations (parent isolated from any DHCP server,
+	// firewall blocking UDP/67-68, broken VLAN tag) at create time
+	// rather than the first `docker run` attempt.
+	//
+	// macvlan / ipvlan modes only — bridge mode's "parent" is an
+	// existing Linux bridge, where the probe semantics are different
+	// and not yet implemented.
+	//
+	// The probe runs a full DHCPDISCOVER → REQUEST → ACK cycle
+	// (busybox udhcpc has no DISCOVER-only mode), so the upstream
+	// pool briefly sees one extra lease per `docker network create`
+	// with this opt-in. The probe MAC is random (locally-administered
+	// bit set) so it doesn't collide with anything stable upstream;
+	// the lease times out naturally rather than dragging CreateNetwork
+	// on a slow release path.
+	ValidateDHCP bool `mapstructure:"validate_dhcp"`
 }
 
 // effectiveMode returns Mode with the empty default normalized to ModeBridge.

--- a/test/integration/preflight_probe_test.go
+++ b/test/integration/preflight_probe_test.go
@@ -1,0 +1,155 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	"github.com/docker/docker/api/types/network"
+	docker "github.com/docker/docker/client"
+	"github.com/vishvananda/netlink"
+)
+
+// TestPreflightProbe_PassesOnReachableServer is the v0.9.0 / T2-5
+// happy path: validate_dhcp=true on the standard fixture (dnsmasq
+// on the other end of HostVeth) succeeds and the network is created.
+//
+// Indirectly exercises the macvlan probe-link create + udhcpc
+// one-shot DORA + cleanup paths in pkg/plugin/dhcp_probe.go.
+func TestPreflightProbe_PassesOnReachableServer(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	netName := "dh-itest-preflight-ok"
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{
+		"validate_dhcp": "true",
+	})
+
+	// Reaching this point without t.Fatal means CreateNetwork
+	// returned 200; t.Cleanup tears the network down. Implicit
+	// pass.
+	t.Logf("network %s created with validate_dhcp=true on the working fixture", netName)
+}
+
+// TestPreflightProbe_FailsWhenServerUnreachable is the negative
+// guard: validate_dhcp=true with a parent that has no DHCP server
+// reachable must fail within the probe budget (5s + harness slack)
+// with a clear error mentioning the parent NIC.
+//
+// Uses a dummy interface as the parent — dummies don't carry L2
+// traffic to anywhere, so the DHCPDISCOVER vanishes into the void
+// and udhcpc times out. Cheaper to set up than a fresh veth pair
+// with no peer-side dnsmasq, and the test doesn't exercise the
+// peer-side code anyway.
+func TestPreflightProbe_FailsWhenServerUnreachable(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	// dh-itest-iso < 15 chars; safe for kernel.
+	const dummyName = "dh-itest-iso"
+
+	la := netlink.NewLinkAttrs()
+	la.Name = dummyName
+	dummy := &netlink.Dummy{LinkAttrs: la}
+	if err := netlink.LinkAdd(dummy); err != nil {
+		t.Fatalf("LinkAdd dummy: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := netlink.LinkDel(dummy); err != nil {
+			t.Logf("WARN: LinkDel dummy: %v", err)
+		}
+	})
+	if err := netlink.LinkSetUp(dummy); err != nil {
+		t.Fatalf("LinkSetUp dummy: %v", err)
+	}
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	netName := "dh-itest-preflight-fail"
+	start := time.Now()
+	res, createErr := cli.NetworkCreate(ctx, netName, network.CreateOptions{
+		Driver: harness.DriverName,
+		IPAM:   &network.IPAM{Driver: "null"},
+		Options: map[string]string{
+			"mode":          "macvlan",
+			"parent":        dummyName,
+			"validate_dhcp": "true",
+		},
+	})
+	elapsed := time.Since(start)
+	if createErr == nil {
+		// Tear down the bogus network so the next test doesn't
+		// inherit it.
+		_ = cli.NetworkRemove(context.Background(), res.ID)
+		t.Fatalf("NetworkCreate succeeded against an isolated dummy parent; probe didn't reject")
+	}
+
+	// The probe budget is 5s; harness allowed ~10s including
+	// the udhcpc setup overhead. If we waited ~30s it means the
+	// budget is being ignored somewhere.
+	if elapsed > 15*time.Second {
+		t.Errorf("probe took %v; should have failed within ~6-10s", elapsed)
+	}
+
+	msg := createErr.Error()
+	if !strings.Contains(msg, "DHCP OFFER") && !strings.Contains(msg, "validate_dhcp") {
+		t.Errorf("error message doesn't mention the probe failure clearly: %q", msg)
+	}
+	t.Logf("probe failed in %v with: %s", elapsed, msg)
+}
+
+// TestPreflightProbe_RejectedInBridgeMode pins the v0.9.0 carve-out:
+// validate_dhcp=true is documented as macvlan/ipvlan only. A bridge
+// network that requests it must fail at validateModeOptions, not
+// silently no-op (which would let an operator think their probe ran
+// when it didn't).
+func TestPreflightProbe_RejectedInBridgeMode(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	netName := "dh-itest-preflight-bridge-rejected"
+	res, err := cli.NetworkCreate(ctx, netName, network.CreateOptions{
+		Driver: harness.DriverName,
+		IPAM:   &network.IPAM{Driver: "null"},
+		Options: map[string]string{
+			"mode":          "bridge",
+			"bridge":        harness.BridgeName,
+			"validate_dhcp": "true",
+		},
+	})
+	if err == nil {
+		_ = cli.NetworkRemove(context.Background(), res.ID)
+		t.Fatalf("NetworkCreate accepted validate_dhcp=true in bridge mode; should have rejected")
+	}
+	if !strings.Contains(err.Error(), "validate_dhcp") {
+		t.Errorf("rejection message should mention validate_dhcp; got: %q", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

Adds the `validate_dhcp=true` driver-opt. When set, `CreateNetwork` runs a one-shot DHCP probe on the parent NIC before persisting the network, failing fast with a clear error if no DHCP server answers within the budget.

```bash
docker network create -d net-dhcp -o mode=macvlan -o parent=eth0 \
    -o validate_dhcp=true lan-dhcp
# fails immediately with:
#   no DHCP OFFER on \"eth0\" within 5s — parent NIC may be isolated,
#   firewalled (UDP/67-68), or VLAN-tagged wrong
```

## Probe shape

- Random **locally-administered MAC** (LAA bit set, multicast clear) so the DISCOVER doesn't collide with any stable upstream reservation; recognisably ephemeral to network admins watching dnsmasq logs.
- Unique link name `dh-probe-<6 hex>` fits Linux's IFNAMSIZ-1 (15 chars) limit; avoids concurrent-probe collisions.
- Temporary macvlan child of the parent in the host netns (mode bridge — same submode the production endpoint uses).
- Full DHCPDISCOVER → REQUEST → ACK via `udhcpc.GetIP` (busybox has no DISCOVER-only mode). Cost: **one transient lease per probe** that times out naturally; udhcpc receives no `-R` so the probe doesn't drag CreateNetwork on a slow-release path.
- Unconditional `defer LinkDel` cleanup; warns if cleanup itself fails.

## Mode scope

macvlan / ipvlan only. `validateModeOptions` rejects `validate_dhcp` in bridge mode with `validate_dhcp is not supported in mode=bridge` rather than silently no-op'ing — an operator who set the opt knows to remove it instead of trusting a probe that didn't run.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` clean
- [x] **Unit:** `TestNewProbeMAC` (LAA + multicast bits + rand sanity), `TestNewProbeLinkName` (prefix + length ≤ 15 + uniqueness — caught my own kernel-refused-name bug)
- [x] **Integration:**
  - `TestPreflightProbe_PassesOnReachableServer` — fixture path
  - `TestPreflightProbe_FailsWhenServerUnreachable` — isolated dummy parent, asserts failure within ~10s with a clear `DHCP OFFER` message
  - `TestPreflightProbe_RejectedInBridgeMode` — bridge mode rejection
- [ ] Full integration suite on the self-hosted runner (CI)

Closes #108.