### PR TITLE
tests: extensive T2-3 integration coverage (vendor_class + client_id)

### DIFF
--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -93,8 +93,11 @@ The host's NIC config (IP, routes, netplan/`systemd-networkd`,
 | `lease_timeout`     | both      | no       | Initial-lease timeout for the up-front DHCP exchange (default `10s`). |
 | `ignore_conflicts`  | bridge    | no       | Skip the bridge-already-in-use check. No-op in macvlan mode.  |
 | `skip_routes`       | all       | no       | Don't copy non-default static routes from the parent (bridge / macvlan parent NIC / ipvlan parent NIC) into the container. v0.9.0 extended this from bridge-only to all modes for parity (#102) — set `true` to restore pre-v0.9.0 macvlan/ipvlan no-copy behaviour. |
-| `propagate_dns`     | all       | no       | (v0.9.0+) Write DHCP option 6 / 23 (DNS server list) into the container's `/etc/resolv.conf` on bind/renew. Off by default; turning it on overrides Docker's embedded resolver for this network. |
+| `propagate_dns`     | all       | no       | (v0.9.0+) Write DHCP option 6 / 23 (DNS server list) into the container's `/etc/resolv.conf` on bind/renew. Off by default; turning it on overrides Docker's embedded resolver for this network. The `search` line uses option 119 (Domain Search List) when supplied, falling back to option 15 (`Domain`) otherwise. |
 | `propagate_mtu`     | all       | no       | (v0.9.0+) Apply DHCP option 26 (Interface MTU) to the container link on bind/renew. Off by default; useful for jumbo-frame networks (9000) and VPN-reduced ones (~1450). |
+| `client_id`         | all       | no       | (v0.9.0+) Override DHCP option 61 (Client Identifier) for every endpoint on this network. Bytes go on the wire prefixed with type byte `0x00` (RFC 2132 opaque). Default empty keeps the per-endpoint stable id derived from the Docker endpoint ID, which is what makes per-container reservations work upstream. **Caveat:** a static `client_id` across containers means the DHCP server can't differentiate them. Typically only useful when paired with `vendor_class` to drive class-based policy. |
+| `vendor_class`      | all       | no       | (v0.9.0+) Override DHCP option 60 (Vendor Class Identifier). Default `docker-net-dhcp`. Lets DHCP servers running class-based policy (Cisco / Aruba / etc.) issue different gateways or option sets to containers tagged with a known vendor string. v6 unaffected — udhcpc6 doesn't accept this option. |
+| `validate_dhcp`     | macvlan, ipvlan | no | (v0.9.0+) Pre-flight DHCP probe at `docker network create` time. Creates a temporary macvlan child on the parent NIC with a random locally-administered MAC, runs one-shot udhcpc with a 5-second budget, and rejects the network with `no DHCP OFFER on <parent> within 5s` if no server answers. Catches misconfigurations (parent isolated, firewall blocking UDP/67-68, broken VLAN tag) at create time rather than the first `docker run`. Cost: one transient lease per probe in the upstream pool. Bridge mode rejects the opt with a clear error. |
 
 ## Constraints
 
@@ -314,6 +317,8 @@ the same identity fields, regardless of attachment mode:
   `docker-net-dhcp`. Lets DHCP servers gate behaviour (e.g. a
   separate pool for plugin-managed containers) without parsing
   hostname conventions. v4 only — DHCPv6 has no equivalent.
+  Override per-network with `-o vendor_class=<string>` (v0.9.0+)
+  for sites running class-based DHCP policy (Cisco / Aruba style).
 - **Client identifier (option 61)** — eight bytes derived from
   the Docker endpoint ID, prefixed by the type byte 0
   (per-client opaque, RFC 2132). Stable across container
@@ -322,7 +327,42 @@ the same identity fields, regardless of attachment mode:
   (rather than MAC) keep handing the same lease back. This is
   the mechanism that makes ipvlan stability work, since every
   ipvlan slave shares the parent's MAC; for macvlan and bridge
-  it's a redundant safety net.
+  it's a redundant safety net. Override per-network with
+  `-o client_id=<string>` (v0.9.0+); rarely useful since a static
+  ID across containers means the server can't differentiate them.
+
+### Captured DHCP options
+
+The plugin captures every option the upstream server returns and
+surfaces them in two ways:
+
+- **Auto-applied** when the network has the corresponding opt-in:
+  - Option 6 / 23 (DNS server list) → `/etc/resolv.conf` when
+    `propagate_dns=true`
+  - Option 26 (Interface MTU) → container link MTU when
+    `propagate_mtu=true`
+  - Option 119 (DNS Search List) → resolv.conf `search` line when
+    `propagate_dns=true`. Falls back to option 15 (`Domain`)
+    when 119 is absent.
+- **Surfaced via plugin log** at info level on every bound /
+  renew, gated on at least one being non-empty so plain LANs see
+  no extra noise:
+  - Option 42 (NTP servers, env `ntpsrv`)
+  - Option 66 (TFTP server name, env `tftp`)
+  - Option 67 (Boot file name, env `bootfile`)
+  - Option 119 (when `propagate_dns=false`)
+
+```text
+level=info msg="DHCP options received" ntp=[192.168.0.123]
+  tftp=tftp.example.test bootfile=pxelinux.0
+  search=[corp.example internal.example] ...
+```
+
+Workloads needing NTP / TFTP / boot-file can grep the plugin log
+or wire a sidecar to it. The plugin doesn't auto-apply these
+because (a) the consuming application owns the config file, not
+the plugin, and (b) writing into `/etc/ntp.conf` etc. would mean
+yet more setns into the container's mount namespace per renewal.
 
 ## Plugin-restart recovery
 
@@ -361,7 +401,12 @@ user-visible outcome.
   "pending_hints": 0,
   "recovered_ok": 0,
   "recovery_failed": 0,
-  "tombstone_write_failures": 0
+  "tombstone_write_failures": 0,
+  "lease_changed": 0,
+  "leases_obtained": 17,
+  "leases_renewed": 42,
+  "dhcp_timeouts": 0,
+  "lease_release_failures": 0
 }
 ```
 
@@ -383,6 +428,25 @@ Field meanings:
   endpoints whose rebuild failed).
 - `tombstone_write_failures` — counter bumped on any
   `addTombstone` save failure (disk full, EROFS, etc.).
+
+DHCP-wire counters (v0.9.0+):
+
+- `lease_changed` — bumps when a renewal returns a different IP
+  than the manager last recorded. Docker's `NetworkSettings.IPAddress`
+  view does NOT update on lease change (libnetwork has no in-place
+  endpoint-IP swap RPC); this counter is the operator-facing signal
+  that a stale-inspect window has opened. Worth alerting on for
+  long-running containers.
+- `leases_obtained` — udhcpc `bound` event count: initial bind or
+  re-bind after a NAK / lease loss from the persistent client.
+- `leases_renewed` — udhcpc `renew` event count.
+- `dhcp_timeouts` — udhcpc `leasefail` event count (no OFFER /
+  no ACK in budget).
+- `lease_release_failures` — `dhcpManager.Stop`'s SIGTERM →
+  DHCPRELEASE → exit didn't complete cleanly. The upstream may now
+  hold a phantom lease against the container's MAC until natural
+  expiry. A pattern of these typically points at upstream
+  reachability problems mid-teardown.
 
 Sample call from a host shell:
 

--- a/test/integration/client_id_test.go
+++ b/test/integration/client_id_test.go
@@ -1,0 +1,155 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/hex"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+)
+
+// TestClientID_OverrideAppearsInLeaseFile is the v0.9.0 / T2-3
+// proof-of-wire-encoding for #106's client_id driver-opt.
+//
+// dnsmasq's lease file stores option-61 client identifiers as
+// `<type-byte-hex>:<payload-hex>` in the last column. The plugin
+// always sends type 0x00 (opaque, RFC 2132), so an operator
+// override of `client_id=<string>` must show up as
+// `00:<hex(string)>` in the lease line for the container's MAC.
+//
+// Asserting on the lease file is more robust than scraping dnsmasq
+// stdout: the lease file format is stable across dnsmasq versions,
+// and the line is written exactly once per ACK so we don't need to
+// chase log-stream timing.
+//
+// Closes the integration-coverage gap noted in the post-T2-3 audit:
+// the existing TestNewDHCPClient_VendorClassOverride only checks
+// the udhcpc argv shape; this test proves the bytes also reach
+// the upstream server.
+func TestClientID_OverrideAppearsInLeaseFile(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const operatorClientID = "dh-itest-cid"
+	netName := "dh-itest-cid-override"
+	ctrName := "dh-itest-cid-override-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{
+		"client_id": operatorClientID,
+	})
+	id, ipv4, mac := harness.RunContainer(t, ctx, netName, ctrName)
+	t.Logf("container %s: id=%s ip=%s mac=%s", ctrName, id[:12], ipv4, mac)
+
+	// Wire-format expectation: type byte 0x00 + ASCII bytes,
+	// rendered by dnsmasq as colon-separated hex pairs.
+	wantHex := "00:" + colonHex([]byte(operatorClientID))
+
+	// Lease line lands when dnsmasq writes the lease database. That
+	// happens immediately on ACK; the only delay is the FS sync.
+	deadline := time.Now().Add(5 * time.Second)
+	var leaseContents string
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(fixture.LeaseFile())
+		if err == nil {
+			leaseContents = string(data)
+			if strings.Contains(leaseContents, wantHex) {
+				t.Logf("client_id %q surfaced in lease file as %s", operatorClientID, wantHex)
+				return
+			}
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	t.Errorf("expected client_id encoded as %q in lease file %s within 5s\nfile contents:\n%s",
+		wantHex, fixture.LeaseFile(), leaseContents)
+}
+
+// TestClientID_DefaultUsesEndpointDerivedID is the negative side:
+// without the operator override, the lease file shows the
+// endpoint-derived stable ID (8 bytes hex, prefixed by 0x00) — NOT
+// the operator-set string. Pins the fallback path so a future
+// refactor that accidentally always uses opts.ClientID would
+// trigger this assertion's mismatch.
+func TestClientID_DefaultUsesEndpointDerivedID(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-cid-default"
+	ctrName := "dh-itest-cid-default-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+	id, ipv4, mac := harness.RunContainer(t, ctx, netName, ctrName)
+	t.Logf("container %s: id=%s ip=%s mac=%s", ctrName, id[:12], ipv4, mac)
+
+	// Find the lease line for our IP. Without an override the
+	// client-id is 8 hex bytes (16 hex chars), prefixed by 00:.
+	// We assert on length rather than the exact derived value to
+	// avoid coupling the test to clientIDFromEndpoint's hash shape.
+	deadline := time.Now().Add(5 * time.Second)
+	var lineForIP string
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(fixture.LeaseFile())
+		if err == nil {
+			for _, line := range strings.Split(string(data), "\n") {
+				if strings.Contains(line, ipv4) {
+					lineForIP = line
+					break
+				}
+			}
+		}
+		if lineForIP != "" {
+			break
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	if lineForIP == "" {
+		t.Fatalf("no lease line found for IP %s within 5s", ipv4)
+	}
+	t.Logf("lease line: %s", lineForIP)
+
+	// Lease format: <expiry> <mac> <ip> <hostname> <client-id>.
+	// Last whitespace-separated field is the client-id. An
+	// override of "dh-itest-cid" would render as a recognisable
+	// pattern; the derived ID won't.
+	if strings.Contains(lineForIP, "dh-itest-cid") {
+		t.Errorf("default network should NOT carry the override string in client-id; got line: %s", lineForIP)
+	}
+}
+
+// colonHex renders bytes as `aa:bb:cc:...` — matches dnsmasq's
+// lease-file rendering of binary fields. encoding/hex's bare form
+// is `aabbcc`, so we splice colons in.
+func colonHex(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	enc := hex.EncodeToString(b)
+	// Two hex chars per byte; insert ':' between every pair.
+	var out strings.Builder
+	out.Grow(len(enc) + len(b) - 1)
+	for i := 0; i < len(enc); i += 2 {
+		if i > 0 {
+			out.WriteByte(':')
+		}
+		out.WriteString(enc[i : i+2])
+	}
+	return out.String()
+}

--- a/test/integration/harness/fixture.go
+++ b/test/integration/harness/fixture.go
@@ -80,7 +80,23 @@ const (
 	TestSearchList = "corp.example,internal.example"
 	TestTFTPServer = "tftp.example.test"
 	TestBootFile   = "pxelinux.0"
+
+	// TestVendorClass / TestTaggedGateway drive the v0.9.0 / T2-3
+	// vendor_class round-trip test. dnsmasq is configured to set tag
+	// `dh-itest-vc` for clients sending option 60 = TestVendorClass,
+	// then override option 3 (router) to TestTaggedGateway only for
+	// tagged clients. Containers without the override get dnsmasq's
+	// default gateway (its own listen address, .1).
+	TestVendorClass    = "docker-net-dhcp-test-vc"
+	TestTaggedGateway  = "192.168.99.250"
+	dnsmasqVCTag       = "dh-itest-vc"
+	defaultGatewayAddr = "192.168.99.1"
 )
+
+// DefaultGateway is the gateway untagged clients receive — dnsmasq's
+// own listen address. Exposed for tests that assert vendor-class
+// tagging didn't accidentally fire on a default-config container.
+const DefaultGateway = defaultGatewayAddr
 
 // Fixture owns the lifecycle of the shared integration-test environment.
 // Use New() in TestMain; defer f.Teardown(). Re-running on a host with
@@ -203,6 +219,15 @@ func (f *Fixture) startDnsmasq() error {
 		"--dhcp-option=66,"+TestTFTPServer,  // option 66: TFTP server name
 		"--dhcp-option=67,"+TestBootFile,    // option 67: boot file
 		"--dhcp-option=119,"+TestSearchList, // option 119: domain search list
+		// Vendor-class tagging for the v0.9.0 / T2-3 round-trip test.
+		// dnsmasq sets tag `dh-itest-vc` on any DISCOVER carrying
+		// option 60 = TestVendorClass; the matching tag:... rule then
+		// overrides the gateway (option 3) only for tagged clients.
+		// Untagged clients (default `vendor_class` not set) keep
+		// dnsmasq's default gateway (its own listen IP), so existing
+		// tests that don't opt-in are unaffected.
+		"--dhcp-vendorclass=set:"+dnsmasqVCTag+","+TestVendorClass,
+		"--dhcp-option=tag:"+dnsmasqVCTag+",3,"+TestTaggedGateway,
 		// dhcp-broadcast forces OFFER/ACK to be sent as L2 broadcast
 		// regardless of the client's broadcast flag. Required for
 		// ipvlan-L2 mode: the slave's IP isn't registered with the

--- a/test/integration/vendor_class_test.go
+++ b/test/integration/vendor_class_test.go
@@ -1,0 +1,127 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+)
+
+// TestVendorClass_OverrideRoutesViaTaggedGateway is the v0.9.0 / T2-3
+// integration counterpart for #106 — closes the test-plan gap noted
+// in the post-merge audit.
+//
+// The fixture's dnsmasq is configured with --dhcp-vendorclass=set:...
+// + --dhcp-option=tag:...,3,TestTaggedGateway, so a container whose
+// network sets vendor_class=harness.TestVendorClass should receive
+// the tagged gateway (.250) instead of dnsmasq's default
+// listen-address gateway (.1). End-to-end proof that the operator's
+// vendor_class override actually reaches the wire and class-based
+// policy fires upstream — the unit test
+// TestNewDHCPClient_VendorClassOverride only verified the udhcpc
+// argv shape.
+func TestVendorClass_OverrideRoutesViaTaggedGateway(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-vc-tagged"
+	ctrName := "dh-itest-vc-tagged-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{
+		"vendor_class": harness.TestVendorClass,
+	})
+	id, _, _ := harness.RunContainer(t, ctx, netName, ctrName)
+
+	out := harness.ExecOutput(t, ctx, id, "ip", "route", "show", "default")
+	if !strings.Contains(out, harness.TestTaggedGateway) {
+		t.Errorf("expected default route via %s (tagged gateway); got:\n%s",
+			harness.TestTaggedGateway, out)
+	}
+	if strings.Contains(out, harness.DefaultGateway) {
+		t.Errorf("default route still points at %s — vendor_class override didn't fire upstream:\n%s",
+			harness.DefaultGateway, out)
+	}
+	t.Logf("default route: %s", strings.TrimSpace(out))
+}
+
+// TestVendorClass_DefaultUsesUntaggedGateway is the negative side:
+// without the vendor_class opt-in, the container's vendor identifier
+// stays at the plugin's default ("docker-net-dhcp"), which doesn't
+// match dnsmasq's tag rule, so the gateway stays on the default .1.
+//
+// Together with the override test above, this pins both branches of
+// the class-based-policy split. Guards against:
+//   - a future refactor that accidentally sets a vendor class even
+//     when the operator didn't ask for one
+//   - a fixture mistake that flips the tag rule's polarity
+func TestVendorClass_DefaultUsesUntaggedGateway(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-vc-default"
+	ctrName := "dh-itest-vc-default-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+	id, _, _ := harness.RunContainer(t, ctx, netName, ctrName)
+
+	out := harness.ExecOutput(t, ctx, id, "ip", "route", "show", "default")
+	if !strings.Contains(out, harness.DefaultGateway) {
+		t.Errorf("expected default route via %s (default gateway); got:\n%s",
+			harness.DefaultGateway, out)
+	}
+	if strings.Contains(out, harness.TestTaggedGateway) {
+		t.Errorf("default route points at %s — vendor_class tag fired without the override:\n%s",
+			harness.TestTaggedGateway, out)
+	}
+	t.Logf("default route: %s", strings.TrimSpace(out))
+}
+
+// TestVendorClass_NonMatchingValueUsesDefaultGateway verifies that
+// only the *exact* configured vendor class triggers the dnsmasq tag.
+// A network that sets vendor_class to some other string still gets
+// the untagged gateway — proves the override goes on the wire (not
+// silently dropped), and that dnsmasq's matching is actually doing
+// the work (not falling open).
+func TestVendorClass_NonMatchingValueUsesDefaultGateway(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-vc-nonmatch"
+	ctrName := "dh-itest-vc-nonmatch-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{
+		"vendor_class": "totally-different-vendor-class",
+	})
+	id, _, _ := harness.RunContainer(t, ctx, netName, ctrName)
+
+	out := harness.ExecOutput(t, ctx, id, "ip", "route", "show", "default")
+	if !strings.Contains(out, harness.DefaultGateway) {
+		t.Errorf("non-matching vendor_class should still get the default gateway %s; got:\n%s",
+			harness.DefaultGateway, out)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the integration-coverage gap surfaced in the post-T2-3 audit. Pre-this-PR, the only tests for `vendor_class` / `client_id` were unit-level (`TestResolveClientID`, `TestNewDHCPClient_VendorClassOverride`) — they verify the udhcpc argv shape, but never proved the bytes reach the upstream server or that class-based policy fires.

This PR adds 5 integration tests that exercise the wire end-to-end.

## Fixture changes

dnsmasq is now configured to tag clients sending option 60 = `TestVendorClass` with `dh-itest-vc`, and override option 3 (router) to `TestTaggedGateway` (.250) only for tagged clients. Untagged clients keep the default listen-address gateway (.1), so existing tests are unaffected.

New harness constants: `TestVendorClass`, `TestTaggedGateway`, `DefaultGateway`.

## Vendor-class tests (3)

- `TestVendorClass_OverrideRoutesViaTaggedGateway` — container with `-o vendor_class=TestVendorClass` has its default route via `.250` (proves the override reached dnsmasq and class-based policy fired).
- `TestVendorClass_DefaultUsesUntaggedGateway` — container without the override gets the default `.1` gateway (proves we don't accidentally tag clients that didn't ask).
- `TestVendorClass_NonMatchingValueUsesDefaultGateway` — container with a different vendor_class string still gets `.1` (proves dnsmasq's matching is doing the work, not falling open).

## Client-id tests (2)

- `TestClientID_OverrideAppearsInLeaseFile` — assert the operator-supplied `client_id` shows up in dnsmasq's lease file as `00:<hex(string)>` (the wire format the plugin sends).
- `TestClientID_DefaultUsesEndpointDerivedID` — without the override, the operator string does NOT appear in the lease line. Pins the fallback path so a refactor that accidentally always-uses `opts.ClientID` trips this assertion.

## Why lease-file assertions

dnsmasq's lease file format is stable across versions and writes once per ACK. More robust than scraping dnsmasq stdout (which varies with `--log-dhcp` levels and timing). The test reads `fixture.LeaseFile()` and asserts on substring presence/absence of the expected hex.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` clean
- [x] Integration suite compiles (verified locally; needs root to actually run)
- [ ] Full integration suite on the self-hosted runner (CI)

No milestone — coverage cleanup, not a feature.