### PR TITLE
docs: cover v0.9.0 driver-opts + Plugin.Health counters

### DIFF
--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -93,8 +93,11 @@ The host's NIC config (IP, routes, netplan/`systemd-networkd`,
 | `lease_timeout`     | both      | no       | Initial-lease timeout for the up-front DHCP exchange (default `10s`). |
 | `ignore_conflicts`  | bridge    | no       | Skip the bridge-already-in-use check. No-op in macvlan mode.  |
 | `skip_routes`       | all       | no       | Don't copy non-default static routes from the parent (bridge / macvlan parent NIC / ipvlan parent NIC) into the container. v0.9.0 extended this from bridge-only to all modes for parity (#102) — set `true` to restore pre-v0.9.0 macvlan/ipvlan no-copy behaviour. |
-| `propagate_dns`     | all       | no       | (v0.9.0+) Write DHCP option 6 / 23 (DNS server list) into the container's `/etc/resolv.conf` on bind/renew. Off by default; turning it on overrides Docker's embedded resolver for this network. |
+| `propagate_dns`     | all       | no       | (v0.9.0+) Write DHCP option 6 / 23 (DNS server list) into the container's `/etc/resolv.conf` on bind/renew. Off by default; turning it on overrides Docker's embedded resolver for this network. The `search` line uses option 119 (Domain Search List) when supplied, falling back to option 15 (`Domain`) otherwise. |
 | `propagate_mtu`     | all       | no       | (v0.9.0+) Apply DHCP option 26 (Interface MTU) to the container link on bind/renew. Off by default; useful for jumbo-frame networks (9000) and VPN-reduced ones (~1450). |
+| `client_id`         | all       | no       | (v0.9.0+) Override DHCP option 61 (Client Identifier) for every endpoint on this network. Bytes go on the wire prefixed with type byte `0x00` (RFC 2132 opaque). Default empty keeps the per-endpoint stable id derived from the Docker endpoint ID, which is what makes per-container reservations work upstream. **Caveat:** a static `client_id` across containers means the DHCP server can't differentiate them. Typically only useful when paired with `vendor_class` to drive class-based policy. |
+| `vendor_class`      | all       | no       | (v0.9.0+) Override DHCP option 60 (Vendor Class Identifier). Default `docker-net-dhcp`. Lets DHCP servers running class-based policy (Cisco / Aruba / etc.) issue different gateways or option sets to containers tagged with a known vendor string. v6 unaffected — udhcpc6 doesn't accept this option. |
+| `validate_dhcp`     | macvlan, ipvlan | no | (v0.9.0+) Pre-flight DHCP probe at `docker network create` time. Creates a temporary macvlan child on the parent NIC with a random locally-administered MAC, runs one-shot udhcpc with a 5-second budget, and rejects the network with `no DHCP OFFER on <parent> within 5s` if no server answers. Catches misconfigurations (parent isolated, firewall blocking UDP/67-68, broken VLAN tag) at create time rather than the first `docker run`. Cost: one transient lease per probe in the upstream pool. Bridge mode rejects the opt with a clear error. |
 
 ## Constraints
 
@@ -314,6 +317,8 @@ the same identity fields, regardless of attachment mode:
   `docker-net-dhcp`. Lets DHCP servers gate behaviour (e.g. a
   separate pool for plugin-managed containers) without parsing
   hostname conventions. v4 only — DHCPv6 has no equivalent.
+  Override per-network with `-o vendor_class=<string>` (v0.9.0+)
+  for sites running class-based DHCP policy (Cisco / Aruba style).
 - **Client identifier (option 61)** — eight bytes derived from
   the Docker endpoint ID, prefixed by the type byte 0
   (per-client opaque, RFC 2132). Stable across container
@@ -322,7 +327,42 @@ the same identity fields, regardless of attachment mode:
   (rather than MAC) keep handing the same lease back. This is
   the mechanism that makes ipvlan stability work, since every
   ipvlan slave shares the parent's MAC; for macvlan and bridge
-  it's a redundant safety net.
+  it's a redundant safety net. Override per-network with
+  `-o client_id=<string>` (v0.9.0+); rarely useful since a static
+  ID across containers means the server can't differentiate them.
+
+### Captured DHCP options
+
+The plugin captures every option the upstream server returns and
+surfaces them in two ways:
+
+- **Auto-applied** when the network has the corresponding opt-in:
+  - Option 6 / 23 (DNS server list) → `/etc/resolv.conf` when
+    `propagate_dns=true`
+  - Option 26 (Interface MTU) → container link MTU when
+    `propagate_mtu=true`
+  - Option 119 (DNS Search List) → resolv.conf `search` line when
+    `propagate_dns=true`. Falls back to option 15 (`Domain`)
+    when 119 is absent.
+- **Surfaced via plugin log** at info level on every bound /
+  renew, gated on at least one being non-empty so plain LANs see
+  no extra noise:
+  - Option 42 (NTP servers, env `ntpsrv`)
+  - Option 66 (TFTP server name, env `tftp`)
+  - Option 67 (Boot file name, env `bootfile`)
+  - Option 119 (when `propagate_dns=false`)
+
+```text
+level=info msg="DHCP options received" ntp=[192.168.0.123]
+  tftp=tftp.example.test bootfile=pxelinux.0
+  search=[corp.example internal.example] ...
+```
+
+Workloads needing NTP / TFTP / boot-file can grep the plugin log
+or wire a sidecar to it. The plugin doesn't auto-apply these
+because (a) the consuming application owns the config file, not
+the plugin, and (b) writing into `/etc/ntp.conf` etc. would mean
+yet more setns into the container's mount namespace per renewal.
 
 ## Plugin-restart recovery
 
@@ -361,7 +401,12 @@ user-visible outcome.
   "pending_hints": 0,
   "recovered_ok": 0,
   "recovery_failed": 0,
-  "tombstone_write_failures": 0
+  "tombstone_write_failures": 0,
+  "lease_changed": 0,
+  "leases_obtained": 17,
+  "leases_renewed": 42,
+  "dhcp_timeouts": 0,
+  "lease_release_failures": 0
 }
 ```
 
@@ -383,6 +428,25 @@ Field meanings:
   endpoints whose rebuild failed).
 - `tombstone_write_failures` — counter bumped on any
   `addTombstone` save failure (disk full, EROFS, etc.).
+
+DHCP-wire counters (v0.9.0+):
+
+- `lease_changed` — bumps when a renewal returns a different IP
+  than the manager last recorded. Docker's `NetworkSettings.IPAddress`
+  view does NOT update on lease change (libnetwork has no in-place
+  endpoint-IP swap RPC); this counter is the operator-facing signal
+  that a stale-inspect window has opened. Worth alerting on for
+  long-running containers.
+- `leases_obtained` — udhcpc `bound` event count: initial bind or
+  re-bind after a NAK / lease loss from the persistent client.
+- `leases_renewed` — udhcpc `renew` event count.
+- `dhcp_timeouts` — udhcpc `leasefail` event count (no OFFER /
+  no ACK in budget).
+- `lease_release_failures` — `dhcpManager.Stop`'s SIGTERM →
+  DHCPRELEASE → exit didn't complete cleanly. The upstream may now
+  hold a phantom lease against the container's MAC until natural
+  expiry. A pattern of these typically points at upstream
+  reachability problems mid-teardown.
 
 Sample call from a host shell:
 


### PR DESCRIPTION
## Summary

Updates `docs/parent-attached-modes.md` to reflect the v0.9.0 surface that landed across PRs #112 (Tier 1), #113 (T2-4), #114 (T2-3), #115 (T2-2), and #117 (T2-5).

### Driver-options table

Three new rows: `client_id`, `vendor_class`, `validate_dhcp`. Existing `propagate_dns` row extended to mention option-119 (search list) precedence.

### DHCP identity section

Adds pointers to `vendor_class` / `client_id` overrides under the existing option-60 / option-61 explanations so operators looking at the canonical "what does the plugin send" reference find the override path without having to read RELEASE_NOTES.

### Captured DHCP options (new subsection)

Documents the auto-applied (DNS / MTU / search) vs. log-surfaced (NTP / TFTP / bootfile) split with a sample log line, so operators don't have to grep RELEASE_NOTES to find out the plugin already captured their option.

### Health endpoint section

Updates the JSON sample with the five v0.9.0 counters (`lease_changed`, `leases_obtained`, `leases_renewed`, `dhcp_timeouts`, `lease_release_failures`) and what each one signals.

## Test plan

- [x] No code change — markdown only
- [x] Markdown renders correctly (verified locally)

No milestone — doc update tracking the v0.9.0 feature surface.