### PR TITLE
ci: fix coverage workflow's unit-test invocation

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -89,9 +89,13 @@ jobs:
         if: always()
         run: |
           mkdir -p coverage-unit
-          go test -count=1 -coverpkg=./... \
-              -args -test.gocoverdir="$PWD/coverage-unit" \
-              ./pkg/... ./cmd/...
+          # `go test` syntax: [flags] [packages] [-args test-args].
+          # Packages MUST come before `-args`: anything after `-args`
+          # is passed to the compiled test binary, so the previous form
+          # made go test see no packages and fall back to '.', failing
+          # with "no Go files in <repo>".
+          go test -count=1 -coverpkg=./... ./pkg/... ./cmd/... \
+              -args -test.gocoverdir="$PWD/coverage-unit"
 
       - name: Coverage summary
         if: always()


### PR DESCRIPTION
## Summary

Coverage workflow's unit-test step had `-args` placed before the package list, making `go test` see no package args and fall back to the working directory:

```
no Go files in /opt/actions-runner-claymore666/_work/docker-net-dhcp/docker-net-dhcp
FAIL	. [setup failed]
```

`go test` syntax is `[flags] [packages] [-args test-args]` — packages MUST come before `-args`, since anything after `-args` is passed to the compiled test binary.

This bug was latent because the workflow is `workflow_dispatch` only and hadn't been run since the prior pre-Tier-1 harvest. The first dispatch on dev (run 25396070759) surfaced it.

## Test plan

- [x] No code change in pkg/* — workflow YAML only
- [ ] Re-dispatch coverage workflow on dev after merge to confirm green and harvest fresh combined unit+integration numbers for the v0.9.0 release notes