### PR TITLE
ci: use actions/setup-go in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,14 +29,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Verify Go toolchain
-        run: |
-          if ! command -v go >/dev/null; then
-            echo "go not in PATH on this runner."
-            echo "Run: sudo bash test/integration/install-go-runner.sh"
-            exit 1
-          fi
-          go version
+      # Coverage uses `-coverpkg=./...` for the unit-test step, which
+      # forces go test to recompile stdlib's internal/coverage runtime
+      # support. The runner's pre-installed Go (used unmodified by
+      # integration.yml) had `compile` and `pkg/tool` versions diverge
+      # at one point, so stdlib recompiles failed with
+      # `compile: version "go1.25.9" does not match go tool version
+      // "go1.25.0"`. setup-go gives us a known-clean toolchain at
+      # the cost of ~30s — fine for a 12-minute workflow that runs
+      # only on manual dispatch.
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
 
       - name: Cleanup orphans from previous runs
         run: bash test/integration/cleanup-orphans.sh


### PR DESCRIPTION
## Summary

Run 25397401772 surfaced a Go toolchain version mismatch in coverage.yml's unit-test step:

```
compile: version "go1.25.9" does not match go tool version "go1.25.0"
```

The runner's pre-installed Go had `go` updated to 1.25.9 but `pkg/tool/` stayed on 1.25.0. integration.yml works because its go invocations don't trigger stdlib recompiles. coverage.yml uses `-coverpkg=./...` for the unit-test step, which forces go test to recompile stdlib's `internal/coverage` runtime support and exposes the broken toolchain.

## Fix

Replace the runner's pre-installed-toolchain check with `actions/setup-go@v5` (same pattern as test.yaml). ~30s overhead per run, negligible against the ~12-minute total workflow time and only on `workflow_dispatch`.

## Test plan

- [x] No code change — workflow YAML only
- [ ] Re-dispatch coverage workflow on dev after merge to confirm green and harvest fresh combined unit+integration numbers for the v0.9.0 release notes