### PR TITLE
ci: fix YAML comment syntax in coverage.yml

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,11 +33,11 @@ jobs:
       # forces go test to recompile stdlib's internal/coverage runtime
       # support. The runner's pre-installed Go (used unmodified by
       # integration.yml) had `compile` and `pkg/tool` versions diverge
-      # at one point, so stdlib recompiles failed with
-      # `compile: version "go1.25.9" does not match go tool version
-      // "go1.25.0"`. setup-go gives us a known-clean toolchain at
-      # the cost of ~30s — fine for a 12-minute workflow that runs
-      # only on manual dispatch.
+      # at one point, so stdlib recompiles failed with the
+      # 'compile: version "go1.25.9" does not match go tool version
+      # "go1.25.0"' error. setup-go gives us a known-clean toolchain
+      # at the cost of ~30s — fine for a 12-minute workflow that
+      # runs only on manual dispatch.
       - uses: actions/setup-go@v5
         with:
           go-version: '1.25'


### PR DESCRIPTION
## Summary

#121's setup-go change accidentally introduced a stray `//` (C-style comment) at the start of a comment-block line — only one wrong character, but it broke the workflow's YAML parse.

```yaml
# `compile: version "go1.25.9" does not match go tool version
// "go1.25.0"`. setup-go gives us a known-clean toolchain at
# the cost of ~30s
```

GitHub's workflow parser treats the offending line as invalid YAML and reports the workflow as missing every trigger:

```
HTTP 422: Workflow does not have 'workflow_dispatch' trigger
```

I caught this when `gh workflow run coverage.yml --ref dev` started 422-ing immediately after #121 merged.

## Fix

Every line in the multi-line comment block now starts with `#`. `yaml.safe_load()` round-trips cleanly.

## Test plan

- [x] Local YAML validation: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/coverage.yml'))"`
- [ ] After merge: `gh workflow run coverage.yml --ref dev` returns 204 (the prior dispatch path)
- [ ] Coverage workflow run completes successfully and reports per-package percentages