### PR TITLE
CI hardening: actionlint, dependabot, govulncheck, coverage ratchet, release verification (#127)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+# actionlint config (#127). The integration/coverage workflows run on a
+# self-hosted runner with a custom label; declare it so actionlint
+# doesn't flag `runs-on: [self-hosted, gpu1]` as an unknown runner.
+self-hosted-runner:
+  labels:
+    - gpu1

--- a/.github/coverage-baseline.txt
+++ b/.github/coverage-baseline.txt
@@ -1,0 +1,14 @@
+# Coverage ratchet baseline (#127) — per-package merged
+# (unit + integration) coverage floors in percent, enforced by
+# scripts/coverage-ratchet.sh in the Coverage workflow.
+#
+# Rules:
+#   - Raise a floor in the same PR that earns the improvement.
+#   - Never lower a floor without a recorded decision in the PR body.
+#
+# Seeded from the v0.9.0 published numbers (RELEASE_NOTES.md).
+github.com/devplayer0/docker-net-dhcp/pkg/util 87.7
+github.com/devplayer0/docker-net-dhcp/pkg/plugin 82.4
+github.com/devplayer0/docker-net-dhcp/pkg/udhcpc 81.3
+github.com/devplayer0/docker-net-dhcp/cmd/net-dhcp 75.0
+github.com/devplayer0/docker-net-dhcp/cmd/udhcpc-handler 50.0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Weekly grouped dependency updates (#127). PRs target dev per the
+# branching workflow — nothing lands on main except via release PRs.
+# Grouping keeps the noise at one PR per ecosystem per week.
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: sunday
+    groups:
+      go-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: sunday
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/vuln-allowlist.txt
+++ b/.github/vuln-allowlist.txt
@@ -1,0 +1,19 @@
+# govulncheck allowlist (#127) — vulnerability IDs that are KNOWN,
+# REVIEWED, and accepted, enforced by scripts/govulncheck-gate.sh.
+#
+# Rules:
+#   - An entry requires a justification comment and the PR that added
+#     it. No bare IDs.
+#   - Entries are only for findings with no fixed release available.
+#     The moment a fix ships (dependabot will surface it), the bump
+#     lands and the entry is removed.
+#   - The gate warns when an entry stops being reported — remove it then.
+#
+# GO-2026-4887: moby AuthZ plugin bypass via oversized request bodies.
+# GO-2026-4883: moby off-by-one in plugin privilege validation.
+#   Both live in github.com/docker/docker daemon-side code with no
+#   fixed release published (checked v28.5.2, 2026-06-12). This plugin
+#   only uses the client API against the local daemon socket; the
+#   vulnerable AuthZ/privilege paths run in dockerd, not in us.
+GO-2026-4887
+GO-2026-4883

--- a/.github/workflows/apk-pin-check.yml
+++ b/.github/workflows/apk-pin-check.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check apk pins
         run: bash scripts/check-apk-pins.sh

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,7 @@ jobs:
       COVER_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:golang-cover
       COVER_DIR: /var/lib/dh-cover
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Coverage uses `-coverpkg=./...` for the unit-test step, which
       # forces go test to recompile stdlib's internal/coverage runtime
@@ -55,7 +55,7 @@ jobs:
       # "go1.25.0"' error. setup-go gives us a known-clean toolchain
       # at the cost of ~30s — fine for a 12-minute workflow that
       # runs only on manual dispatch.
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,9 +5,12 @@ name: Coverage
 # against it, then flushes counter files via `docker plugin disable`
 # and reports per-package coverage + uploads an HTML report.
 #
-# Manual-only (`workflow_dispatch`) — coverage runs cost ~3-5 min on top
-# of the integration suite (cover plugin build + flush + report) and
-# don't gate PR merges. The production gate is `integration.yml`.
+# Triggers: manual (`workflow_dispatch`) for on-demand numbers, plus
+# pull_request into main so release PRs are gated by the coverage
+# ratchet (scripts/coverage-ratchet.sh vs .github/coverage-baseline.txt).
+# Coverage runs cost ~3-5 min on top of the integration suite (cover
+# plugin build + flush + report); the per-PR production gate stays
+# `integration.yml`.
 #
 # Same self-hosted runner as integration.yml (gpu1), same security
 # posture (outside-collaborator approval required for forked PRs —
@@ -15,6 +18,20 @@ name: Coverage
 # this at all).
 on:
   workflow_dispatch:
+  # Release PRs (dev → main) run coverage as a required check: the
+  # ratchet below guarantees no release ships with regressed coverage.
+  # Feature PRs into dev stay on-demand via workflow_dispatch — the
+  # ~15-20 min cost is a release gate, not a per-PR tax (#127).
+  pull_request:
+    branches:
+      - main
+
+# Shared group with integration.yml — both mutate the same runner's
+# docker state. See the note there about GitHub's one-pending-run
+# replacement behaviour (#127).
+concurrency:
+  group: selfhosted-docker
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -126,6 +143,21 @@ jobs:
                   echo '```'
               fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # The ratchet: merged per-package coverage must hold the floors
+      # in .github/coverage-baseline.txt. No `if: always()` on purpose —
+      # a failed suite produces partial counters and would false-alarm;
+      # the ratchet only judges complete runs (#127).
+      - name: Coverage ratchet
+        run: |
+          if ls coverage-unit/covcounters.* >/dev/null 2>&1; then
+            go tool covdata percent -i="${COVER_DIR}",coverage-unit > /tmp/covdata-percent.txt
+          else
+            echo "No unit counters found — ratcheting on integration coverage alone would false-alarm."
+            exit 1
+          fi
+          cat /tmp/covdata-percent.txt
+          bash scripts/coverage-ratchet.sh /tmp/covdata-percent.txt .github/coverage-baseline.txt
 
       - name: Generate coverage reports
         if: always()

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,6 +20,17 @@ on:
       - main
       - dev
 
+# Serialize against every other workflow that touches the self-hosted
+# runner's shared docker state (the :integration / :golang-cover plugin
+# refs and the dnsmasq fixture ports). Shared group with coverage.yml.
+# Note GitHub keeps at most one running + one pending run per group: a
+# third run replaces the pending one (it shows as cancelled — re-run it
+# if its PR still needs the check). cancel-in-progress stays false so a
+# running suite is never killed mid-test (#127).
+concurrency:
+  group: selfhosted-docker
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,7 +41,7 @@ jobs:
     env:
       INTEGRATION_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:integration
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # The Go toolchain is pre-installed on the runner via
       # test/integration/install-go-runner.sh (one-time operator

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,19 +93,19 @@ jobs:
             echo "Pre-release tag: $TAG — :latest will not be moved"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ steps.tag.outputs.tag }}
           # Full history so RELEASE_NOTES.md credits / "since vX" greps
           # behave the same as on a developer checkout.
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -114,7 +114,7 @@ jobs:
       - name: Log in to Docker Hub
         id: hub-login
         if: env.HAS_HUB_CREDS == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -169,7 +169,7 @@ jobs:
       # alone won't do.
       - name: Sync Docker Hub description from README
         if: env.HAS_HUB_CREDS == 'true'
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+
     env:
       # GHCR is always pushed. Hub repo only pushed when secrets are set.
       # Hub uses the shorter `net-dhcp` name (matching upstream's
@@ -176,3 +179,36 @@ jobs:
               echo "_Docker Hub push skipped — set DOCKERHUB_USERNAME / DOCKERHUB_TOKEN secrets to enable._"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # Post-publish verification: install the artifact users will actually
+  # pull, from a clean GitHub-hosted runner. "We pushed bytes" is not
+  # "the deliverable works" — a plugin that 500s on install or fails to
+  # enable must turn the release run red, not surface in a user issue
+  # (#127). Exercised before each real release by the runbook's
+  # workflow_dispatch dry-run against the previous tag.
+  verify-install:
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GHCR_NAME: ghcr.io/claymore666/docker-net-dhcp
+    steps:
+      - name: Install released plugin from GHCR
+        run: |
+          TAG="${{ needs.release.outputs.tag }}"
+          REF="${GHCR_NAME}:${TAG}"
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          docker plugin install --grant-all-permissions "$REF"
+          docker plugin ls
+
+      - name: Assert plugin is enabled
+        run: |
+          TAG="${{ needs.release.outputs.tag }}"
+          REF="${GHCR_NAME}:${TAG}"
+          ENABLED="$(docker plugin inspect -f '{{.Enabled}}' "$REF")"
+          if [ "$ENABLED" != "true" ]; then
+            echo "Plugin installed but not enabled (Enabled=$ENABLED)"
+            docker plugin inspect "$REF"
+            exit 1
+          fi
+          echo "Plugin ${REF} installs and enables cleanly." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,12 @@ name: Release
 #
 # Trigger shapes:
 #   - `git tag v0.8.0 && git push --tags` → automatic
-#   - GitHub UI → "Run workflow" → enter tag → manual dry-run
+#   - `git tag v1.0.0-rc1 && git push --tags` → automatic, pre-release
+#     mode: full chain runs but `:latest` is NOT moved — the zero-impact
+#     end-to-end dry-run to do before every real release tag
+#   - GitHub UI → "Run workflow" → enter tag → manual re-run of an
+#     existing tag (NOTE: a bare vX.Y.Z here rebuilds and re-points
+#     that tag AND `:latest` — prefer the rc-tag dry-run)
 #
 # Required secrets (Settings → Secrets and variables → Actions):
 #   - DOCKERHUB_USERNAME — Docker Hub login (e.g. `claymore666`)
@@ -74,7 +79,19 @@ jobs:
             exit 1
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "Releasing tag: $TAG"
+          # Pre-release guard: a suffixed tag (vX.Y.Z-rc1 etc.) runs the
+          # full publishing chain — build, dual-registry push of the rc
+          # tag, description sync, verify-install — but must NOT move
+          # `:latest` or overwrite any bare release tag. This makes rc
+          # tags a zero-impact end-to-end dry-run of this workflow
+          # before the real vX.Y.Z tag (see docs/release-runbook.md).
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "Releasing tag: $TAG"
+          else
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "Pre-release tag: $TAG — :latest will not be moved"
+          fi
 
       - uses: actions/checkout@v4
         with:
@@ -118,19 +135,26 @@ jobs:
       # images do — every tag is a separate push of the same rootfs.
       # The Make `create` target rebuilds only the plugin handle, not
       # the underlying rootfs image, so the second push is fast.
+      # `:latest` is guarded: pre-release tags never move it (and would
+      # otherwise also let a dispatch of an OLD tag silently regress
+      # what `:latest` points at — only bare vX.Y.Z tags may move it).
       - name: Push to GHCR
-        run: |
-          make PLUGIN_NAME="${GHCR_NAME}" PLUGIN_TAG="${{ steps.tag.outputs.tag }}" push
-          make PLUGIN_NAME="${GHCR_NAME}" PLUGIN_TAG="latest" push
+        run: make PLUGIN_NAME="${GHCR_NAME}" PLUGIN_TAG="${{ steps.tag.outputs.tag }}" push
+
+      - name: Push :latest to GHCR
+        if: steps.tag.outputs.prerelease != 'true'
+        run: make PLUGIN_NAME="${GHCR_NAME}" PLUGIN_TAG="latest" push
 
       # Same plugin to Docker Hub when credentials are present. Make
       # rebuilds the rootfs with the Hub-prefixed name; the underlying
       # Docker image layer cache is reused so this is cheap.
       - name: Push to Docker Hub
         if: env.HAS_HUB_CREDS == 'true'
-        run: |
-          make PLUGIN_NAME="${HUB_NAME}" PLUGIN_TAG="${{ steps.tag.outputs.tag }}" push
-          make PLUGIN_NAME="${HUB_NAME}" PLUGIN_TAG="latest" push
+        run: make PLUGIN_NAME="${HUB_NAME}" PLUGIN_TAG="${{ steps.tag.outputs.tag }}" push
+
+      - name: Push :latest to Docker Hub
+        if: env.HAS_HUB_CREDS == 'true' && steps.tag.outputs.prerelease != 'true'
+        run: make PLUGIN_NAME="${HUB_NAME}" PLUGIN_TAG="latest" push
 
       # Refresh the Docker Hub long description from the repo's README
       # so the Hub page never drifts from what's on GitHub. Short
@@ -162,7 +186,11 @@ jobs:
           {
             echo "## Released ${{ steps.tag.outputs.tag }}"
             echo
-            echo "Each registry receives both \`:${{ steps.tag.outputs.tag }}\` (pin) and \`:latest\` (tip)."
+            if [ "${{ steps.tag.outputs.prerelease }}" = "true" ]; then
+              echo "**Pre-release dry-run** — \`:latest\` was not moved."
+            else
+              echo "Each registry receives both \`:${{ steps.tag.outputs.tag }}\` (pin) and \`:latest\` (tip)."
+            fi
             echo
             echo "### Install from GHCR"
             echo '```'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
       - dev
+  # Weekly run so govulncheck surfaces CVEs that publish between
+  # commits — new vulnerabilities don't wait for our next push (#127).
+  schedule:
+    - cron: '23 6 * * 1'
 
 permissions:
   contents: read
@@ -16,6 +20,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -23,6 +28,11 @@ jobs:
         with:
           go-version: '1.25'
           cache: true
+
+      # Drifted go.mod/go.sum slips through silently until someone
+      # builds from a clean checkout. -diff reports without rewriting.
+      - name: go.mod tidy check
+        run: go mod tidy -diff
 
       - name: Build
         run: go build ./...
@@ -41,8 +51,16 @@ jobs:
       - name: Test (with race detector)
         run: go test -race -count=1 ./...
 
+      # The CI gate scripts are code too — their table-driven tests run
+      # here so a broken ratchet/vuln gate fails like any unit test.
+      - name: Gate script self-tests
+        run: |
+          bash scripts/test-coverage-ratchet.sh
+          bash scripts/test-govulncheck-gate.sh
+
   staticcheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -53,3 +71,56 @@ jobs:
         run: go install honnef.co/go/tools/cmd/staticcheck@latest
       - name: Run staticcheck
         run: staticcheck ./...
+
+  # Lints all workflow files (+ shellcheck on run: blocks). A workflow
+  # parse error doesn't fail loudly on GitHub — it produces zero-job
+  # "failed" runs and silently disables tag triggers (bit us in v0.8.0).
+  # scripts/test-actionlint.sh additionally asserts the linter still
+  # catches that exact bug class, so a toothless actionlint upgrade
+  # turns this job red instead of passing silently (#127).
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+      - name: Lint workflows
+        run: actionlint -color
+      - name: Verify actionlint catches known-bad patterns
+        run: bash scripts/test-actionlint.sh actionlint
+
+  # Reachable-vulnerability scan. Known-and-reviewed findings without a
+  # published fix live in .github/vuln-allowlist.txt; anything else
+  # fails. The gate also warns when an allowlist entry stops being
+  # reported, so stale acceptances get removed (#127).
+  govulncheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      # Keep this toolchain in sync with the Dockerfile's golang base
+      # image — stdlib findings are evaluated against the scan
+      # toolchain, which should represent what ships in the plugin.
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Scan
+        run: |
+          govulncheck ./... > vulns.txt || true
+          cat vulns.txt
+          # A crashed scan must not pass as "no findings": assert the
+          # report actually concluded one way or the other.
+          if ! grep -qE 'No vulnerabilities found|Your code is affected' vulns.txt; then
+            echo "govulncheck did not produce a conclusive report"
+            exit 1
+          fi
+      - name: Gate against allowlist
+        run: bash scripts/govulncheck-gate.sh vulns.txt .github/vuln-allowlist.txt

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
           cache: true
@@ -62,8 +62,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
           cache: true
@@ -82,8 +82,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
           cache: true
@@ -102,11 +102,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # Keep this toolchain in sync with the Dockerfile's golang base
       # image — stdlib findings are evaluated against the scan
       # toolchain, which should represent what ships in the plugin.
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
           cache: true

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -78,7 +78,11 @@ fail loudly — it produces a "failed" run with no jobs and silently
 `if: ${{ secrets.X != '' }}` at step level (rejected; secrets
 context isn't allowed in step-level `if`).
 
-Defence: every release.yml change should be tested with
+First line of defence: the `actionlint` job in the Test workflow
+lints every workflow file on every PR (and
+`scripts/test-actionlint.sh` asserts the linter still catches this
+exact bug class). Second line: every release.yml change should be
+tested with
 `gh workflow run release.yml -f tag=vEXISTING.TAG --ref main`
 **before** tagging a real release. That dispatches the workflow
 against an already-published tag and exercises the full path
@@ -108,11 +112,18 @@ the `vX.Y.Z` milestone (the workflow leans on this for the
    notes** (e.g. v0.8.0 narrowed the `IsDHCPPlugin` regex — that
    needed a callout).
 4. **PR `release/vX.Y.Z` → `dev`.** Required checks: `test`,
-   `staticcheck`. Integration is informational. Merge when green.
+   `staticcheck`, `integration` (every PR builds and exercises its
+   own plugin on the integration runner). Merge when green.
 5. **Open the release PR `dev` → `main`** with title
    `Release vX.Y.Z` and a `Closes #N` line for **every issue** in
    the milestone. The list is what auto-closes them when the PR
    merges; without it the milestone stays open after the tag.
+   Release PRs additionally run the **Coverage** workflow with the
+   coverage ratchet (`scripts/coverage-ratchet.sh` vs
+   `.github/coverage-baseline.txt`): no release ships with less
+   per-package coverage than the previous one. If a package beat its
+   floor during the cycle, raise the baseline as part of the release
+   branch.
 6. **Merge the release PR.** Squash or merge commit — both fine;
    match what's in `git log`.
 7. **Pull main and tag:**
@@ -125,7 +136,11 @@ the `vX.Y.Z` milestone (the workflow leans on this for the
    <https://github.com/claymore666/docker-net-dhcp/actions/workflows/release.yml>.
    Expected steps: Resolve tag → checkout → setup-go →
    GHCR login → Hub login (or skip) → Push to GHCR → Push to
-   Hub (or skip) → Sync Hub description → Workflow summary.
+   Hub (or skip) → Sync Hub description → Workflow summary →
+   **verify-install** (separate job: installs the just-published
+   plugin from GHCR on a clean hosted runner and asserts it
+   enables — a red verify-install means users can't install what
+   we just shipped).
 8. **Cut the GitHub Release** — points the Releases page at the
    right artefact. Either:
    ```sh

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -97,7 +97,7 @@ verify-install — but **`:latest` is not moved** and no bare
 release tag is touched. Zero impact on anything a user pulls by
 default.
 
-Use it before every real release tag (step 7 below):
+Use it before every real release tag (step 8 below):
 
 ```sh
 git checkout main && git pull --ff-only      # the release commit
@@ -105,7 +105,11 @@ git tag v1.0.0-rc1 && git push origin v1.0.0-rc1
 ```
 
 Watch the run; every step including **verify-install** must be
-green. Then tag the real release. Naming: rc of the *upcoming*
+green. The rc window doubles as the final **documentation
+checkpoint** (procedure step 3): confirm README, `docs/`, and the
+RELEASE_NOTES section describe the version about to ship — if
+stale text surfaces now, fix it before the real tag. Then tag the
+real release. Naming: rc of the *upcoming*
 version (`v1.0.0-rc1` before `v1.0.0`) — semver orders it before
 the release and it labels the content truthfully. Bump the rc
 number for another attempt after a fix; never reuse an rc tag.
@@ -130,16 +134,27 @@ the `vX.Y.Z` milestone (the workflow leans on this for the
    - `docs/parent-attached-modes.md` — the `STATE_DIR` override
      example.
    Verify with `grep -n vPREV README.md docs/parent-attached-modes.md`.
-3. **Add a `## vX.Y.Z` section** to `RELEASE_NOTES.md`, **above
+3. **Documentation review** — read everything user-visible
+   top-to-bottom against what this release actually contains, not
+   just the version pins from step 2: `README.md` (feature list,
+   driver-opt table, examples), every file under `docs/`
+   (including this runbook — process changes during the cycle land
+   here too), and the coverage table if republished. Anything
+   describing the previous version's behaviour, options, or
+   numbers gets updated on the release branch now. When the
+   project gains a GitHub wiki, it joins this review. The rc
+   dry-run (step 8) is the *last checkpoint* for catching stale
+   docs — by the real tag, text and code must agree.
+4. **Add a `## vX.Y.Z` section** to `RELEASE_NOTES.md`, **above
    the previous version's section**. Summarise what's changing in
    user-visible terms; the workflow doesn't auto-build this from
    commit messages. Include any **operator-visible compatibility
    notes** (e.g. v0.8.0 narrowed the `IsDHCPPlugin` regex — that
    needed a callout).
-4. **PR `release/vX.Y.Z` → `dev`.** Required checks: `test`,
+5. **PR `release/vX.Y.Z` → `dev`.** Required checks: `test`,
    `staticcheck`, `integration` (every PR builds and exercises its
    own plugin on the integration runner). Merge when green.
-5. **Open the release PR `dev` → `main`** with title
+6. **Open the release PR `dev` → `main`** with title
    `Release vX.Y.Z` and a `Closes #N` line for **every issue** in
    the milestone. The list is what auto-closes them when the PR
    merges; without it the milestone stays open after the tag.
@@ -149,9 +164,9 @@ the `vX.Y.Z` milestone (the workflow leans on this for the
    per-package coverage than the previous one. If a package beat its
    floor during the cycle, raise the baseline as part of the release
    branch.
-6. **Merge the release PR.** Squash or merge commit — both fine;
+7. **Merge the release PR.** Squash or merge commit — both fine;
    match what's in `git log`.
-7. **Pull main, dry-run, then tag:** first push `vX.Y.Z-rc1` and
+8. **Pull main, dry-run, then tag:** first push `vX.Y.Z-rc1` and
    confirm the workflow run is green end-to-end (pre-release mode,
    `:latest` untouched — see "Pre-release dry-run" above). Then:
    ```sh
@@ -168,7 +183,7 @@ the `vX.Y.Z` milestone (the workflow leans on this for the
    plugin from GHCR on a clean hosted runner and asserts it
    enables — a red verify-install means users can't install what
    we just shipped).
-8. **Cut the GitHub Release** — points the Releases page at the
+9. **Cut the GitHub Release** — points the Releases page at the
    right artefact. Either:
    ```sh
    awk '/^## vX\.Y\.Z$/{flag=1; next} /^## v/{flag=0} flag' \
@@ -183,7 +198,7 @@ the `vX.Y.Z` milestone (the workflow leans on this for the
    Don't skip this — Hub and the GitHub Releases page diverge
    without it, and downstream consumers checking the Releases tag
    for "is this the real release?" will get confused.
-9. **Fast-forward `dev` to `main`** so the release commit (version
+10. **Fast-forward `dev` to `main`** so the release commit (version
    pins, RELEASE_NOTES section) lands on `dev` too:
    ```sh
    git checkout dev && git merge --ff-only main && git push origin dev

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -81,13 +81,38 @@ context isn't allowed in step-level `if`).
 First line of defence: the `actionlint` job in the Test workflow
 lints every workflow file on every PR (and
 `scripts/test-actionlint.sh` asserts the linter still catches this
-exact bug class). Second line: every release.yml change should be
-tested with
-`gh workflow run release.yml -f tag=vEXISTING.TAG --ref main`
-**before** tagging a real release. That dispatches the workflow
-against an already-published tag and exercises the full path
-without needing a new tag — if the dispatch returns
-`HTTP 422: failed to parse workflow`, the file's broken.
+exact bug class). Second line: the **rc-tag dry-run** (next
+section) exercises the whole publishing chain before every real
+tag. Avoid dispatching `release.yml` with a bare existing release
+tag — that *rebuilds and re-points* the tag and `:latest`
+(different toolchain ⇒ different digest), mutating artifacts users
+may have pinned.
+
+### Pre-release dry-run (rc tags)
+
+A tag with a pre-release suffix (`v1.0.0-rc1`) runs the release
+workflow in **pre-release mode**: the full chain executes — build,
+push of `:v1.0.0-rc1` to both registries, Hub description sync,
+verify-install — but **`:latest` is not moved** and no bare
+release tag is touched. Zero impact on anything a user pulls by
+default.
+
+Use it before every real release tag (step 7 below):
+
+```sh
+git checkout main && git pull --ff-only      # the release commit
+git tag v1.0.0-rc1 && git push origin v1.0.0-rc1
+```
+
+Watch the run; every step including **verify-install** must be
+green. Then tag the real release. Naming: rc of the *upcoming*
+version (`v1.0.0-rc1` before `v1.0.0`) — semver orders it before
+the release and it labels the content truthfully. Bump the rc
+number for another attempt after a fix; never reuse an rc tag.
+
+Cleanup (optional): rc plugin tags can be deleted from GHCR/Hub
+after the real release ships; the git tag stays as the audit
+trail.
 
 ## Per-release procedure
 
@@ -126,7 +151,9 @@ the `vX.Y.Z` milestone (the workflow leans on this for the
    branch.
 6. **Merge the release PR.** Squash or merge commit — both fine;
    match what's in `git log`.
-7. **Pull main and tag:**
+7. **Pull main, dry-run, then tag:** first push `vX.Y.Z-rc1` and
+   confirm the workflow run is green end-to-end (pre-release mode,
+   `:latest` untouched — see "Pre-release dry-run" above). Then:
    ```sh
    git checkout main && git pull --ff-only
    git tag -a vX.Y.Z -m "vX.Y.Z — <one-liner>"

--- a/scripts/coverage-ratchet.sh
+++ b/scripts/coverage-ratchet.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Coverage ratchet (#127): compare per-package coverage against the
+# committed baseline. Fails when any baselined package drops more than
+# RATCHET_EPSILON points below its floor. The baseline only moves up:
+# when a package beats its floor, raise the number in the baseline
+# file in the same PR that earned it.
+#
+# Usage: coverage-ratchet.sh <covdata-percent-output> <baseline-file>
+#   <covdata-percent-output>: file containing `go tool covdata percent`
+#       output, lines like:
+#         github.com/.../pkg/plugin   coverage: 82.4% of statements
+#   <baseline-file>: lines of "<package> <min-percent>", '#' comments ok.
+#
+# RATCHET_EPSILON (default 0.5): tolerated drop in percentage points,
+# absorbing run-to-run noise from timing-dependent integration paths.
+set -u
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 <covdata-percent-output> <baseline-file>" >&2
+    exit 2
+fi
+
+PERCENT_FILE="$1"
+BASELINE_FILE="$2"
+EPSILON="${RATCHET_EPSILON:-0.5}"
+fail=0
+
+while read -r pkg want; do
+    [ -z "$pkg" ] && continue
+    case "$pkg" in '#'*) continue ;; esac
+
+    got=$(awk -v p="$pkg" '$1 == p && $2 == "coverage:" { gsub(/%/, "", $3); print $3; exit }' "$PERCENT_FILE")
+    if [ -z "$got" ]; then
+        echo "FAIL  $pkg: in baseline but absent from coverage output — deleted/renamed? Update $BASELINE_FILE deliberately."
+        fail=1
+        continue
+    fi
+
+    verdict=$(awk -v got="$got" -v want="$want" -v eps="$EPSILON" 'BEGIN {
+        if (got + eps < want)      print "regressed"
+        else if (got > want)       print "improved"
+        else                       print "held"
+    }')
+    case "$verdict" in
+        regressed)
+            echo "FAIL  $pkg: ${got}% is below baseline ${want}% (epsilon ${EPSILON})"
+            fail=1
+            ;;
+        improved)
+            echo "PASS  $pkg: ${got}% beats baseline ${want}% — raise the floor in $BASELINE_FILE"
+            ;;
+        held)
+            echo "PASS  $pkg: ${got}% holds baseline ${want}%"
+            ;;
+    esac
+done < "$BASELINE_FILE"
+
+if [ "$fail" -ne 0 ]; then
+    echo
+    echo "Coverage ratchet failed. Add tests covering what this change touches;"
+    echo "lowering a floor in $BASELINE_FILE requires a recorded decision in the PR."
+fi
+exit "$fail"

--- a/scripts/govulncheck-gate.sh
+++ b/scripts/govulncheck-gate.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# govulncheck gate (#127): fail on any vulnerability govulncheck reports
+# as reachable from our code, unless its ID is in the reviewed
+# allowlist. Warn (without failing) about allowlist entries that are no
+# longer reported, so stale acceptances get cleaned up.
+#
+# Usage: govulncheck-gate.sh <govulncheck-text-output> <allowlist-file>
+#   <govulncheck-text-output>: captured stdout of `govulncheck ./...`
+#       (exit 3 from govulncheck means "findings exist" — capture the
+#       output and let this gate decide).
+#   <allowlist-file>: one GO-XXXX-XXXX ID per line, '#' comments ok.
+set -u
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 <govulncheck-text-output> <allowlist-file>" >&2
+    exit 2
+fi
+
+REPORT="$1"
+ALLOWLIST="$2"
+fail=0
+
+# IDs govulncheck reports as affecting our code (default text output
+# lists only reachable findings as "Vulnerability #N: GO-...").
+found=$(grep -E '^Vulnerability #' "$REPORT" | grep -oE 'GO-[0-9]{4}-[0-9]+' | sort -u)
+allowed=$(grep -vE '^[[:space:]]*(#|$)' "$ALLOWLIST" | grep -oE 'GO-[0-9]{4}-[0-9]+' | sort -u)
+
+for id in $found; do
+    if printf '%s\n' "$allowed" | grep -qx "$id"; then
+        echo "ALLOW $id: reported, accepted via $ALLOWLIST"
+    else
+        echo "FAIL  $id: reachable vulnerability not in $ALLOWLIST — fix the dependency or add a reviewed entry"
+        fail=1
+    fi
+done
+
+for id in $allowed; do
+    if ! printf '%s\n' "$found" | grep -qx "$id"; then
+        echo "WARN  $id: allowlisted but no longer reported — likely fixed; remove it from $ALLOWLIST"
+    fi
+done
+
+if [ "$fail" -eq 0 ]; then
+    echo "govulncheck gate passed"
+fi
+exit "$fail"

--- a/scripts/test-actionlint.sh
+++ b/scripts/test-actionlint.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Regression test for the actionlint gate (#127): assert actionlint
+# still flags the known-bad fixture, in particular the v0.8.0 trap
+# (secrets context in a step-level `if:`), which GitHub rejects at
+# parse time and thereby silently disables every trigger of the
+# workflow. If this script fails, the linter has lost the teeth we
+# rely on — treat it like a failing unit test, not a flaky check.
+#
+# Usage: test-actionlint.sh [path-to-actionlint]
+set -u
+
+ACTIONLINT="${1:-actionlint}"
+FIXTURE="$(dirname "$0")/testdata/bad-workflow.yml"
+OUT="$(mktemp)"
+trap 'rm -f "$OUT"' EXIT
+
+if "$ACTIONLINT" -no-color "$FIXTURE" >"$OUT" 2>&1; then
+    echo "FAIL: actionlint exited 0 on $FIXTURE — it must flag the fixture"
+    exit 1
+fi
+
+if ! grep -q 'context "secrets" is not allowed' "$OUT"; then
+    echo "FAIL: actionlint no longer flags 'secrets' in a step-level if: (the v0.8.0 trap)"
+    echo "--- actionlint output:"
+    cat "$OUT"
+    exit 1
+fi
+
+echo "PASS: actionlint flags the known-bad fixture (including the v0.8.0 secrets-in-step-if trap)"

--- a/scripts/test-coverage-ratchet.sh
+++ b/scripts/test-coverage-ratchet.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Table-driven tests for coverage-ratchet.sh (#127). Synthesizes
+# `go tool covdata percent` outputs and asserts the ratchet's verdicts:
+# hold/improve/within-epsilon pass, regression and vanished packages fail.
+set -u
+
+RATCHET="$(dirname "$0")/coverage-ratchet.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+BASELINE="$TMP/baseline.txt"
+cat > "$BASELINE" <<'EOF'
+# comment lines and blanks are ignored
+
+example.com/mod/pkg/a 80.0
+example.com/mod/pkg/b 50.0
+EOF
+
+failures=0
+check() {
+    local name="$1" want_exit="$2" percent_file="$3"
+    local eps="${4:-}"
+    local got_exit
+    if [ -n "$eps" ]; then
+        RATCHET_EPSILON="$eps" bash "$RATCHET" "$percent_file" "$BASELINE" > "$TMP/out" 2>&1
+    else
+        bash "$RATCHET" "$percent_file" "$BASELINE" > "$TMP/out" 2>&1
+    fi
+    got_exit=$?
+    if [ "$got_exit" -eq "$want_exit" ]; then
+        echo "PASS: $name"
+    else
+        echo "FAIL: $name (want exit $want_exit, got $got_exit)"
+        sed 's/^/    /' "$TMP/out"
+        failures=$((failures + 1))
+    fi
+}
+
+percent() { # percent <file> <pct-a> [<pct-b>]
+    local f="$1"
+    printf '\texample.com/mod/pkg/a\t\tcoverage: %s%% of statements\n' "$2" > "$f"
+    if [ "$#" -ge 3 ]; then
+        printf '\texample.com/mod/pkg/b\t\tcoverage: %s%% of statements\n' "$3" >> "$f"
+    fi
+}
+
+percent "$TMP/hold.txt" 80.0 50.0
+check "exact hold passes" 0 "$TMP/hold.txt"
+
+percent "$TMP/up.txt" 85.5 61.2
+check "improvement passes" 0 "$TMP/up.txt"
+
+percent "$TMP/noise.txt" 79.7 50.0
+check "drop within epsilon passes" 0 "$TMP/noise.txt"
+
+percent "$TMP/down.txt" 77.9 50.0
+check "regression fails" 1 "$TMP/down.txt"
+
+percent "$TMP/down-b.txt" 80.0 48.0
+check "regression in second package fails" 1 "$TMP/down-b.txt"
+
+percent "$TMP/gone.txt" 80.0
+check "baselined package missing from output fails" 1 "$TMP/gone.txt"
+
+percent "$TMP/eps.txt" 78.0 50.0
+check "wider RATCHET_EPSILON tolerates the drop" 0 "$TMP/eps.txt" 2.5
+
+if bash "$RATCHET" "$TMP/hold.txt" > /dev/null 2>&1; [ $? -eq 2 ]; then
+    echo "PASS: usage error exits 2"
+else
+    echo "FAIL: usage error should exit 2"
+    failures=$((failures + 1))
+fi
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures ratchet test(s) failed"
+    exit 1
+fi
+echo "All ratchet tests passed"

--- a/scripts/test-govulncheck-gate.sh
+++ b/scripts/test-govulncheck-gate.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Table-driven tests for govulncheck-gate.sh (#127): synthetic
+# govulncheck outputs against a synthetic allowlist.
+set -u
+
+GATE="$(dirname "$0")/govulncheck-gate.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+ALLOW="$TMP/allow.txt"
+cat > "$ALLOW" <<'EOF'
+# accepted, daemon-side only
+GO-2026-4887
+GO-2026-4883
+EOF
+
+failures=0
+check() {
+    local name="$1" want_exit="$2" report="$3"
+    bash "$GATE" "$report" "$ALLOW" > "$TMP/out" 2>&1
+    local got_exit=$?
+    if [ "$got_exit" -eq "$want_exit" ]; then
+        echo "PASS: $name"
+    else
+        echo "FAIL: $name (want exit $want_exit, got $got_exit)"
+        sed 's/^/    /' "$TMP/out"
+        failures=$((failures + 1))
+    fi
+}
+
+cat > "$TMP/clean.txt" <<'EOF'
+No vulnerabilities found.
+EOF
+check "no findings passes (and warns about stale allowlist)" 0 "$TMP/clean.txt"
+grep -q 'WARN  GO-2026-4887' "$TMP/out" || { echo "FAIL: missing stale-entry warning"; failures=$((failures + 1)); }
+
+cat > "$TMP/allowed.txt" <<'EOF'
+Vulnerability #1: GO-2026-4887
+    Moby AuthZ plugin bypass
+Vulnerability #2: GO-2026-4883
+    Moby off-by-one
+Your code is affected by 2 vulnerabilities from 1 module.
+EOF
+check "only allowlisted findings passes" 0 "$TMP/allowed.txt"
+
+cat > "$TMP/new.txt" <<'EOF'
+Vulnerability #1: GO-2026-4887
+    Moby AuthZ plugin bypass
+Vulnerability #2: GO-2099-0001
+    Something new and scary
+Your code is affected by 2 vulnerabilities.
+EOF
+check "non-allowlisted finding fails" 1 "$TMP/new.txt"
+
+# An ID that appears only in prose (informational sections) must not count.
+cat > "$TMP/prose.txt" <<'EOF'
+This scan also found GO-2099-0002 in packages you import, but your code
+doesn't appear to call it.
+No vulnerabilities found.
+EOF
+check "IDs outside 'Vulnerability #' lines are ignored" 0 "$TMP/prose.txt"
+
+if bash "$GATE" "$TMP/clean.txt" > /dev/null 2>&1; [ $? -eq 2 ]; then
+    echo "PASS: usage error exits 2"
+else
+    echo "FAIL: usage error should exit 2"
+    failures=$((failures + 1))
+fi
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures gate test(s) failed"
+    exit 1
+fi
+echo "All govulncheck-gate tests passed"

--- a/scripts/testdata/bad-workflow.yml
+++ b/scripts/testdata/bad-workflow.yml
@@ -1,0 +1,29 @@
+# Deliberately broken workflow — regression fixture for actionlint.
+#
+# This file lives OUTSIDE .github/workflows/ on purpose: GitHub must
+# never parse it, it exists only so scripts/test-actionlint.sh can
+# assert that actionlint still catches the patterns that have bitten
+# this repo. If actionlint ever stops flagging these, the CI job goes
+# red and we know our linter lost its teeth.
+name: bad fixture
+on:
+  push:
+    branches: [never-runs]
+jobs:
+  bad:
+    runs-on: ubuntu-latest
+    steps:
+      # The v0.8.0 trap: secrets context in a step-level `if:` is
+      # rejected by GitHub at parse time, which silently disables ALL
+      # triggers of the workflow — including tag pushes.
+      - name: secrets in step-level if
+        if: ${{ secrets.SOME_TOKEN != '' }}
+        run: echo never
+      # Reference to an undefined step output.
+      - name: undefined needs reference
+        run: echo "${{ needs.nonexistent.outputs.foo }}"
+      # Shellcheck must fire on run: blocks (unquoted var with glob).
+      - name: shellcheck target
+        run: |
+          FILES=$(ls *.txt)
+          for f in $FILES; do echo $f; done


### PR DESCRIPTION
## Summary

Implements the core items of #127. One PR with one revertible commit per item (rather than seven PRs) — the items share the scripts/test scaffolding and each PR would cost a full integration-runner cycle.

- **actionlint** (`b138b11`) — lints all workflows + shellchecks `run:` blocks on every PR. `scripts/test-actionlint.sh` asserts actionlint keeps catching the v0.8.0 secrets-in-step-`if` parse trap against a checked-in bad fixture, so the linter itself is regression-tested.
- **Dependabot** (`cc6a2b3`) — weekly grouped gomod + github-actions updates, targeting `dev`.
- **govulncheck gate** (`8204f64`) — fails on any reachable vulnerability not in the reviewed allowlist; warns on stale allowlist entries. **Live findings handled:** scanning found 6 reachable vulns — 4 stdlib ones vanish when built/scanned with the current Go 1.25 patch (the floating `golang:1.25-alpine` builder picks that up at next release build; note the shipped v0.9.0 binary predates the fixes), and 2 moby daemon-side ones (GO-2026-4887, GO-2026-4883) have **no fixed release** (verified against v28.5.2) and are allowlisted with justification and review date.
- **Coverage ratchet** (`5917a31`) — per-package floors seeded from the v0.9.0 published numbers; the Coverage workflow now also triggers on PRs into `main`, so release PRs are gated on never shipping regressed coverage. Floors only move up.
- **Release verify-install** (`779a1a8`) — after publishing, a clean hosted runner installs the GHCR artifact and asserts `Enabled=true`. Will be exercised end-to-end by the pre-release `workflow_dispatch` dry-run the runbook already mandates.
- **Hygiene + concurrency** (`7b1e637`) — `go mod tidy -diff` check, job timeouts, weekly schedule for CVE freshness, gate-script self-tests in CI; shared concurrency group serializing integration + coverage on the self-hosted runner.
- **Runbook** (`c188377`) — corrects the stale "integration is informational" line (required check since 2026-06-12) and documents the new gates.

Branch protection changes that pair with this PR (already applied / to apply on merge): `integration` required on dev+main (done); `coverage` to be added as a required check on `main` once this merges.

Deferred to #127's stretch list: CodeQL, Trivy rootfs scan, SHA-pinning actions (pairs with dependabot), hosted-runner spike.

## Test plan

- [x] All five workflows + dependabot config pass actionlint (with shellcheck) and YAML-parse locally.
- [x] `scripts/test-coverage-ratchet.sh` — 8 table-driven cases green.
- [x] `scripts/test-govulncheck-gate.sh` — 6 table-driven cases green.
- [x] `scripts/test-actionlint.sh` — fixture flagged, v0.8.0 pattern specifically detected.
- [x] govulncheck + gate run against the real module: passes with Go ≥1.25.10 toolchain, exactly the two allowlisted findings reported.
- [x] All scripts shellcheck-clean.
Post-merge observations (not checkable at merge time) are tracked as a checklist on #127: first scheduled Test run, first dependabot run, ratchet on the next release PR, verify-install via the v1.0.0-rc1 dry-run.
