### PR TITLE
tests: fix flaky vendor-class gateway assertions

### DIFF
--- a/test/integration/harness/container.go
+++ b/test/integration/harness/container.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	docker "github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
 )
 
 const (
@@ -167,16 +168,15 @@ func ExecOutput(t *testing.T, ctx context.Context, containerID string, cmd ...st
 		t.Fatalf("ExecAttach: %v", err)
 	}
 	defer att.Close()
-	buf := make([]byte, 8192)
+	// The exec has no TTY, so the attach stream is multiplexed: each
+	// frame carries an 8-byte header (stream id + payload length).
+	// Reading it raw embeds those header bytes in the returned string —
+	// line starts get garbage prefixes, which breaks any line-anchored
+	// parsing (#130). StdCopy demultiplexes; stdout and stderr both
+	// write into out to preserve the combined-output contract.
 	var out strings.Builder
-	for {
-		n, err := att.Reader.Read(buf)
-		if n > 0 {
-			out.Write(buf[:n])
-		}
-		if err != nil {
-			break
-		}
+	if _, err := stdcopy.StdCopy(&out, &out, att.Reader); err != nil {
+		t.Fatalf("demux exec output: %v", err)
 	}
 	return out.String()
 }

--- a/test/integration/vendor_class_test.go
+++ b/test/integration/vendor_class_test.go
@@ -44,13 +44,9 @@ func TestVendorClass_OverrideRoutesViaTaggedGateway(t *testing.T) {
 	id, _, _ := harness.RunContainer(t, ctx, netName, ctrName)
 
 	out := harness.ExecOutput(t, ctx, id, "ip", "route", "show", "default")
-	if !strings.Contains(out, harness.TestTaggedGateway) {
-		t.Errorf("expected default route via %s (tagged gateway); got:\n%s",
-			harness.TestTaggedGateway, out)
-	}
-	if strings.Contains(out, harness.DefaultGateway) {
-		t.Errorf("default route still points at %s — vendor_class override didn't fire upstream:\n%s",
-			harness.DefaultGateway, out)
+	if gw := defaultRouteGateway(t, out); gw != harness.TestTaggedGateway {
+		t.Errorf("default route via %s, want tagged gateway %s — vendor_class override didn't fire upstream:\n%s",
+			gw, harness.TestTaggedGateway, out)
 	}
 	t.Logf("default route: %s", strings.TrimSpace(out))
 }
@@ -83,13 +79,9 @@ func TestVendorClass_DefaultUsesUntaggedGateway(t *testing.T) {
 	id, _, _ := harness.RunContainer(t, ctx, netName, ctrName)
 
 	out := harness.ExecOutput(t, ctx, id, "ip", "route", "show", "default")
-	if !strings.Contains(out, harness.DefaultGateway) {
-		t.Errorf("expected default route via %s (default gateway); got:\n%s",
-			harness.DefaultGateway, out)
-	}
-	if strings.Contains(out, harness.TestTaggedGateway) {
-		t.Errorf("default route points at %s — vendor_class tag fired without the override:\n%s",
-			harness.TestTaggedGateway, out)
+	if gw := defaultRouteGateway(t, out); gw != harness.DefaultGateway {
+		t.Errorf("default route via %s, want default gateway %s — vendor_class tag fired without the override:\n%s",
+			gw, harness.DefaultGateway, out)
 	}
 	t.Logf("default route: %s", strings.TrimSpace(out))
 }
@@ -120,8 +112,28 @@ func TestVendorClass_NonMatchingValueUsesDefaultGateway(t *testing.T) {
 	id, _, _ := harness.RunContainer(t, ctx, netName, ctrName)
 
 	out := harness.ExecOutput(t, ctx, id, "ip", "route", "show", "default")
-	if !strings.Contains(out, harness.DefaultGateway) {
-		t.Errorf("non-matching vendor_class should still get the default gateway %s; got:\n%s",
-			harness.DefaultGateway, out)
+	if gw := defaultRouteGateway(t, out); gw != harness.DefaultGateway {
+		t.Errorf("non-matching vendor_class should still get the default gateway %s, got %s:\n%s",
+			harness.DefaultGateway, gw, out)
 	}
+}
+
+// defaultRouteGateway extracts the gateway of the default route from
+// `ip route` output. BusyBox `ip` (alpine test containers) ignores the
+// `show default` filter and prints the whole routing table, so
+// substring assertions against the raw output false-match the leased
+// address: the default gateway "192.168.99.1" is a prefix of every
+// lease in .10–.19, which appears in the subnet route's `src` field
+// (~11% flake, #130). Parse the actual default line and compare
+// gateways exactly instead.
+func defaultRouteGateway(t *testing.T, out string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[0] == "default" && fields[1] == "via" {
+			return fields[2]
+		}
+	}
+	t.Fatalf("no default route in ip route output:\n%s", out)
+	return ""
 }


### PR DESCRIPTION
## Summary

Fixes #130. The three `TestVendorClass_*` tests asserted gateways via `strings.Contains` on busybox `ip route show default` output — which is the **whole** routing table (busybox ignores the filter), so the default gateway `192.168.99.1` substring-matched the `src` field of any lease in `.10–.19` (~11% of the pool). First bite: PR #129's required integration run drew `.11` and false-failed `TestVendorClass_OverrideRoutesViaTaggedGateway` while the dumped route plainly showed the override had fired.

Replaces all substring assertions with a `defaultRouteGateway` helper that parses the `default via <gw>` line and compares exactly. Each test now reports the actual-vs-wanted gateway on failure instead of a misleading claim.

## Test plan

- [x] `go vet -tags integration` + gofmt clean.
- [x] Required `integration` check on this PR runs the three fixed tests against the live fixture.