### PR TITLE
docs: add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # docker-net-dhcp
 
+[![Test](https://github.com/claymore666/docker-net-dhcp/actions/workflows/test.yaml/badge.svg)](https://github.com/claymore666/docker-net-dhcp/actions/workflows/test.yaml)
+[![Integration](https://github.com/claymore666/docker-net-dhcp/actions/workflows/integration.yml/badge.svg)](https://github.com/claymore666/docker-net-dhcp/actions/workflows/integration.yml)
+[![Dependencies](https://img.shields.io/badge/dependencies-Dependabot%20%2B%20govulncheck-brightgreen?logo=dependabot)](https://github.com/claymore666/docker-net-dhcp/network/updates)
+[![Release](https://img.shields.io/github/v/release/claymore666/docker-net-dhcp?sort=semver)](https://github.com/claymore666/docker-net-dhcp/releases)
+
 > **This is a maintained fork** of [`devplayer0/docker-net-dhcp`][upstream].
 > The upstream repository has been quiet since 2021 and no longer builds on
 > current Docker. This fork modernises the toolchain (Go 1.25, docker SDK


### PR DESCRIPTION
## Summary

Four badges on the front page:

- **Test** + **Integration** — live workflow status (default branch).
- **Dependencies** — static informational badge (Dependabot + govulncheck), linking to the Dependabot update-jobs page (`/network/updates`). Static because GitHub offers no dynamic Dependabot-status endpoint; the *enforced* truth behind it is the govulncheck job in the Test workflow.
- **Release** — latest semver from GitHub Releases.

Note: the Dependabot link target stays empty until `dependabot.yml` reaches `main` with the v1.0.0 release PR — Dependabot (and `schedule:` triggers) read config from the default branch only.

## Test plan

- [x] Badge URLs verified to render (workflow badge endpoints + shields.io).
- [x] Markdown-only change; no code paths.