### PR TITLE
ci: add Dependabot config to default branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Weekly grouped dependency updates (#127). PRs target dev per the
+# branching workflow — nothing lands on main except via release PRs.
+# Grouping keeps the noise at one PR per ecosystem per week.
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: sunday
+    groups:
+      go-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: sunday
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot reads `.github/dependabot.yml` exclusively from the **default branch**. The config merged to `dev` in #129 is invisible to the service until it reaches `main` — the Dependabot tab currently shows "needs a config" despite the feature being enabled.

This brings the identical file (gomod + github-actions, weekly, grouped, `target-branch: dev`) to `main` so version updates and the manual **Check for updates** trigger are active ahead of the v1.0.0 release.

Follows the runbook's main-first exception pattern; no dev backport needed — `dev` already carries this exact file, so the next release PR merges cleanly over it.

- [x] File is byte-identical to `dev`'s (`git checkout origin/dev -- .github/dependabot.yml`)
- [ ] Dependabot tab populates after merge (verify post-merge)