### PR TITLE
docs: driver reference manual + option-docs drift check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,6 +57,12 @@ jobs:
         run: |
           bash scripts/test-coverage-ratchet.sh
           bash scripts/test-govulncheck-gate.sh
+          bash scripts/test-check-option-docs.sh
+
+      # Every driver-option key the code parses must be documented in
+      # docs/reference.md — an undocumented option turns CI red (#132).
+      - name: Option-docs drift check
+        run: bash scripts/check-option-docs.sh
 
   staticcheck:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@
 > exchanges through all three modes plus recovery, tombstone-stability,
 > and concurrency scenarios.
 >
-> See [`RELEASE_NOTES.md`](RELEASE_NOTES.md) for the full changelog and
+> See [`docs/reference.md`](docs/reference.md) for the complete driver
+> reference (all options, settings, observability, troubleshooting),
+> [`RELEASE_NOTES.md`](RELEASE_NOTES.md) for the full changelog and
 > credits, [`docs/parent-attached-modes.md`](docs/parent-attached-modes.md)
 > for the macvlan / ipvlan how-to, and
 > [`docs/release-runbook.md`](docs/release-runbook.md) for the

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,295 @@
+# docker-net-dhcp — driver reference
+
+The complete operator reference for the plugin: installation, network
+creation in every mode, all driver options, plugin settings,
+observability, Compose usage, and troubleshooting. This file is
+versioned with the code — the copy in your installed version's tag is
+the truth for that version. CI enforces that every driver-option key
+the code parses appears in this document
+(`scripts/check-option-docs.sh`), so the options table cannot go
+stale silently.
+
+Deeper-dive companions: [`parent-attached-modes.md`](parent-attached-modes.md)
+(macvlan/ipvlan concepts, DHCP identity, recovery semantics) and the
+top-level [`README.md`](../README.md) (bridge-mode walkthrough,
+implementation notes).
+
+---
+
+## Install / upgrade / uninstall
+
+The plugin publishes to two registries; GHCR is primary:
+
+- `ghcr.io/claymore666/docker-net-dhcp:vX.Y.Z` (primary)
+- `claymore666/net-dhcp:vX.Y.Z` (Docker Hub mirror)
+
+**Install** (interactive privilege grant, or `--grant-all-permissions`
+for unattended):
+
+```bash
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v0.9.0
+```
+
+Privileges requested: `network: host`, host PID namespace, the Docker
+socket mount, `CAP_NET_ADMIN` + `CAP_SYS_ADMIN`. All four are inherent
+to what the plugin does (creating links in arbitrary netns, driving
+DHCP on the host's L2 segments, querying the daemon).
+
+**Pin a version.** `:latest` exists and tracks the newest release, but
+networks remember the exact driver string they were created with — a
+network created against `:v0.9.0` needs that tag present to operate.
+Pinning makes upgrades a deliberate step instead of a pull-side
+surprise.
+
+**Upgrade** — networks reference the plugin tag they were created
+with, so the safe sequence for moving from `vOLD` to `vNEW` is:
+
+```bash
+# 1. Stop containers using plugin networks
+# 2. Remove the networks (they're cheap to recreate; leases release)
+docker network rm my-dhcp-net
+# 3. Swap the plugin
+docker plugin disable ghcr.io/claymore666/docker-net-dhcp:vOLD
+docker plugin rm ghcr.io/claymore666/docker-net-dhcp:vOLD
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:vNEW
+# 4. Recreate networks against vNEW, restart containers
+```
+
+(`docker plugin upgrade` exists but in-place upgrades while networks
+exist risk a driver-reference mismatch; the remove/recreate path is
+the supported one.)
+
+**Uninstall:**
+
+```bash
+docker plugin disable ghcr.io/claymore666/docker-net-dhcp:vX.Y.Z
+docker plugin rm ghcr.io/claymore666/docker-net-dhcp:vX.Y.Z
+```
+
+`disable` fails while networks still use the plugin — remove those
+first (`docker network ls`, `docker network rm ...`).
+
+---
+
+## Creating networks
+
+All modes share two invariants:
+
+- `--ipam-driver null` is **required**. The LAN's DHCP server is the
+  source of address truth; Docker's own IPAM would allocate from a
+  subnet of its choosing and collide with the LAN.
+- One DHCP-served network per container is the supported shape.
+
+### bridge (default)
+
+You bring an existing Linux bridge that is L2-connected to the LAN
+(see the [README](../README.md#network-creation-bridge-mode) for the
+bridge setup itself):
+
+```bash
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.9.0 \
+    --ipam-driver null \
+    -o bridge=my-bridge \
+    my-dhcp-net
+```
+
+### macvlan
+
+No host changes — containers get per-container kernel-generated MACs
+as macvlan children of a host NIC:
+
+```bash
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.9.0 \
+    --ipam-driver null \
+    -o mode=macvlan -o parent=eth0 \
+    lan-dhcp
+```
+
+### ipvlan (L2)
+
+Like macvlan, but children share the parent NIC's MAC — for switches
+or hypervisors that refuse multiple MACs per port (sticky-MAC port
+security, hostile vSwitches, some Wi-Fi APs). The DHCP server must
+key reservations on DHCP option 61 (client identifier), not MAC:
+
+```bash
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.9.0 \
+    --ipam-driver null \
+    -o mode=ipvlan -o parent=eth0 \
+    lan-dhcp
+```
+
+Mode-specific constraints (MAC behaviour, parent-NIC rules, kernel
+limitations) are catalogued in
+[`parent-attached-modes.md`](parent-attached-modes.md#constraints).
+
+---
+
+## Driver options (network-level)
+
+Passed as `-o key=value` on `docker network create`, or under
+`driver_opts:` in Compose. Booleans take `'true'` / `'false'`
+(quote them in YAML).
+
+| option | modes | default | since | description |
+| ------ | ----- | ------- | ----- | ----------- |
+| `mode` | — | `bridge` | macvlan v0.2.0, ipvlan v0.4.0 | Attachment strategy: `bridge`, `macvlan`, or `ipvlan` (L2). |
+| `bridge` | bridge | *(required)* | upstream | Existing Linux bridge to plug container veths into. |
+| `parent` | macvlan, ipvlan | *(required)* | v0.2.0 | Host NIC to attach children to (e.g. `eth0`, `ens18`). Must exist and be administratively `UP`. |
+| `gateway` | all | from DHCP | v0.3.0 | Override the IPv4 default gateway returned by the DHCP server — for split-horizon LANs where containers should egress via a different router (e.g. a VPN gateway). |
+| `ipv6` | all | `false` | upstream | Also run DHCPv6 (udhcpc6) alongside DHCPv4. |
+| `lease_timeout` | all | `10s` | upstream | Budget for the up-front DHCP exchange at container creation. Raise on slow/relayed networks (`-o lease_timeout=60s`). |
+| `ignore_conflicts` | bridge | `false` | upstream | Skip the bridge-already-in-use check against other Docker networks. No-op in macvlan/ipvlan. |
+| `skip_routes` | all | `false` | upstream; all modes since v0.9.0 | Don't copy non-default static routes from the parent (bridge or NIC) into containers. v0.9.0 extended route-copying from bridge-only to all modes (#102); set `true` to restore the old macvlan/ipvlan no-copy behaviour. |
+| `propagate_dns` | all | `false` | v0.9.0 | Write the DHCP-supplied DNS server list (option 6 / v6 option 23) into the container's `/etc/resolv.conf` on every bind/renew. Overrides Docker's embedded resolver for this network; the `search` line uses option 119 with fallback to option 15. |
+| `propagate_mtu` | all | `false` | v0.9.0 | Apply DHCP option 26 (Interface MTU) to the container link on bind/renew. For jumbo-frame (9000) and VPN-reduced (~1450) networks. |
+| `client_id` | all | per-endpoint id | v0.9.0 | Override DHCP option 61 (Client Identifier) for every endpoint on this network; sent as RFC 2132 opaque bytes (type `0x00`). The default per-endpoint id is what makes per-container reservations work — a fixed `client_id` makes all containers look like one client to the server. Pair with `vendor_class` for class-based policy. |
+| `vendor_class` | all | `docker-net-dhcp` | v0.9.0 | Override DHCP option 60 (Vendor Class Identifier), for DHCP servers running class-based policy (different gateway/option sets per class). v4 only — udhcpc6 doesn't take this option. |
+| `validate_dhcp` | macvlan, ipvlan | `false` | v0.9.0 | Pre-flight probe at `docker network create`: one-shot DHCP exchange on the parent with a random locally-administered MAC, rejecting the network if no server answers within 5s. Catches isolated parents / blocked UDP 67-68 / broken VLAN tags at create time. Costs one transient lease per probe. Bridge mode rejects the option. |
+| `audit_log` | all | `false` | v1.0.0 | Append every lease-lifecycle event (`bound` / `renew` / `release` / `release_failed`) to `STATE_DIR/leases.jsonl` — one JSON object per line with timestamp, network, endpoint, container, hostname, IP, MAC. Rotated at 16 MB or 30 days (one rotated generation kept, ≤ ~32 MB total). Append failures bump `ledger_write_failures` on `/Plugin.Health`, never affecting lease handling. Off by default: per-event disk write, and container↔IP correlation on disk is privacy-relevant in some environments. |
+
+## Driver options (per-endpoint)
+
+Passed per container via `docker network connect --driver-opt`, or as
+`driver_opts:` under a service's network attachment in Compose:
+
+| option | description |
+| ------ | ----------- |
+| `ip` | Request a specific IPv4 address (bare IP, no CIDR — the netmask comes from DHCP). Equivalent to `docker run --ip`; setting both to different values is an error. The address is *requested* from the DHCP server (DHCPREQUEST for it); the server still has final say. |
+
+A static IPv6 request (`--ip6` / Interface.AddressIPv6) is currently
+accepted but logged-and-skipped — busybox udhcpc6 has no
+request-this-address flag. The v6 lease comes unhinted.
+
+Container-level knobs that interact with the plugin:
+
+- `--mac-address` / Compose `mac_address` — fix the MAC so the DHCP
+  server's MAC-keyed reservations apply (macvlan and bridge; ipvlan
+  rejects custom MACs by kernel design).
+- `--hostname` / Compose `hostname` — sent as DHCP option 12, so
+  DHCP-DNS integration registers the container under this name.
+
+---
+
+## Plugin settings
+
+Set with `docker plugin set <plugin> NAME=value`; take effect after
+`docker plugin disable && docker plugin enable`:
+
+| name | default | meaning |
+| ---- | ------- | ------- |
+| `LOG_LEVEL` | `info` | logrus level (`trace`, `debug`, `info`, `warn`, `error`). `trace` includes per-event udhcpc lines and full HTTP-RPC bodies. |
+| `AWAIT_TIMEOUT` | `10s` | Cap on the polling helpers (sandbox readiness, link rename, netns appearance). Bump if a slow daemon-restore window starves endpoint setup. |
+| `STATE_DIR` | `/var/lib/net-dhcp` | Where per-network options, the tombstone file, and the `audit_log` ledger persist (inside the plugin rootfs). |
+
+---
+
+## Observability
+
+### `/Plugin.Health`
+
+JSON liveness + counters on the plugin's UNIX socket:
+
+```bash
+PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v0.9.0)
+curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
+    http://localhost/Plugin.Health | jq .
+```
+
+| field | healthy-affecting | meaning |
+| ----- | ----------------- | ------- |
+| `healthy` | — | `false` when `recovery_failed` or `tombstone_write_failures` is non-zero — an operator should look. The plugin keeps serving fresh attaches either way. |
+| `uptime_seconds` | — | Seconds since the plugin process started. |
+| `active_endpoints` | — | DHCP managers currently registered (post-Join, pre-Leave). |
+| `pending_hints` | — | Join hints awaiting consumption; steady-state ~0. |
+| `recovered_ok` | — | Endpoints successfully rebuilt by plugin-restart recovery. |
+| `recovery_failed` | yes | Endpoints whose post-restart rebuild failed — those containers run without lease renewal and lose their IP at expiry; restart them. |
+| `tombstone_write_failures` | yes | Failed tombstone saves (disk full, EROFS) — the next restart of some container will pick a fresh MAC/IP instead of inheriting. |
+| `lease_changed` | no | Renewals that returned a different IP than last recorded. Docker's `inspect` view does **not** update on lease change (libnetwork has no in-place endpoint-IP swap), so this is the stale-inspect-window signal — alert on it for long-running containers. |
+| `leases_obtained` | no | udhcpc `bound` events (initial bind or re-bind after NAK/lease loss). |
+| `leases_renewed` | no | udhcpc `renew` events. |
+| `dhcp_timeouts` | no | udhcpc `leasefail` events (no OFFER / no ACK within budget). |
+| `lease_release_failures` | no | Teardown DHCPRELEASE didn't complete cleanly — the server may hold a phantom lease until natural expiry. A pattern points at upstream reachability problems mid-teardown. |
+| `ledger_write_failures` | no | Failed `audit_log` ledger appends — degrades forensics, not networking. Operators using `audit_log` alert on this. |
+
+### Plugin log
+
+```bash
+sudo cat /var/lib/docker/plugins/*/rootfs/var/log/net-dhcp.log
+```
+
+Raise verbosity with `docker plugin set <plugin> LOG_LEVEL=trace`
+(plus a disable/enable cycle).
+
+### Lease audit ledger (`audit_log=true`)
+
+`STATE_DIR/leases.jsonl` inside the plugin rootfs:
+
+```bash
+sudo cat /var/lib/docker/plugins/*/rootfs/var/lib/net-dhcp/leases.jsonl | jq .
+```
+
+One JSON object per line; kinds `bound`, `renew`, `release`,
+`release_failed`. `release_failed` means the DHCPRELEASE may not have
+reached the server — the ledger never claims a release that might not
+have happened.
+
+---
+
+## Compose usage
+
+Recommended shape — network created once out-of-band, referenced as
+external (shareable across projects, survives `compose down`):
+
+```yaml
+services:
+  app:
+    image: nginx
+    hostname: my-server          # → DHCP option 12 → DHCP-DNS name
+    mac_address: 02:42:ac:00:00:01  # match a server-side reservation
+    networks:
+      - lan
+networks:
+  lan:
+    external: true
+    name: lan-dhcp
+```
+
+Compose-managed alternative (network lifecycle tied to the project):
+
+```yaml
+networks:
+  lan:
+    driver: ghcr.io/claymore666/docker-net-dhcp:v0.9.0
+    driver_opts:
+      mode: macvlan
+      parent: eth0
+      propagate_dns: 'true'
+    ipam:
+      driver: 'null'
+```
+
+Multi-network containers work (one plugin network per container is
+the *supported* shape; multiple attach but interface naming order is
+engine-determined — see the known-limitations note in issue #125).
+
+---
+
+## Troubleshooting
+
+| symptom | likely cause | fix |
+| ------- | ------------ | --- |
+| `docker run` hangs then fails with a lease timeout | No DHCP reply on the parent L2 (isolated NIC, firewall on UDP 67/68, wrong VLAN) | Verify with `-o validate_dhcp=true` at create time; check the parent's connectivity; raise `-o lease_timeout` for slow/relayed networks |
+| `invalid rootfs in image configuration` at install | Old Docker engine | Upgrade Docker |
+| Network create fails `Bridge already in use` | Another Docker network owns the bridge | Use a dedicated bridge, or `-o ignore_conflicts=true` if the detection is wrong |
+| Container has an IP but `docker inspect` shows a different one | Mid-life re-acquisition after NAK/lease change | Expected degraded mode; watch `lease_changed` on `/Plugin.Health`; restart the container to resync Docker's view |
+| `--mac-address` fails on an ipvlan network | ipvlan children share the parent MAC (kernel design) | Use `mode=macvlan`, or drop the custom MAC |
+| Reservations don't stick on ipvlan | DHCP server keys on MAC only, ignores option 61 | Use `mode=macvlan`, or configure the server to honor client identifiers |
+| Container can't reach the Docker host (or vice versa) | macvlan/ipvlan kernel rule: children can't talk to the parent NIC's host IP | Bridge mode, or a second NIC — not a plugin setting |
+| `healthy: false` on `/Plugin.Health` | Recovery or tombstone-write failure | See the field table above; restart affected containers; check disk space under the plugin rootfs |
+| `docker plugin disable` refuses | Networks still reference the plugin | `docker network rm` them first |
+| Renewals failing after a server outage | — | Containers keep their address and udhcpc keeps retrying; `dhcp_timeouts` climbs while the server is gone and `leases_renewed` resumes after it returns |
+
+Operator-side release/publishing issues (registry auth, Hub tokens)
+are covered in the maintainer-facing
+[`release-runbook.md`](release-runbook.md#troubleshooting).

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -133,7 +133,11 @@ the `vX.Y.Z` milestone (the workflow leans on this for the
      install instructions.
    - `docs/parent-attached-modes.md` — the `STATE_DIR` override
      example.
-   Verify with `grep -n vPREV README.md docs/parent-attached-modes.md`.
+   - `docs/reference.md` — install/upgrade snippets, the Health
+     `curl` example, and the Compose `driver:` example all pin the
+     version.
+   Verify with
+   `grep -n vPREV README.md docs/parent-attached-modes.md docs/reference.md`.
 3. **Documentation review** — read everything user-visible
    top-to-bottom against what this release actually contains, not
    just the version pins from step 2: `README.md` (feature list,

--- a/scripts/check-option-docs.sh
+++ b/scripts/check-option-docs.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Option-docs drift check (#132): every driver-option key the plugin
+# parses must appear (backticked) in the reference manual. Adding an
+# option without documenting it turns CI red — staleness becomes
+# impossible rather than reviewable.
+#
+# Keys are extracted from the code, not hardcoded here:
+#   1. Network-level options: fields of the DHCPNetworkOptions struct —
+#      the mapstructure tag when present, the lowercased field name
+#      otherwise (mapstructure's case-insensitive default match).
+#   2. Per-endpoint options: string literals indexing an options map,
+#      i.e. `options["<key>"]` / `Options["<key>"]`.
+#
+# Usage: check-option-docs.sh [<go-package-dir>] [<reference-doc>]
+#   defaults: pkg/plugin docs/reference.md (run from the repo root)
+set -u
+
+PKG_DIR="${1:-pkg/plugin}"
+DOC="${2:-docs/reference.md}"
+
+if [ ! -d "$PKG_DIR" ] || [ ! -f "$DOC" ]; then
+    echo "usage: $0 [<go-package-dir>] [<reference-doc>]" >&2
+    echo "missing: $PKG_DIR or $DOC" >&2
+    exit 2
+fi
+
+# Non-test Go sources only — tests synthesize option maps freely.
+src_files=$(find "$PKG_DIR" -maxdepth 1 -name '*.go' ! -name '*_test.go')
+if [ -z "$src_files" ]; then
+    echo "FAIL  no Go sources found under $PKG_DIR" >&2
+    exit 2
+fi
+
+# shellcheck disable=SC2086  # word-splitting src_files is intended
+struct_keys=$(awk '
+    /type DHCPNetworkOptions struct \{/ { in_struct = 1; next }
+    in_struct && /^\}/                  { in_struct = 0 }
+    in_struct {
+        line = $0
+        sub(/^[ \t]+/, "", line)
+        if (line ~ /^\/\// || line == "") next
+        if (match(line, /^[A-Z][A-Za-z0-9]*/)) {
+            name = substr(line, RSTART, RLENGTH)
+            if (match(line, /mapstructure:"[^"]+"/)) {
+                tag = substr(line, RSTART, RLENGTH)
+                gsub(/mapstructure:"|"/, "", tag)
+                print tag
+            } else {
+                print tolower(name)
+            }
+        }
+    }
+' $src_files)
+
+if [ -z "$struct_keys" ]; then
+    echo "FAIL  DHCPNetworkOptions struct not found in $PKG_DIR — moved/renamed? Update $0 deliberately." >&2
+    exit 1
+fi
+
+# shellcheck disable=SC2086
+endpoint_keys=$(grep -hoE '[Oo]ptions\["[a-z0-9_]+"\]' $src_files \
+    | sed -E 's/.*\["([a-z0-9_]+)"\].*/\1/' | sort -u)
+
+fail=0
+for key in $(printf '%s\n%s\n' "$struct_keys" "$endpoint_keys" | sort -u); do
+    if grep -q "\`$key\`" "$DOC"; then
+        echo "PASS  $key documented in $DOC"
+    else
+        echo "FAIL  $key: parsed by the code but not documented in $DOC"
+        fail=1
+    fi
+done
+
+if [ "$fail" -ne 0 ]; then
+    echo
+    echo "Option-docs drift: add the missing key(s) to the driver-options"
+    echo "table in $DOC (backticked) in the same PR that introduces them."
+fi
+exit "$fail"

--- a/scripts/test-check-option-docs.sh
+++ b/scripts/test-check-option-docs.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Table-driven tests for check-option-docs.sh (#132). Synthesizes a Go
+# package with a DHCPNetworkOptions struct + endpoint-opt parsing and a
+# reference doc, asserting: full documentation passes, a missing tagged
+# key / untagged field / endpoint opt each fail, test files are
+# ignored, and a vanished struct is an explicit failure.
+set -u
+
+CHECK="$(dirname "$0")/check-option-docs.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PKG="$TMP/pkg"
+mkdir -p "$PKG"
+
+cat > "$PKG/plugin.go" <<'EOF'
+package plugin
+
+// DHCPNetworkOptions mirrors the real struct's shapes: tagged fields,
+// untagged fields (mapstructure matches the lowercased name), and
+// comment lines inside the struct body.
+type DHCPNetworkOptions struct {
+	Mode   string `mapstructure:"mode"`
+	Bridge string
+	// LeaseTimeout has a comment line above it.
+	LeaseTimeout time.Duration `mapstructure:"lease_timeout"`
+	AuditLog     bool          `mapstructure:"audit_log"`
+}
+EOF
+
+cat > "$PKG/network.go" <<'EOF'
+package plugin
+
+func parseDriverOptIP(options map[string]interface{}) {
+	_ = options["ip"]
+}
+EOF
+
+# Option keys referenced only in tests must NOT be required.
+cat > "$PKG/network_test.go" <<'EOF'
+package plugin
+
+func TestSomething(t *testing.T) {
+	_ = map[string]interface{}{}["only_in_tests"]
+}
+EOF
+
+DOC="$TMP/reference.md"
+all_documented() {
+    cat > "$DOC" <<'EOF'
+| `mode` | the mode |
+| `bridge` | the bridge |
+| `lease_timeout` | the timeout |
+| `audit_log` | the ledger |
+| `ip` | endpoint static IP |
+EOF
+}
+
+failures=0
+check() {
+    local name="$1" want_exit="$2"
+    bash "$CHECK" "$PKG" "$DOC" > "$TMP/out" 2>&1
+    local got_exit=$?
+    if [ "$got_exit" -eq "$want_exit" ]; then
+        echo "PASS: $name"
+    else
+        echo "FAIL: $name (want exit $want_exit, got $got_exit)"
+        sed 's/^/    /' "$TMP/out"
+        failures=$((failures + 1))
+    fi
+}
+
+# 1. Everything documented -> green.
+all_documented
+check "all keys documented passes" 0
+
+# 2. Missing tagged key -> red, named in output.
+all_documented && sed -i '/audit_log/d' "$DOC"
+check "missing tagged key fails" 1
+grep -q 'FAIL  audit_log' "$TMP/out" || { echo "FAIL: missing key not named"; failures=$((failures + 1)); }
+
+# 3. Missing untagged field (lowercased name) -> red.
+all_documented && sed -i '/bridge/d' "$DOC"
+check "missing untagged field fails" 1
+
+# 4. Missing endpoint driver-opt -> red.
+# shellcheck disable=SC2016  # literal backticks in the sed pattern
+all_documented && sed -i '/`ip`/d' "$DOC"
+check "missing endpoint opt fails" 1
+
+# 5. Keys only in _test.go files are not required.
+all_documented
+check "test-only keys ignored" 0
+
+# 6. Struct vanished (renamed/moved) -> explicit failure, not silent green.
+all_documented
+mv "$PKG/plugin.go" "$PKG/plugin.go.bak"
+check "vanished struct fails" 1
+mv "$PKG/plugin.go.bak" "$PKG/plugin.go"
+
+# 7. Bad usage -> exit 2.
+bash "$CHECK" "$TMP/nonexistent" "$DOC" > "$TMP/out" 2>&1
+if [ $? -eq 2 ]; then echo "PASS: bad usage exits 2"; else echo "FAIL: bad usage"; failures=$((failures + 1)); fi
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures test(s) failed"
+    exit 1
+fi
+echo "all check-option-docs tests passed"


### PR DESCRIPTION
Closes-via-release: #132 (stays open until the release PR's `Closes` list lands on main, per workflow)

## What

- **`docs/reference.md`** — the complete versioned operator reference: install / upgrade / uninstall, network creation per mode (bridge / macvlan / ipvlan), the full **driver-options table** (14 network-level keys incl. `audit_log`, plus the per-endpoint `ip` opt), plugin settings (`LOG_LEVEL`, `AWAIT_TIMEOUT`, `STATE_DIR`), every `/Plugin.Health` field with healthy-affecting flags, Compose usage, and a troubleshooting table. In-repo and versioned — wiki explicitly rejected in #132.
- **`scripts/check-option-docs.sh`** — drift gate: extracts every option key the code parses (mapstructure tags, lowercased untagged `DHCPNetworkOptions` fields, `options["…"]` endpoint opts — no hardcoded key list) and fails CI naming any key absent from `reference.md`.
- **`scripts/test-check-option-docs.sh`** — 7-case table-driven self-test (documented→pass, missing tagged/untagged/endpoint key→fail, test-only keys ignored, vanished struct→explicit fail, bad usage→exit 2), run in the Test workflow's gate-script step.
- New **Option-docs drift check** step in `test.yaml`.
- Runbook pin-bump step now lists `reference.md` (it carries version pins); README links the manual.

## Verification

- Self-test: 7/7 PASS locally; real run: 15/15 keys documented.
- **Red-path demonstration** (required by #132's test plan) — with all `audit_log` mentions removed from the doc:
  ```
  FAIL  audit_log: parsed by the code but not documented in docs/reference.md
  exit: 1
  ```
- shellcheck clean (koalaman/shellcheck:stable), actionlint clean.
- Every option row verified against the parsing code: `pkg/plugin/plugin.go` `DHCPNetworkOptions` (lines 122-206), `pkg/plugin/network.go` `parseDriverOptIP`/`resolveExplicitV4` (lines 270-330); Health fields against `pkg/plugin/endpoints.go` `HealthResponse` (lines 238-267).

- [x] Drift-check self-test green in CI (gate-script step)
- [x] Deliberate removal of one documented key turns the check red (demonstrated above)
- [x] Manual review: every option in the table verified against the parsing code (file references above)