### PR TITLE
tests: runtime failure-injection suite + naks_received counter

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,9 @@ permissions:
 jobs:
   coverage:
     runs-on: [self-hosted, gpu1]
-    timeout-minutes: 20
+    # 35 = main + failure-injection suites against the instrumented
+    # plugin (#128) + cover build + margin.
+    timeout-minutes: 35
     env:
       COVER_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:golang-cover
       COVER_DIR: /var/lib/dh-cover
@@ -90,6 +92,15 @@ jobs:
         env:
           INTEGRATION_PLUGIN_REF: ${{ env.COVER_PLUGIN_REF }}
         run: make integration-test
+
+      # The failure-injection suite (#128) exercises paths the main
+      # suite can't reach (NAK handling, post-expiry retry loop) — the
+      # ratchet counts both runs' coverage, so both must drive the
+      # instrumented plugin.
+      - name: Run failure-injection tests against cover plugin
+        env:
+          INTEGRATION_PLUGIN_REF: ${{ env.COVER_PLUGIN_REF }}
+        run: make integration-test-failure
 
       # Flush counter files. Go's binary coverage runtime only writes
       # `covcounters.*` on graceful exit, which `docker plugin disable`

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,7 +37,9 @@ permissions:
 jobs:
   integration:
     runs-on: [self-hosted, gpu1]
-    timeout-minutes: 20
+    # 35 = main suite (~10) + failure-injection suite (~10, mostly
+    # deliberate DHCP-timing waits) + plugin build + margin (#128).
+    timeout-minutes: 35
     env:
       INTEGRATION_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:integration
     steps:
@@ -84,6 +86,13 @@ jobs:
 
       - name: Run integration tests
         run: make integration-test
+
+      # Failure-injection suite (#128): server loss, NAK on renewal,
+      # lease expiry — each against a per-test ephemeral DHCP server.
+      # Separate step so a red here is immediately distinguishable
+      # from a main-suite regression.
+      - name: Run failure-injection tests
+        run: make integration-test-failure
 
       # Tear down so a follow-up workflow on the same runner doesn't
       # find a stale `:integration` plugin pinned to the previous

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ BINARY = bin/net-dhcp
 
 PLUGIN_COVER_TAG ?= golang-cover
 
-.PHONY: all debug build create enable disable pdebug push clean integration-test integration-cleanup \
+.PHONY: all debug build create enable disable pdebug push clean integration-test \
+        integration-test-failure integration-cleanup \
         build-cover plugin-cover create-cover enable-cover disable-cover
 
 all: create enable
@@ -99,7 +100,18 @@ integration-test:
 		echo "integration-test must run as root. Re-run with sudo."; \
 		exit 1; \
 	fi
-	go test -v -tags integration -count=1 -timeout 10m ./test/integration/...
+	go test -v -tags integration -count=1 -timeout 10m -skip 'TestFailure_' ./test/integration/...
+
+# Failure-injection suite (#128): crosses real DHCP timing boundaries
+# (lease expiry, NAK at T1) against per-test ephemeral DHCP servers —
+# ~9 serial minutes of mostly deliberate waiting, so it runs as its
+# own step instead of inflating the main suite's feedback loop.
+integration-test-failure:
+	@if [ "$$(id -u)" -ne 0 ]; then \
+		echo "integration-test-failure must run as root. Re-run with sudo."; \
+		exit 1; \
+	fi
+	go test -v -tags integration -count=1 -timeout 15m -run 'TestFailure_' ./test/integration/...
 
 # Manual orphan cleanup for when an integration test panics mid-setup
 # and leaves dh-itest-* interfaces / containers / networks behind.

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ integration-test:
 		echo "integration-test must run as root. Re-run with sudo."; \
 		exit 1; \
 	fi
-	go test -v -tags integration -count=1 -timeout 10m -skip 'TestFailure_' ./test/integration/...
+	go test -v -tags integration -count=1 -timeout 20m -skip 'TestFailure_' ./test/integration/...
 
 # Failure-injection suite (#128): crosses real DHCP timing boundaries
 # (lease expiry, NAK at T1) against per-test ephemeral DHCP servers —

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -407,7 +407,8 @@ user-visible outcome.
   "leases_obtained": 17,
   "leases_renewed": 42,
   "dhcp_timeouts": 0,
-  "lease_release_failures": 0
+  "lease_release_failures": 0,
+  "naks_received": 0
 }
 ```
 
@@ -448,6 +449,14 @@ DHCP-wire counters (v0.9.0+):
   hold a phantom lease against the container's MAC until natural
   expiry. A pattern of these typically points at upstream
   reachability problems mid-teardown.
+- `naks_received` (v1.0.0+) — the server NAKed a renewal/rebind
+  REQUEST (pool reconfigured, address reassigned, lease revoked).
+  udhcpc recovers by re-DISCOVERing, so each NAK is typically
+  followed by `leases_obtained` and — if the address moved —
+  `lease_changed` bumps. NAKs climbing alongside `lease_changed`
+  means containers are being re-addressed mid-life: `docker
+  inspect` goes stale (see `lease_changed` above) and anything
+  keyed on the old IPs needs attention.
 
 Sample call from a host shell:
 

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -552,6 +552,9 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 					}
 					log.WithFields(m.logFields(v6)).Warn("udhcpc failed to get a lease")
 				case "nak":
+					if m.plugin != nil {
+						m.plugin.naksReceived.Add(1)
+					}
 					log.WithFields(m.logFields(v6)).Warn("udhcpc client received NAK")
 				}
 

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -286,6 +286,42 @@ func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
 			WithField("old_ip", lastIP).
 			WithField("new_ip", ip).
 			Warn("udhcpc renew with changed IP — Docker's view is now stale")
+
+		// Apply the re-acquired lease to the link (v4). Found by
+		// TestFailure_LeaseRefusedOnRenewal (#128): without this the
+		// kernel keeps the ORIGINAL address forever — the container
+		// answers on an address the server may already have handed to
+		// someone else, and after a server-side renumbering the
+		// default-route replacement below failed with "network is
+		// unreachable" (no address in the new subnet), aborting the
+		// bind and black-holing the endpoint. Address first, routes
+		// after — same ordering the kernel itself requires.
+		//
+		// v6 is deliberately left alone for now: the persistent
+		// udhcpc6 negotiates a second IA (different IAID than
+		// CreateEndpoint's one-shot), so "changed IP" is the v6
+		// steady-state, and re-addressing would flip every ipv6=true
+		// container to the persistent IA seconds after start. That
+		// unification is its own design change, tracked with #103's
+		// follow-up.
+		//
+		// netHandle/ctrLink are always live on the production path
+		// (renew runs from the event loop, post-Start); the guard
+		// keeps pre-Start unit tests of the counter semantics valid.
+		if !v6 && m.netHandle != nil && m.ctrLink != nil {
+			if err := m.netHandle.AddrReplace(m.ctrLink, ip); err != nil {
+				return fmt.Errorf("failed to apply re-acquired address %v: %w", ip, err)
+			}
+			if err := m.netHandle.AddrDel(m.ctrLink, lastIP); err != nil {
+				// Non-fatal: a lingering stale address is strictly
+				// better than failing the bind on cleanup.
+				log.
+					WithError(err).
+					WithFields(m.logFields(v6)).
+					WithField("stale_ip", lastIP).
+					Warn("Failed to remove stale address after lease change")
+			}
+		}
 	}
 
 	// Surface DHCP options the plugin captures but doesn't auto-apply

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -415,6 +415,71 @@ func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
 	return nil
 }
 
+// handleEvent dispatches one udhcpc lifecycle event from the
+// persistent client: health counters, audit-ledger entries, and the
+// kernel-facing renew work. Extracted from the consumer goroutine so
+// the counter semantics are unit-testable — wire-level NAKs in
+// particular can't be provoked deterministically (dnsmasq silently
+// ignores refused renewals in several shapes instead of NAKing), so
+// the naks_received contract is pinned here rather than in an
+// integration test (#128).
+func (m *dhcpManager) handleEvent(event udhcpc.Event, v6 bool) {
+	switch event.Type {
+	// "deconfig" is intentionally not handled. Deleting the
+	// container's IP from the kernel would also wipe the
+	// static routes Join copied off the host bridge, and
+	// there's no clean way to re-derive them without
+	// re-running the bridge route copy. Better to keep
+	// the stale address until the next bound/renew
+	// overwrites it.
+	case "bound":
+		// The persistent client's first DHCPACK can land
+		// on a different IP than CreateEndpoint's initial
+		// DISCOVER (some servers, including Fritz.Box,
+		// hand out a fresh address per DISCOVER even for
+		// the same MAC). Reuse the renew path so LastIP
+		// reflects what's actually in the kernel.
+		if m.plugin != nil {
+			m.plugin.leasesObtained.Add(1)
+		}
+		m.audit("bound", bareIP(event.Data.IP))
+		if err := m.renew(v6, event.Data); err != nil {
+			log.
+				WithError(err).
+				WithFields(m.logFields(v6)).
+				WithField("ip", event.Data.IP).
+				Error("Failed to record initial bind")
+		}
+	case "renew":
+		log.
+			WithFields(m.logFields(v6)).
+			Debug("udhcpc renew")
+
+		if m.plugin != nil {
+			m.plugin.leasesRenewed.Add(1)
+		}
+		m.audit("renew", bareIP(event.Data.IP))
+		if err := m.renew(v6, event.Data); err != nil {
+			log.
+				WithError(err).
+				WithFields(m.logFields(v6)).
+				WithField("gateway", event.Data.Gateway).
+				WithField("new_ip", event.Data.IP).
+				Error("Failed to execute IP renewal")
+		}
+	case "leasefail":
+		if m.plugin != nil {
+			m.plugin.dhcpTimeouts.Add(1)
+		}
+		log.WithFields(m.logFields(v6)).Warn("udhcpc failed to get a lease")
+	case "nak":
+		if m.plugin != nil {
+			m.plugin.naksReceived.Add(1)
+		}
+		log.WithFields(m.logFields(v6)).Warn("udhcpc client received NAK")
+	}
+}
+
 func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 	v6Str := ""
 	if v6 {
@@ -503,60 +568,7 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 					errChan <- nil
 					return
 				}
-				switch event.Type {
-				// "deconfig" is intentionally not handled. Deleting the
-				// container's IP from the kernel would also wipe the
-				// static routes Join copied off the host bridge, and
-				// there's no clean way to re-derive them without
-				// re-running the bridge route copy. Better to keep
-				// the stale address until the next bound/renew
-				// overwrites it.
-				case "bound":
-					// The persistent client's first DHCPACK can land
-					// on a different IP than CreateEndpoint's initial
-					// DISCOVER (some servers, including Fritz.Box,
-					// hand out a fresh address per DISCOVER even for
-					// the same MAC). Reuse the renew path so LastIP
-					// reflects what's actually in the kernel.
-					if m.plugin != nil {
-						m.plugin.leasesObtained.Add(1)
-					}
-					m.audit("bound", bareIP(event.Data.IP))
-					if err := m.renew(v6, event.Data); err != nil {
-						log.
-							WithError(err).
-							WithFields(m.logFields(v6)).
-							WithField("ip", event.Data.IP).
-							Error("Failed to record initial bind")
-					}
-				case "renew":
-					log.
-						WithFields(m.logFields(v6)).
-						Debug("udhcpc renew")
-
-					if m.plugin != nil {
-						m.plugin.leasesRenewed.Add(1)
-					}
-					m.audit("renew", bareIP(event.Data.IP))
-					if err := m.renew(v6, event.Data); err != nil {
-						log.
-							WithError(err).
-							WithFields(m.logFields(v6)).
-							WithField("gateway", event.Data.Gateway).
-							WithField("new_ip", event.Data.IP).
-							Error("Failed to execute IP renewal")
-					}
-				case "leasefail":
-					if m.plugin != nil {
-						m.plugin.dhcpTimeouts.Add(1)
-					}
-					log.WithFields(m.logFields(v6)).Warn("udhcpc failed to get a lease")
-				case "nak":
-					if m.plugin != nil {
-						m.plugin.naksReceived.Add(1)
-					}
-					log.WithFields(m.logFields(v6)).Warn("udhcpc client received NAK")
-				}
+				m.handleEvent(event, v6)
 
 			case <-m.stopChan:
 				log.

--- a/pkg/plugin/dhcp_manager_test.go
+++ b/pkg/plugin/dhcp_manager_test.go
@@ -86,3 +86,60 @@ func TestRenew_LeaseChangedCounter(t *testing.T) {
 		}
 	})
 }
+
+// TestHandleEvent_Counters pins which health counter each udhcpc
+// lifecycle event bumps (#128). The "nak" arm matters most: dnsmasq
+// silently ignores refused renewals in several shapes instead of
+// emitting DHCPNAK, so this contract cannot be pinned reliably at the
+// integration level — when a real server does NAK (busybox udhcpc
+// emits the event verbatim), this is the path that counts it.
+func TestHandleEvent_Counters(t *testing.T) {
+	addr, err := netlink.ParseAddr("192.168.0.10/24")
+	if err != nil {
+		t.Fatalf("ParseAddr: %v", err)
+	}
+
+	cases := []struct {
+		event string
+		read  func(p *Plugin) int32
+	}{
+		{"bound", func(p *Plugin) int32 { return p.leasesObtained.Load() }},
+		{"renew", func(p *Plugin) int32 { return p.leasesRenewed.Load() }},
+		{"leasefail", func(p *Plugin) int32 { return p.dhcpTimeouts.Load() }},
+		{"nak", func(p *Plugin) int32 { return p.naksReceived.Load() }},
+	}
+	for _, c := range cases {
+		t.Run(c.event, func(t *testing.T) {
+			p := &Plugin{}
+			m := &dhcpManager{plugin: p}
+			m.setLastIP(false, addr)
+
+			m.handleEvent(udhcpc.Event{Type: c.event, Data: udhcpc.Info{IP: addr.String()}}, false)
+
+			if got := c.read(p); got != 1 {
+				t.Errorf("%s counter = %d, want 1", c.event, got)
+			}
+		})
+	}
+
+	t.Run("deconfig and unknown bump nothing", func(t *testing.T) {
+		p := &Plugin{}
+		m := &dhcpManager{plugin: p}
+		for _, evt := range []string{"deconfig", "something-new"} {
+			m.handleEvent(udhcpc.Event{Type: evt}, false)
+		}
+		total := p.leasesObtained.Load() + p.leasesRenewed.Load() +
+			p.dhcpTimeouts.Load() + p.naksReceived.Load()
+		if total != 0 {
+			t.Errorf("counters moved on non-counting events: %d", total)
+		}
+	})
+
+	t.Run("nil plugin is safe for every event", func(t *testing.T) {
+		m := &dhcpManager{plugin: nil}
+		m.setLastIP(false, addr)
+		for _, evt := range []string{"bound", "renew", "leasefail", "nak", "deconfig"} {
+			m.handleEvent(udhcpc.Event{Type: evt, Data: udhcpc.Info{IP: addr.String()}}, false)
+		}
+	})
+}

--- a/pkg/plugin/endpoints.go
+++ b/pkg/plugin/endpoints.go
@@ -259,6 +259,11 @@ type HealthResponse struct {
 	LeasesRenewed        int32 `json:"leases_renewed"`
 	DHCPTimeouts         int32 `json:"dhcp_timeouts"`
 	LeaseReleaseFailures int32 `json:"lease_release_failures"`
+	// NAKsReceived counts server NAKs on renewal/rebind. Not
+	// Healthy-affecting on its own — udhcpc recovers by
+	// re-DISCOVERing — but each NAK-triggered re-bind widens the
+	// docker-inspect divergence tracked by lease_changed (#128).
+	NAKsReceived int32 `json:"naks_received"`
 	// LedgerWriteFailures counts failed appends to the audit_log
 	// lease ledger (#109). Not Healthy-affecting — a lost audit line
 	// degrades forensics, not networking; operators using audit_log
@@ -291,6 +296,7 @@ func (p *Plugin) apiHealth(w http.ResponseWriter, r *http.Request) {
 		LeasesRenewed:          p.leasesRenewed.Load(),
 		DHCPTimeouts:           p.dhcpTimeouts.Load(),
 		LeaseReleaseFailures:   p.leaseReleaseFailures.Load(),
+		NAKsReceived:           p.naksReceived.Load(),
 		LedgerWriteFailures:    p.ledgerWriteFailures.Load(),
 	}, http.StatusOK)
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -316,6 +316,17 @@ type Plugin struct {
 	dhcpTimeouts         atomic.Int32
 	leaseReleaseFailures atomic.Int32
 
+	// naksReceived counts udhcpc "nak" events — the server refused a
+	// REQUEST (pool reconfigured, address reassigned, lease revoked).
+	// Until v1.0.0 a NAK was only a warn-level log line, invisible to
+	// operators (#128). A NAK is followed by udhcpc re-DISCOVERing, so
+	// pair this with lease_changed: naks_received climbing while
+	// lease_changed follows means containers are being re-addressed
+	// mid-life — Docker's inspect view goes stale (see leaseChanged
+	// above / #104) and DNS or firewall rules keyed on the old IP need
+	// attention.
+	naksReceived atomic.Int32
+
 	// ledger is the append-only lease audit log (#109), written by
 	// dhcpManager.audit for networks created with audit_log=true.
 	// ledgerWriteFailures counts failed appends, surfaced on

--- a/pkg/udhcpc/event_builder.go
+++ b/pkg/udhcpc/event_builder.go
@@ -55,7 +55,18 @@ func BuildEvent(eventType string, getenv Getenv) (Event, bool) {
 				event.Data.DNSServers = strings.Fields(dns)
 			}
 		} else {
-			event.Data.IP = getenv("ip") + "/" + getenv("mask")
+			// Validate the v4 lease the same way the v6 branch does:
+			// a bound/renew with a missing/garbage `ip` or `mask` env
+			// (handler invoked by hand, or a future busybox shape
+			// change) must not emit "1.2.3.4/abc" downstream, where
+			// netlink.ParseAddr would fail deep inside the renewal
+			// path. Malformed input skips the event (#128).
+			ipMask := getenv("ip") + "/" + getenv("mask")
+			if _, _, err := net.ParseCIDR(ipMask); err != nil {
+				log.WithError(err).WithField("ip", ipMask).Error("Failed to parse IPv4 lease; skipping event")
+				return Event{}, false
+			}
+			event.Data.IP = ipMask
 			event.Data.Gateway = getenv("router")
 			event.Data.Domain = getenv("domain")
 			// dns is busybox udhcpc's env-var name for option 6.

--- a/pkg/udhcpc/event_builder_test.go
+++ b/pkg/udhcpc/event_builder_test.go
@@ -203,3 +203,106 @@ func TestBuildEvent_BoundV4_OmittedOptionsAreEmpty(t *testing.T) {
 		t.Errorf("missing env vars produced non-empty slices: %+v", got.Data)
 	}
 }
+
+// TestBuildEvent_BoundV4_MalformedLeaseIsSkipped pins the #128
+// hardening: a bound/renew whose `ip`/`mask` env doesn't form a valid
+// CIDR is dropped at the handler instead of flowing downstream where
+// netlink.ParseAddr would fail mid-renewal. Cases mirror the issue's
+// test design: empty ip with valid mask, non-numeric mask, junk both.
+func TestBuildEvent_BoundV4_MalformedLeaseIsSkipped(t *testing.T) {
+	cases := map[string]map[string]string{
+		"empty ip, valid mask": {"ip": "", "mask": "24"},
+		"valid ip, empty mask": {"ip": "10.0.0.5", "mask": ""},
+		"non-numeric mask":     {"ip": "10.0.0.5", "mask": "abc"},
+		"negative mask":        {"ip": "10.0.0.5", "mask": "-1"},
+		"mask out of range":    {"ip": "10.0.0.5", "mask": "33"},
+		"garbage ip":           {"ip": "not-an-ip", "mask": "24"},
+		"nothing set":          {},
+	}
+	for name, env := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, emit := BuildEvent("bound", fakeEnv(env)); emit {
+				t.Errorf("emit=true for malformed v4 lease env %v; want skipped", env)
+			}
+		})
+	}
+}
+
+// TestBuildEvent_RenewValidatesLikeBound: the validation guards both
+// event types that carry lease data.
+func TestBuildEvent_RenewValidatesLikeBound(t *testing.T) {
+	if _, emit := BuildEvent("renew", fakeEnv(map[string]string{"ip": "", "mask": "24"})); emit {
+		t.Error("emit=true for malformed renew; want skipped")
+	}
+}
+
+// TestBuildEvent_BoundV6_LinkLocalIsEmitted pins that a link-local
+// udhcpc6 lease (fe80::...) is structurally valid and flows through —
+// filtering link-local is a consumer policy decision, not the
+// handler's.
+func TestBuildEvent_BoundV6_LinkLocalIsEmitted(t *testing.T) {
+	got, emit := BuildEvent("bound", fakeEnv(map[string]string{
+		"ipv6": "fe80::42:acff:fe00:1",
+	}))
+	if !emit {
+		t.Fatal("emit=false for link-local v6 lease")
+	}
+	if got.Data.IP != "fe80::42:acff:fe00:1/128" {
+		t.Errorf("IP = %q, want canonicalised /128 link-local", got.Data.IP)
+	}
+}
+
+// TestBuildEvent_BoundV6_UncompressedIsCanonicalised: udhcpc6 emits
+// fully zero-padded addresses; the event must carry the compressed
+// canonical form so downstream string comparisons are stable.
+func TestBuildEvent_BoundV6_UncompressedIsCanonicalised(t *testing.T) {
+	got, emit := BuildEvent("bound", fakeEnv(map[string]string{
+		"ipv6": "fd00:6470:6863:0000:0000:0000:0000:0010",
+	}))
+	if !emit {
+		t.Fatal("emit=false for uncompressed v6 lease")
+	}
+	if got.Data.IP != "fd00:6470:6863::10/128" {
+		t.Errorf("IP = %q, want compressed canonical form", got.Data.IP)
+	}
+}
+
+// TestBuildEvent_BoundV6_MultipleDNS6Servers: option 23 with several
+// servers arrives space-separated; each becomes one entry.
+func TestBuildEvent_BoundV6_MultipleDNS6Servers(t *testing.T) {
+	got, emit := BuildEvent("bound", fakeEnv(map[string]string{
+		"ipv6": "fd00::10",
+		"dns6": "fd00::53 fd00::54",
+	}))
+	if !emit {
+		t.Fatal("emit=false")
+	}
+	want := []string{"fd00::53", "fd00::54"}
+	if !reflect.DeepEqual(got.Data.DNSServers, want) {
+		t.Errorf("DNSServers = %v, want %v", got.Data.DNSServers, want)
+	}
+}
+
+// TestBuildEvent_BoundV6_EmptyIPv6FallsThroughToV4Validation: an
+// empty `ipv6` env on a v6 bound routes into the v4 branch (the
+// documented contract), where empty ip/mask now skips the event
+// rather than emitting "/" as an address.
+func TestBuildEvent_BoundV6_EmptyIPv6FallsThroughToV4Validation(t *testing.T) {
+	if _, emit := BuildEvent("bound", fakeEnv(map[string]string{"ipv6": ""})); emit {
+		t.Error("emit=true for empty ipv6 + no v4 env; want skipped")
+	}
+}
+
+// TestBuildEvent_MTUNegativeIsIgnored extends the best-effort MTU
+// contract to negative numbers ("-5" parses but is not a valid MTU).
+func TestBuildEvent_MTUNegativeIsIgnored(t *testing.T) {
+	got, emit := BuildEvent("bound", fakeEnv(map[string]string{
+		"ip": "10.0.0.5", "mask": "24", "mtu": "-5",
+	}))
+	if !emit {
+		t.Fatal("emit=false; MTU problems must not kill the event")
+	}
+	if got.Data.MTU != 0 {
+		t.Errorf("MTU = %d, want 0 (negative input ignored)", got.Data.MTU)
+	}
+}

--- a/test/integration/failure_test.go
+++ b/test/integration/failure_test.go
@@ -1,0 +1,342 @@
+//go:build integration
+
+// Runtime failure-injection tests (#128): what happens AFTER a
+// container is bound and the world breaks. Each test runs against a
+// per-test EphemeralFixture DHCP server (never the suite-static one —
+// every other test depends on that staying up) and documents the
+// *intended* degraded-mode behaviour it asserts, so those semantics
+// are decided here rather than discovered in production.
+//
+// These tests cross real DHCP timing boundaries (the fixture lease
+// floor is 2m, so T1=60s, T2=105s, expiry=120s) and add ~9 serial
+// minutes — they are split out of the main suite into
+// `make integration-test-failure` (second CI step).
+//
+// busybox-udhcpc timing facts the asserts below lean on (defaults:
+// -t 3 -T 3 -A 20, see pkg/udhcpc/client.go — no overrides):
+//   - a dead server produces NO udhcpc event at T1/T2 (silent unicast
+//     /broadcast retries); the first observable event is "leasefail",
+//     emitted ~10s after lease EXPIRY when re-DISCOVER times out
+//     (3 tries × 3s). dhcp_timeouts therefore moves at ~t+130s, not
+//     at T1.
+//   - after "leasefail", udhcpc sleeps 20s (-A) and re-DISCOVERs
+//     forever — so recovery after the server returns lands within
+//     ~30s, and while it's gone, dhcp_timeouts keeps climbing on a
+//     ~30s period.
+//   - at expiry udhcpc emits "deconfig", which the plugin DELIBERATELY
+//     ignores (would wipe copied routes, see dhcp_manager.go) — the
+//     container keeps its address through an outage.
+package integration
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	docker "github.com/docker/docker/client"
+)
+
+// failureHealth polls /Plugin.Health until cond is true or the budget
+// is spent, returning the last response either way.
+func failureHealth(t *testing.T, ctx context.Context, cli *docker.Client, budget time.Duration, cond func(*harness.HealthResponse) bool) (*harness.HealthResponse, bool) {
+	t.Helper()
+	deadline := time.Now().Add(budget)
+	var last *harness.HealthResponse
+	for time.Now().Before(deadline) {
+		h, err := harness.PluginHealth(ctx, cli)
+		if err == nil {
+			last = h
+			if cond(h) {
+				return h, true
+			}
+		}
+		time.Sleep(time.Second)
+	}
+	return last, false
+}
+
+// containerHasIP reports whether `ip -4 addr` inside the container
+// still shows the given address.
+func containerHasIP(t *testing.T, ctx context.Context, ctrID, ip string) bool {
+	t.Helper()
+	out := harness.ExecOutput(t, ctx, ctrID, "ip", "-4", "addr")
+	return strings.Contains(out, ip+"/")
+}
+
+// inRange reports whether bare IPv4 ip falls inside [start, end].
+func inRange(ip, start, end string) bool {
+	v4 := net.ParseIP(ip).To4()
+	s := net.ParseIP(start).To4()
+	e := net.ParseIP(end).To4()
+	if v4 == nil || s == nil || e == nil {
+		return false
+	}
+	return bytes.Compare(v4, s) >= 0 && bytes.Compare(v4, e) <= 0
+}
+
+// TestFailure_ServerLossDuringRenewal: the "router rebooted at 3am"
+// scenario. Intended behaviour asserted:
+//   - while the server is gone, the container KEEPS its address (the
+//     deconfig no-op), the plugin stays Healthy, and dhcp_timeouts
+//     records the failure;
+//   - when the server returns with its lease DB intact, the client
+//     re-binds to the SAME address (lease_changed stays flat) without
+//     operator intervention.
+func TestFailure_ServerLossDuringRenewal(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+
+	ef := harness.NewEphemeralFixture(t)
+	t.Cleanup(func() {
+		if t.Failed() {
+			ef.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	harness.CreateNetwork(t, ctx, "dh-itest-floss", "macvlan", map[string]string{
+		"parent": harness.EphemeralHostVeth,
+	})
+	id, ip, mac := harness.RunContainer(t, ctx, "dh-itest-floss", "dh-itest-floss-ctr")
+	t.Logf("bound: ip=%s mac=%s", ip, mac)
+
+	base, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("Plugin.Health (baseline): %v", err)
+	}
+
+	// Kill the server uncleanly. The persistent client now faces
+	// silent T1/T2 retries, expiry, and a failing re-DISCOVER.
+	ef.Stop()
+	t.Log("server killed; waiting for the post-expiry leasefail (~130s)...")
+
+	h, ok := failureHealth(t, ctx, cli, 170*time.Second, func(h *harness.HealthResponse) bool {
+		return h.DHCPTimeouts > base.DHCPTimeouts
+	})
+	if !ok {
+		t.Fatalf("dhcp_timeouts never rose above %d during server outage (last: %+v)", base.DHCPTimeouts, h)
+	}
+	if !h.Healthy {
+		t.Error("plugin went unhealthy during a server outage; a dead DHCP server is a degraded mode, not a plugin failure")
+	}
+	if !containerHasIP(t, ctx, id, ip) {
+		t.Errorf("container lost %s during the outage; the deconfig no-op should retain the address", ip)
+	}
+
+	// Server returns, lease DB intact: the udhcpc retry loop must
+	// re-bind to the same address within ~30s (poll 90s for margin).
+	acksBefore := ef.CountLogLines("DHCPACK", mac)
+	ef.StartAgain()
+	t.Log("server restarted with preserved lease DB; awaiting re-bind...")
+
+	deadline := time.Now().Add(90 * time.Second)
+	recovered := false
+	for time.Now().Before(deadline) {
+		if ef.CountLogLines("DHCPACK", mac) > acksBefore {
+			recovered = true
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	if !recovered {
+		t.Fatal("no DHCPACK for the container's MAC within 90s of the server returning")
+	}
+	if !containerHasIP(t, ctx, id, ip) {
+		t.Errorf("container's address changed across the outage; with a preserved lease DB it must re-bind to %s", ip)
+	}
+	after, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("Plugin.Health (after): %v", err)
+	}
+	if after.LeaseChanged != base.LeaseChanged {
+		t.Errorf("lease_changed moved %d -> %d across an outage with a preserved lease DB; want flat", base.LeaseChanged, after.LeaseChanged)
+	}
+}
+
+// TestFailure_NAKOnRenewal: the pool gets reconfigured under a live
+// lease and the authoritative server NAKs the renewal. Intended
+// behaviour asserted:
+//   - naks_received (new in v1.0.0, #128) records the NAK — before,
+//     it was only a log line;
+//   - udhcpc re-acquires from the new pool and the container's LIVE
+//     address moves there; lease_changed records the move;
+//   - `docker inspect` keeps reporting the ORIGINAL address: libnetwork
+//     has no in-place endpoint-IP swap RPC, so the inspect divergence
+//     is the DEFINED degraded mode (#104) — lease_changed is the
+//     operator's signal, and this assertion is the documentation.
+func TestFailure_NAKOnRenewal(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+
+	ef := harness.NewEphemeralFixture(t)
+	t.Cleanup(func() {
+		if t.Failed() {
+			ef.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	harness.CreateNetwork(t, ctx, "dh-itest-fnak", "macvlan", map[string]string{
+		"parent": harness.EphemeralHostVeth,
+	})
+	id, oldIP, mac := harness.RunContainer(t, ctx, "dh-itest-fnak", "dh-itest-fnak-ctr")
+	t.Logf("bound: ip=%s mac=%s", oldIP, mac)
+
+	base, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("Plugin.Health (baseline): %v", err)
+	}
+
+	// Shift the pool out from under the lease and wipe the lease DB.
+	// The authoritative restart NAKs the T1 renewal REQUEST (~60s).
+	ef.Restart(harness.EphemeralShiftedPoolStart, harness.EphemeralShiftedPoolEnd)
+	t.Log("server restarted with shifted pool; awaiting NAK at T1 (~60s)...")
+
+	h, ok := failureHealth(t, ctx, cli, 150*time.Second, func(h *harness.HealthResponse) bool {
+		return h.NAKsReceived > base.NAKsReceived
+	})
+	if !ok {
+		t.Fatalf("naks_received never rose above %d (last: %+v); dnsmasq log NAKs for MAC: %d",
+			base.NAKsReceived, h, ef.CountLogLines("DHCPNAK", mac))
+	}
+
+	// After the NAK, udhcpc re-DISCOVERs immediately; the fresh bound
+	// lands within seconds.
+	h, ok = failureHealth(t, ctx, cli, 60*time.Second, func(h *harness.HealthResponse) bool {
+		return h.LeaseChanged > base.LeaseChanged
+	})
+	if !ok {
+		t.Fatalf("lease_changed never recorded the post-NAK re-bind (last: %+v)", h)
+	}
+
+	// The live address must now be in the shifted pool...
+	var liveIP string
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		out := harness.ExecOutput(t, ctx, id, "ip", "-4", "addr")
+		for _, f := range strings.Fields(out) {
+			if !strings.Contains(f, "/") {
+				continue
+			}
+			bare := strings.SplitN(f, "/", 2)[0]
+			if inRange(bare, harness.EphemeralShiftedPoolStart, harness.EphemeralShiftedPoolEnd) {
+				liveIP = bare
+			}
+		}
+		if liveIP != "" {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	if liveIP == "" {
+		t.Fatalf("container never showed a live address from the shifted pool %s-%s; ip -4 addr:\n%s",
+			harness.EphemeralShiftedPoolStart, harness.EphemeralShiftedPoolEnd,
+			harness.ExecOutput(t, ctx, id, "ip", "-4", "addr"))
+	}
+
+	// ...while docker inspect still shows the original address: the
+	// DEFINED divergence (#104). If this ever starts failing because
+	// inspect tracks the new IP, a re-Join mechanism landed — update
+	// the reference manual's troubleshooting row along with this test.
+	ins, err := cli.ContainerInspect(ctx, id)
+	if err != nil {
+		t.Fatalf("ContainerInspect: %v", err)
+	}
+	var inspectIP string
+	for _, ep := range ins.NetworkSettings.Networks {
+		inspectIP = ep.IPAddress
+	}
+	if inspectIP != oldIP {
+		t.Errorf("docker inspect reports %s; expected the stale original %s (documented degraded mode, #104)", inspectIP, oldIP)
+	}
+	if h.Healthy != true {
+		t.Error("plugin went unhealthy over a NAK re-bind; NAK recovery is a defined, healthy flow")
+	}
+}
+
+// TestFailure_LeaseExpiry: the server disappears permanently and the
+// lease fully lapses. Intended behaviour asserted: address retention
+// is DELIBERATE (deconfig no-op), the endpoint stays L2-reachable on
+// the stale address, dhcp_timeouts keeps climbing as the retry loop
+// spins, and the plugin reports Healthy — "server gone" is a defined
+// degraded mode, not undefined behaviour.
+func TestFailure_LeaseExpiry(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+
+	ef := harness.NewEphemeralFixture(t)
+	t.Cleanup(func() {
+		if t.Failed() {
+			ef.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	harness.CreateNetwork(t, ctx, "dh-itest-fexp", "macvlan", map[string]string{
+		"parent": harness.EphemeralHostVeth,
+	})
+	id, ip, mac := harness.RunContainer(t, ctx, "dh-itest-fexp", "dh-itest-fexp-ctr")
+	t.Logf("bound: ip=%s mac=%s", ip, mac)
+
+	base, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("Plugin.Health (baseline): %v", err)
+	}
+
+	ef.Stop()
+	t.Log("server killed permanently; crossing T2 and full expiry (~130s)...")
+
+	first, ok := failureHealth(t, ctx, cli, 170*time.Second, func(h *harness.HealthResponse) bool {
+		return h.DHCPTimeouts > base.DHCPTimeouts
+	})
+	if !ok {
+		t.Fatalf("dhcp_timeouts never rose above %d after lease expiry (last: %+v)", base.DHCPTimeouts, first)
+	}
+
+	// The retry loop must keep recording failures (~30s period).
+	second, ok := failureHealth(t, ctx, cli, 80*time.Second, func(h *harness.HealthResponse) bool {
+		return h.DHCPTimeouts > first.DHCPTimeouts
+	})
+	if !ok {
+		t.Errorf("dhcp_timeouts stalled at %d; the re-DISCOVER loop should keep recording failures (last: %+v)", first.DHCPTimeouts, second)
+	}
+	if second != nil && !second.Healthy {
+		t.Error("plugin went unhealthy on a permanent server loss; this is a defined degraded mode")
+	}
+
+	// Address retention past expiry is deliberate...
+	if !containerHasIP(t, ctx, id, ip) {
+		t.Errorf("container lost %s after lease expiry; retention (deconfig no-op) is the defined behaviour", ip)
+	}
+
+	// ...and the endpoint stays L2-reachable: ping the container from
+	// the server side of the veth pair (the address survives on the
+	// link even though dnsmasq is dead).
+	ping := exec.Command("ping", "-c", "1", "-W", "2", "-I", ef.ServerIP(), ip)
+	if out, err := ping.CombinedOutput(); err != nil {
+		t.Errorf("container %s not L2-reachable on its expired-lease address: %v\n%s", ip, err, out)
+	}
+}

--- a/test/integration/failure_test.go
+++ b/test/integration/failure_test.go
@@ -164,13 +164,16 @@ func TestFailure_ServerLossDuringRenewal(t *testing.T) {
 	}
 }
 
-// TestFailure_NAKOnRenewal: the pool gets reconfigured under a live
-// lease and the authoritative server NAKs the renewal. Intended
+// TestFailure_NAKOnRenewal: the server reassigns a live lease to
+// another client and NAKs the rightful renewal ("address in use" —
+// dnsmasq's lease DB is seeded with the container's address held by a
+// foreign MAC; an out-of-range pool shift does NOT produce a NAK,
+// dnsmasq silently ignores those, see Restart's caveat). Intended
 // behaviour asserted:
 //   - naks_received (new in v1.0.0, #128) records the NAK — before,
 //     it was only a log line;
-//   - udhcpc re-acquires from the new pool and the container's LIVE
-//     address moves there; lease_changed records the move;
+//   - udhcpc re-acquires a fresh address and the container's LIVE
+//     address moves; lease_changed records the move;
 //   - `docker inspect` keeps reporting the ORIGINAL address: libnetwork
 //     has no in-place endpoint-IP swap RPC, so the inspect divergence
 //     is the DEFINED degraded mode (#104) — lease_changed is the
@@ -204,10 +207,13 @@ func TestFailure_NAKOnRenewal(t *testing.T) {
 		t.Fatalf("Plugin.Health (baseline): %v", err)
 	}
 
-	// Shift the pool out from under the lease and wipe the lease DB.
-	// The authoritative restart NAKs the T1 renewal REQUEST (~60s).
-	ef.Restart(harness.EphemeralShiftedPoolStart, harness.EphemeralShiftedPoolEnd)
-	t.Log("server restarted with shifted pool; awaiting NAK at T1 (~60s)...")
+	// Reassign the container's address to a foreign client in the
+	// lease DB and bring the server back: the T1 renewal REQUEST for
+	// an address-now-owned-by-someone-else draws the DHCPNAK (~60s).
+	ef.Stop()
+	ef.SeedStolenLease(oldIP)
+	ef.StartAgain()
+	t.Log("server restarted with the lease reassigned; awaiting NAK at T1 (~60s)...")
 
 	h, ok := failureHealth(t, ctx, cli, 150*time.Second, func(h *harness.HealthResponse) bool {
 		return h.NAKsReceived > base.NAKsReceived
@@ -226,7 +232,8 @@ func TestFailure_NAKOnRenewal(t *testing.T) {
 		t.Fatalf("lease_changed never recorded the post-NAK re-bind (last: %+v)", h)
 	}
 
-	// The live address must now be in the shifted pool...
+	// The live address must move to a fresh pool address (the old one
+	// is "taken")...
 	var liveIP string
 	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
@@ -236,7 +243,7 @@ func TestFailure_NAKOnRenewal(t *testing.T) {
 				continue
 			}
 			bare := strings.SplitN(f, "/", 2)[0]
-			if inRange(bare, harness.EphemeralShiftedPoolStart, harness.EphemeralShiftedPoolEnd) {
+			if bare != oldIP && inRange(bare, harness.EphemeralPoolStart, harness.EphemeralPoolEnd) {
 				liveIP = bare
 			}
 		}
@@ -246,9 +253,8 @@ func TestFailure_NAKOnRenewal(t *testing.T) {
 		time.Sleep(time.Second)
 	}
 	if liveIP == "" {
-		t.Fatalf("container never showed a live address from the shifted pool %s-%s; ip -4 addr:\n%s",
-			harness.EphemeralShiftedPoolStart, harness.EphemeralShiftedPoolEnd,
-			harness.ExecOutput(t, ctx, id, "ip", "-4", "addr"))
+		t.Fatalf("container never showed a fresh pool address (old %s reassigned); ip -4 addr:\n%s",
+			oldIP, harness.ExecOutput(t, ctx, id, "ip", "-4", "addr"))
 	}
 
 	// ...while docker inspect still shows the original address: the

--- a/test/integration/failure_test.go
+++ b/test/integration/failure_test.go
@@ -164,22 +164,26 @@ func TestFailure_ServerLossDuringRenewal(t *testing.T) {
 	}
 }
 
-// TestFailure_NAKOnRenewal: the server reassigns a live lease to
-// another client and NAKs the rightful renewal ("address in use" —
-// dnsmasq's lease DB is seeded with the container's address held by a
-// foreign MAC; an out-of-range pool shift does NOT produce a NAK,
-// dnsmasq silently ignores those, see Restart's caveat). Intended
-// behaviour asserted:
-//   - naks_received (new in v1.0.0, #128) records the NAK — before,
-//     it was only a log line;
-//   - udhcpc re-acquires a fresh address and the container's LIVE
-//     address moves; lease_changed records the move;
+// TestFailure_LeaseRefusedOnRenewal: the site gets renumbered under a
+// live lease — the server comes back on a different subnet and the
+// container's held address is foreign to it. Two CI iterations showed
+// dnsmasq REFUSES such renewals *silently* in several shapes (out-of-
+// range REQUEST: ignored; address-taken REQUEST: ignored) rather than
+// emitting DHCPNAK, so this test asserts the *intended degraded-mode
+// semantics* rather than a specific wire message:
+//   - the client re-acquires from the new subnet's pool without
+//     operator intervention; lease_changed records the move;
 //   - `docker inspect` keeps reporting the ORIGINAL address: libnetwork
 //     has no in-place endpoint-IP swap RPC, so the inspect divergence
 //     is the DEFINED degraded mode (#104) — lease_changed is the
-//     operator's signal, and this assertion is the documentation.
-func TestFailure_NAKOnRenewal(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+//     operator's signal, and this assertion is the documentation;
+//   - the plugin stays Healthy throughout.
+//
+// The naks_received counter's contract is pinned in unit tests
+// (TestHandleEvent_Counters) — when a server does NAK, that's the
+// path that counts it; any NAK observed here is logged for interest.
+func TestFailure_LeaseRefusedOnRenewal(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
 	defer cancel()
 
 	ef := harness.NewEphemeralFixture(t)
@@ -196,46 +200,40 @@ func TestFailure_NAKOnRenewal(t *testing.T) {
 	}
 	defer cli.Close()
 
-	harness.CreateNetwork(t, ctx, "dh-itest-fnak", "macvlan", map[string]string{
+	pre, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("Plugin.Health (pre): %v", err)
+	}
+
+	harness.CreateNetwork(t, ctx, "dh-itest-fref", "macvlan", map[string]string{
 		"parent": harness.EphemeralHostVeth,
 	})
-	id, oldIP, mac := harness.RunContainer(t, ctx, "dh-itest-fnak", "dh-itest-fnak-ctr")
-	t.Logf("bound: ip=%s mac=%s", oldIP, mac)
+	id, inspectIP, mac := harness.RunContainer(t, ctx, "dh-itest-fref", "dh-itest-fref-ctr")
+	t.Logf("bound: inspect ip=%s mac=%s", inspectIP, mac)
 
+	// Settle: wait for the persistent client's own bound (it can
+	// differ from CreateEndpoint's one-shot lease) so the baseline
+	// isn't polluted by start-up churn.
+	if _, ok := failureHealth(t, ctx, cli, 30*time.Second, func(h *harness.HealthResponse) bool {
+		return h.LeasesObtained > pre.LeasesObtained
+	}); !ok {
+		t.Fatal("persistent client never bound")
+	}
 	base, err := harness.PluginHealth(ctx, cli)
 	if err != nil {
 		t.Fatalf("Plugin.Health (baseline): %v", err)
 	}
 
-	// Reassign the container's address to a foreign client in the
-	// lease DB and bring the server back: the T1 renewal REQUEST for
-	// an address-now-owned-by-someone-else draws the DHCPNAK (~60s).
-	ef.Stop()
-	ef.SeedStolenLease(oldIP)
-	ef.StartAgain()
-	t.Log("server restarted with the lease reassigned; awaiting NAK at T1 (~60s)...")
+	// Renumber the site: new server address, new pool, wiped DB. The
+	// unicast T1 renewal dies (the old server address is gone); the
+	// T2 broadcast rebind carries a foreign address; re-acquisition
+	// follows somewhere between T2 (105s) and expiry+rediscover
+	// (~135s).
+	ef.RestartOnSubnet(harness.EphemeralAltServerAddr, harness.EphemeralAltPoolStart, harness.EphemeralAltPoolEnd)
+	t.Log("server renumbered; awaiting re-acquisition (T2 ~105s, expiry ~135s)...")
 
-	h, ok := failureHealth(t, ctx, cli, 150*time.Second, func(h *harness.HealthResponse) bool {
-		return h.NAKsReceived > base.NAKsReceived
-	})
-	if !ok {
-		t.Fatalf("naks_received never rose above %d (last: %+v); dnsmasq log NAKs for MAC: %d",
-			base.NAKsReceived, h, ef.CountLogLines("DHCPNAK", mac))
-	}
-
-	// After the NAK, udhcpc re-DISCOVERs immediately; the fresh bound
-	// lands within seconds.
-	h, ok = failureHealth(t, ctx, cli, 60*time.Second, func(h *harness.HealthResponse) bool {
-		return h.LeaseChanged > base.LeaseChanged
-	})
-	if !ok {
-		t.Fatalf("lease_changed never recorded the post-NAK re-bind (last: %+v)", h)
-	}
-
-	// The live address must move to a fresh pool address (the old one
-	// is "taken")...
 	var liveIP string
-	deadline := time.Now().Add(30 * time.Second)
+	deadline := time.Now().Add(4 * time.Minute)
 	for time.Now().Before(deadline) {
 		out := harness.ExecOutput(t, ctx, id, "ip", "-4", "addr")
 		for _, f := range strings.Fields(out) {
@@ -243,37 +241,49 @@ func TestFailure_NAKOnRenewal(t *testing.T) {
 				continue
 			}
 			bare := strings.SplitN(f, "/", 2)[0]
-			if bare != oldIP && inRange(bare, harness.EphemeralPoolStart, harness.EphemeralPoolEnd) {
+			if inRange(bare, harness.EphemeralAltPoolStart, harness.EphemeralAltPoolEnd) {
 				liveIP = bare
 			}
 		}
 		if liveIP != "" {
 			break
 		}
-		time.Sleep(time.Second)
+		time.Sleep(2 * time.Second)
 	}
 	if liveIP == "" {
-		t.Fatalf("container never showed a fresh pool address (old %s reassigned); ip -4 addr:\n%s",
-			oldIP, harness.ExecOutput(t, ctx, id, "ip", "-4", "addr"))
+		t.Fatalf("container never re-acquired from the new subnet's pool %s-%s; ip -4 addr:\n%s",
+			harness.EphemeralAltPoolStart, harness.EphemeralAltPoolEnd,
+			harness.ExecOutput(t, ctx, id, "ip", "-4", "addr"))
+	}
+	t.Logf("re-acquired: live ip=%s", liveIP)
+
+	h, ok := failureHealth(t, ctx, cli, 30*time.Second, func(h *harness.HealthResponse) bool {
+		return h.LeaseChanged > base.LeaseChanged
+	})
+	if !ok {
+		t.Errorf("lease_changed never recorded the re-acquisition (last: %+v)", h)
+	}
+	if h != nil && !h.Healthy {
+		t.Error("plugin went unhealthy over a lease re-acquisition; this is a defined, healthy flow")
+	}
+	if h != nil && h.NAKsReceived > base.NAKsReceived {
+		t.Logf("server NAKed on the wire (naks_received %d -> %d)", base.NAKsReceived, h.NAKsReceived)
 	}
 
-	// ...while docker inspect still shows the original address: the
-	// DEFINED divergence (#104). If this ever starts failing because
-	// inspect tracks the new IP, a re-Join mechanism landed — update
-	// the reference manual's troubleshooting row along with this test.
+	// docker inspect still shows the original address: the DEFINED
+	// divergence (#104). If this ever fails because inspect tracks
+	// the new IP, a re-Join mechanism landed — update the reference
+	// manual's troubleshooting row along with this test.
 	ins, err := cli.ContainerInspect(ctx, id)
 	if err != nil {
 		t.Fatalf("ContainerInspect: %v", err)
 	}
-	var inspectIP string
+	var nowInspect string
 	for _, ep := range ins.NetworkSettings.Networks {
-		inspectIP = ep.IPAddress
+		nowInspect = ep.IPAddress
 	}
-	if inspectIP != oldIP {
-		t.Errorf("docker inspect reports %s; expected the stale original %s (documented degraded mode, #104)", inspectIP, oldIP)
-	}
-	if h.Healthy != true {
-		t.Error("plugin went unhealthy over a NAK re-bind; NAK recovery is a defined, healthy flow")
+	if nowInspect != inspectIP {
+		t.Errorf("docker inspect reports %s; expected the stale original %s (documented degraded mode, #104)", nowInspect, inspectIP)
 	}
 }
 

--- a/test/integration/harness/ephemeral.go
+++ b/test/integration/harness/ephemeral.go
@@ -1,0 +1,272 @@
+//go:build integration
+
+package harness
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	// EphemeralHostVeth / ephemeralDhcpVeth are the per-test veth pair
+	// the failure-injection tests (#128) attach to. Distinct names and
+	// subnet from the suite-static fixture so killing this DHCP server
+	// can never starve the rest of the suite. The suite runs serially,
+	// so static names are safe — each test tears its instance down.
+	EphemeralHostVeth = "dh-itest-ehost"
+	ephemeralDhcpVeth = "dh-itest-edhcp"
+
+	EphemeralServerAddr = "192.168.101.1/24"
+	EphemeralPoolStart  = "192.168.101.10"
+	EphemeralPoolEnd    = "192.168.101.99"
+	// EphemeralShiftedPoolStart/End are a disjoint range for
+	// Restart() in the NAK test: an address leased from the original
+	// pool is out-of-range for an authoritative server configured
+	// with this one, so its renewal REQUEST draws a DHCPNAK.
+	EphemeralShiftedPoolStart = "192.168.101.150"
+	EphemeralShiftedPoolEnd   = "192.168.101.199"
+)
+
+// EphemeralFixture is a per-test DHCP server on its own veth pair,
+// for tests that break the server on purpose: SIGKILL it, bring it
+// back with the lease DB intact, or bring it back reconfigured so
+// held leases get NAKed. The suite-static Fixture must never be
+// touched by failure tests — every other test depends on it staying
+// up (#128).
+//
+// dnsmasq runs --dhcp-authoritative, like a production DHCP server
+// that owns its subnet: REQUESTs for out-of-pool or unknown addresses
+// are NAKed immediately instead of ignored.
+type EphemeralFixture struct {
+	t *testing.T
+
+	cmd       *exec.Cmd
+	tmpDir    string
+	leaseFile string
+	logFile   string
+
+	poolStart, poolEnd string
+}
+
+// NewEphemeralFixture creates the veth pair and starts the
+// authoritative dnsmasq. Teardown is registered via t.Cleanup and is
+// idempotent against a previous panicked run's leftovers.
+func NewEphemeralFixture(t *testing.T) *EphemeralFixture {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Fatalf("EphemeralFixture needs root (got uid=%d)", os.Geteuid())
+	}
+
+	cleanupEphemeralLinks()
+
+	la := netlink.NewLinkAttrs()
+	la.Name = EphemeralHostVeth
+	veth := &netlink.Veth{LinkAttrs: la, PeerName: ephemeralDhcpVeth}
+	if err := netlink.LinkAdd(veth); err != nil {
+		t.Fatalf("LinkAdd ephemeral veth: %v", err)
+	}
+
+	ef := &EphemeralFixture{
+		t:         t,
+		poolStart: EphemeralPoolStart,
+		poolEnd:   EphemeralPoolEnd,
+	}
+	t.Cleanup(ef.teardown)
+
+	hostLink, err := netlink.LinkByName(EphemeralHostVeth)
+	if err != nil {
+		t.Fatalf("LinkByName %s: %v", EphemeralHostVeth, err)
+	}
+	dhcpLink, err := netlink.LinkByName(ephemeralDhcpVeth)
+	if err != nil {
+		t.Fatalf("LinkByName %s: %v", ephemeralDhcpVeth, err)
+	}
+	if err := netlink.LinkSetUp(hostLink); err != nil {
+		t.Fatalf("LinkSetUp %s: %v", EphemeralHostVeth, err)
+	}
+	if err := netlink.LinkSetUp(dhcpLink); err != nil {
+		t.Fatalf("LinkSetUp %s: %v", ephemeralDhcpVeth, err)
+	}
+	addr, err := netlink.ParseAddr(EphemeralServerAddr)
+	if err != nil {
+		t.Fatalf("ParseAddr: %v", err)
+	}
+	if err := netlink.AddrAdd(dhcpLink, addr); err != nil {
+		t.Fatalf("AddrAdd %s: %v", ephemeralDhcpVeth, err)
+	}
+
+	tmp, err := os.MkdirTemp("", "dh-itest-ephemeral-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	ef.tmpDir = tmp
+	ef.leaseFile = filepath.Join(tmp, "leases")
+	ef.logFile = filepath.Join(tmp, "dnsmasq.log")
+
+	ef.start()
+	return ef
+}
+
+// start launches dnsmasq with the fixture's current pool and waits
+// until it has logged its DHCP range (the readiness probe used for
+// the static fixture — binding UDP/67 — can't distinguish this
+// instance from the suite fixture's dnsmasq, which is also up).
+func (ef *EphemeralFixture) start() {
+	ef.t.Helper()
+	logF, err := os.OpenFile(ef.logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		ef.t.Fatalf("open ephemeral dnsmasq log: %v", err)
+	}
+	defer logF.Close()
+
+	startMark := ef.logSize()
+	ef.cmd = exec.Command("/usr/sbin/dnsmasq",
+		"--no-daemon",
+		"--conf-file=/dev/null",
+		"--port=0",
+		"--interface="+ephemeralDhcpVeth,
+		"--bind-interfaces",
+		"--except-interface=lo",
+		"--dhcp-range="+ef.poolStart+","+ef.poolEnd+","+LeaseTime,
+		"--dhcp-leasefile="+ef.leaseFile,
+		"--dhcp-no-override",
+		// Authoritative: NAK requests for leases this instance
+		// doesn't recognise, like a real production server that owns
+		// the subnet. Without it dnsmasq stays silent on unknown
+		// REQUESTs and the NAK test would never see a NAK.
+		"--dhcp-authoritative",
+		"--dhcp-broadcast",
+		"--log-dhcp",
+		"--log-facility=-",
+	)
+	ef.cmd.Stdout = logF
+	ef.cmd.Stderr = logF
+	ef.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := ef.cmd.Start(); err != nil {
+		ef.t.Fatalf("start ephemeral dnsmasq: %v", err)
+	}
+
+	// Ready when the new instance has logged its IP range.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(ef.logFile)
+		if err == nil && len(data) > startMark &&
+			strings.Contains(string(data[startMark:]), "IP range") {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	ef.t.Fatalf("ephemeral dnsmasq did not become ready; log:\n%s", ef.readLog())
+}
+
+func (ef *EphemeralFixture) logSize() int {
+	st, err := os.Stat(ef.logFile)
+	if err != nil {
+		return 0
+	}
+	return int(st.Size())
+}
+
+// Stop SIGKILLs the DHCP server — the unclean "router died" shape, no
+// DHCPRELEASE-side effects, lease DB left as-is on disk.
+func (ef *EphemeralFixture) Stop() {
+	ef.t.Helper()
+	if ef.cmd == nil || ef.cmd.Process == nil {
+		return
+	}
+	// Negative pid: the whole process group (Setpgid above).
+	_ = syscall.Kill(-ef.cmd.Process.Pid, syscall.SIGKILL)
+	_ = ef.cmd.Wait()
+	ef.cmd = nil
+}
+
+// StartAgain restarts dnsmasq with the same pool and the preserved
+// lease DB — the "router came back" shape. Existing leases are still
+// known, so renewals from before the outage ACK on the same address.
+func (ef *EphemeralFixture) StartAgain() {
+	ef.t.Helper()
+	if ef.cmd != nil {
+		ef.t.Fatal("StartAgain: server still running; call Stop first")
+	}
+	ef.start()
+}
+
+// Restart brings the server back with a different pool and a wiped
+// lease DB — the "subnet got renumbered / pool reconfigured" shape.
+// Being authoritative, the new instance NAKs renewal REQUESTs for
+// addresses from the old pool.
+func (ef *EphemeralFixture) Restart(poolStart, poolEnd string) {
+	ef.t.Helper()
+	ef.Stop()
+	if err := os.Remove(ef.leaseFile); err != nil && !os.IsNotExist(err) {
+		ef.t.Fatalf("wipe ephemeral lease DB: %v", err)
+	}
+	ef.poolStart, ef.poolEnd = poolStart, poolEnd
+	ef.start()
+}
+
+// ServerIP returns the server's bare IP (the gateway dnsmasq
+// advertises by default — its own listen address).
+func (ef *EphemeralFixture) ServerIP() string {
+	return strings.SplitN(EphemeralServerAddr, "/", 2)[0]
+}
+
+// CountLogLines counts log lines containing every one of the given
+// substrings (case-insensitive), e.g. ("DHCPACK", mac) or
+// ("DHCPNAK", mac). The log accumulates across Stop/StartAgain/
+// Restart cycles, so counts are monotonic for the fixture's lifetime.
+func (ef *EphemeralFixture) CountLogLines(substrings ...string) int {
+	ef.t.Helper()
+	count := 0
+	for _, line := range strings.Split(ef.readLog(), "\n") {
+		l := strings.ToLower(line)
+		all := true
+		for _, s := range substrings {
+			if !strings.Contains(l, strings.ToLower(s)) {
+				all = false
+				break
+			}
+		}
+		if all {
+			count++
+		}
+	}
+	return count
+}
+
+func (ef *EphemeralFixture) readLog() string {
+	data, err := os.ReadFile(ef.logFile)
+	if err != nil {
+		return fmt.Sprintf("(could not read ephemeral dnsmasq log: %v)", err)
+	}
+	return string(data)
+}
+
+// DumpLogs mirrors Fixture.DumpLogs for failure-path diagnostics.
+func (ef *EphemeralFixture) DumpLogs(write func(string)) {
+	write("--- ephemeral dnsmasq log ---\n" + ef.readLog())
+}
+
+func (ef *EphemeralFixture) teardown() {
+	ef.Stop()
+	if ef.tmpDir != "" {
+		_ = os.RemoveAll(ef.tmpDir)
+	}
+	cleanupEphemeralLinks()
+}
+
+func cleanupEphemeralLinks() {
+	for _, name := range []string{EphemeralHostVeth, ephemeralDhcpVeth} {
+		if link, err := netlink.LinkByName(name); err == nil {
+			_ = netlink.LinkDel(link)
+		}
+	}
+}

--- a/test/integration/harness/ephemeral.go
+++ b/test/integration/harness/ephemeral.go
@@ -154,12 +154,16 @@ func (ef *EphemeralFixture) start() {
 		ef.t.Fatalf("start ephemeral dnsmasq: %v", err)
 	}
 
-	// Ready when the new instance has logged its IP range.
+	// Ready when the new instance has logged its DHCP range. Match on
+	// the pool's start address, not the surrounding words — dnsmasq
+	// localizes its log strings ("IP range" is "IP-Bereich" under a
+	// German locale, which is what the integration runner speaks),
+	// but addresses are addresses in every language.
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
 		data, err := os.ReadFile(ef.logFile)
 		if err == nil && len(data) > startMark &&
-			strings.Contains(string(data[startMark:]), "IP range") {
+			strings.Contains(string(data[startMark:]), ef.poolStart) {
 			return
 		}
 		time.Sleep(50 * time.Millisecond)

--- a/test/integration/harness/ephemeral.go
+++ b/test/integration/harness/ephemeral.go
@@ -25,8 +25,15 @@ const (
 	ephemeralDhcpVeth = "dh-itest-edhcp"
 
 	EphemeralServerAddr = "192.168.101.1/24"
-	EphemeralPoolStart  = "192.168.101.10"
-	EphemeralPoolEnd    = "192.168.101.99"
+	// EphemeralAltServerAddr / pools: a wholly different subnet for
+	// RestartOnSubnet — the "site got renumbered" shape. A renewal
+	// REQUEST carrying the old subnet's address against this server
+	// is a wrong-network refusal; the client must re-acquire here.
+	EphemeralAltServerAddr = "192.168.102.1/24"
+	EphemeralAltPoolStart  = "192.168.102.10"
+	EphemeralAltPoolEnd    = "192.168.102.99"
+	EphemeralPoolStart     = "192.168.101.10"
+	EphemeralPoolEnd       = "192.168.101.99"
 	// EphemeralShiftedPoolStart/End are a disjoint range for
 	// Restart() in the NAK test: an address leased from the original
 	// pool is out-of-range for an authoritative server configured
@@ -54,6 +61,7 @@ type EphemeralFixture struct {
 	logFile   string
 
 	poolStart, poolEnd string
+	serverCIDR         string
 }
 
 // NewEphemeralFixture creates the veth pair and starts the
@@ -75,9 +83,10 @@ func NewEphemeralFixture(t *testing.T) *EphemeralFixture {
 	}
 
 	ef := &EphemeralFixture{
-		t:         t,
-		poolStart: EphemeralPoolStart,
-		poolEnd:   EphemeralPoolEnd,
+		t:          t,
+		poolStart:  EphemeralPoolStart,
+		poolEnd:    EphemeralPoolEnd,
+		serverCIDR: EphemeralServerAddr,
 	}
 	t.Cleanup(ef.teardown)
 
@@ -95,7 +104,7 @@ func NewEphemeralFixture(t *testing.T) *EphemeralFixture {
 	if err := netlink.LinkSetUp(dhcpLink); err != nil {
 		t.Fatalf("LinkSetUp %s: %v", ephemeralDhcpVeth, err)
 	}
-	addr, err := netlink.ParseAddr(EphemeralServerAddr)
+	addr, err := netlink.ParseAddr(ef.serverCIDR)
 	if err != nil {
 		t.Fatalf("ParseAddr: %v", err)
 	}
@@ -221,6 +230,41 @@ func (ef *EphemeralFixture) Restart(poolStart, poolEnd string) {
 	ef.start()
 }
 
+// RestartOnSubnet brings the server back on a DIFFERENT subnet with
+// a wiped lease DB — the "site got renumbered" shape. The old server
+// address disappears from the veth, so unicast renewals die silently;
+// the client's broadcast REBIND carries an address foreign to the new
+// subnet (wrong-network refusal — dnsmasq may NAK or stay silent
+// depending on the shape) and re-acquisition lands in the new pool.
+func (ef *EphemeralFixture) RestartOnSubnet(serverCIDR, poolStart, poolEnd string) {
+	ef.t.Helper()
+	ef.Stop()
+	if err := os.Remove(ef.leaseFile); err != nil && !os.IsNotExist(err) {
+		ef.t.Fatalf("wipe ephemeral lease DB: %v", err)
+	}
+	link, err := netlink.LinkByName(ephemeralDhcpVeth)
+	if err != nil {
+		ef.t.Fatalf("LinkByName %s: %v", ephemeralDhcpVeth, err)
+	}
+	old, err := netlink.ParseAddr(ef.serverCIDR)
+	if err != nil {
+		ef.t.Fatalf("ParseAddr old server CIDR: %v", err)
+	}
+	if err := netlink.AddrDel(link, old); err != nil {
+		ef.t.Fatalf("AddrDel %s: %v", ef.serverCIDR, err)
+	}
+	fresh, err := netlink.ParseAddr(serverCIDR)
+	if err != nil {
+		ef.t.Fatalf("ParseAddr new server CIDR: %v", err)
+	}
+	if err := netlink.AddrAdd(link, fresh); err != nil {
+		ef.t.Fatalf("AddrAdd %s: %v", serverCIDR, err)
+	}
+	ef.serverCIDR = serverCIDR
+	ef.poolStart, ef.poolEnd = poolStart, poolEnd
+	ef.start()
+}
+
 // SeedStolenLease overwrites the (stopped) server's lease DB with a
 // single entry assigning ip to a foreign client. On StartAgain,
 // dnsmasq loads it and treats ip as taken — the rightful client's
@@ -242,7 +286,7 @@ func (ef *EphemeralFixture) SeedStolenLease(ip string) {
 // ServerIP returns the server's bare IP (the gateway dnsmasq
 // advertises by default — its own listen address).
 func (ef *EphemeralFixture) ServerIP() string {
-	return strings.SplitN(EphemeralServerAddr, "/", 2)[0]
+	return strings.SplitN(ef.serverCIDR, "/", 2)[0]
 }
 
 // CountLogLines counts log lines containing every one of the given

--- a/test/integration/harness/ephemeral.go
+++ b/test/integration/harness/ephemeral.go
@@ -205,8 +205,12 @@ func (ef *EphemeralFixture) StartAgain() {
 
 // Restart brings the server back with a different pool and a wiped
 // lease DB — the "subnet got renumbered / pool reconfigured" shape.
-// Being authoritative, the new instance NAKs renewal REQUESTs for
-// addresses from the old pool.
+//
+// NAK caveat (learned from the first CI run): dnsmasq 2.91 silently
+// IGNORES renewal REQUESTs for addresses outside its configured range
+// even with --dhcp-authoritative — the client recovers via expiry +
+// re-DISCOVER, but no DHCPNAK is ever emitted. To provoke an actual
+// NAK, use SeedStolenLease + StartAgain instead.
 func (ef *EphemeralFixture) Restart(poolStart, poolEnd string) {
 	ef.t.Helper()
 	ef.Stop()
@@ -215,6 +219,24 @@ func (ef *EphemeralFixture) Restart(poolStart, poolEnd string) {
 	}
 	ef.poolStart, ef.poolEnd = poolStart, poolEnd
 	ef.start()
+}
+
+// SeedStolenLease overwrites the (stopped) server's lease DB with a
+// single entry assigning ip to a foreign client. On StartAgain,
+// dnsmasq loads it and treats ip as taken — the rightful client's
+// renewal REQUEST then draws the classic "address in use" DHCPNAK,
+// the scenario where a server reassigns a live lease (#128).
+// Lease-file format per dnsmasq(8): "expiry MAC IP hostname client-id".
+func (ef *EphemeralFixture) SeedStolenLease(ip string) {
+	ef.t.Helper()
+	if ef.cmd != nil {
+		ef.t.Fatal("SeedStolenLease: stop the server first; dnsmasq reads the lease DB only at startup")
+	}
+	expiry := time.Now().Add(time.Hour).Unix()
+	line := fmt.Sprintf("%d aa:bb:cc:dd:ee:ff %s stolen-by *\n", expiry, ip)
+	if err := os.WriteFile(ef.leaseFile, []byte(line), 0o644); err != nil {
+		ef.t.Fatalf("seed stolen lease: %v", err)
+	}
 }
 
 // ServerIP returns the server's bare IP (the gateway dnsmasq

--- a/test/integration/harness/health.go
+++ b/test/integration/harness/health.go
@@ -31,6 +31,7 @@ type HealthResponse struct {
 	LeasesRenewed          int32   `json:"leases_renewed"`
 	DHCPTimeouts           int32   `json:"dhcp_timeouts"`
 	LeaseReleaseFailures   int32   `json:"lease_release_failures"`
+	NAKsReceived           int32   `json:"naks_received"`
 	LedgerWriteFailures    int32   `json:"ledger_write_failures"`
 }
 


### PR DESCRIPTION
For #128 (closes at release via the release PR's list).

## What

**Three `TestFailure_*` integration tests** — the post-bind world-breaks scenarios, each asserting *intended* degraded-mode behaviour so the semantics are decided here, not discovered in production:

| test | injected failure | asserted semantics |
|---|---|---|
| `TestFailure_ServerLossDuringRenewal` | SIGKILL the DHCP server, later bring it back with its lease DB | address retained (the deconfig no-op becomes asserted behaviour), `dhcp_timeouts` records the outage, plugin stays Healthy; on return: re-bind to the **same** address, `lease_changed` flat |
| `TestFailure_NAKOnRenewal` | authoritative restart with a shifted pool → DHCPNAK at T1 | **`naks_received`** (new counter, below) + `lease_changed` move; live address lands in the new pool; `docker inspect` keeps the stale original — the #104 divergence asserted as the *defined* degraded mode |
| `TestFailure_LeaseExpiry` | server gone permanently, lease fully lapses | retention past expiry is deliberate, `dhcp_timeouts` keeps climbing (retry loop alive), endpoint stays L2-reachable, Healthy throughout |

**`harness.EphemeralFixture`** — per-test authoritative dnsmasq on its own veth pair + subnet (`192.168.101.0/24`), `Stop()` / `StartAgain()` (lease DB preserved) / `Restart(pool)` (DB wiped). The suite-static fixture is never touched — every other test depends on it staying up. `cleanup-orphans.sh` already covers the new links via the `dh-itest-` prefix.

**`naks_received` health counter** — a NAK was a warn-level log line only; now it's on `/Plugin.Health` (not Healthy-affecting; pairs with `lease_changed` as the mid-life re-addressing signal). Documented in `parent-attached-modes.md`.

**BuildEvent v4 validation** — bound/renew with malformed `ip`/`mask` env is now skipped at the handler (like the v6 branch always did) instead of emitting `1.2.3.4/abc` to fail deep in the renewal path. Plus table tests: 7 malformed-lease shapes, v6 link-local / uncompressed-canonicalisation / multi-dns6, negative MTU.

**Wall-clock plan** — the failure tests are ~9 deliberate-wait minutes, so they're split behind `make integration-test-failure`: the main suite `-skip`'s them (feedback speed unchanged), `integration.yml` and `coverage.yml` run them as a separate step (ratchet counts both runs' coverage), job timeouts 20→35.

The tests lean on busybox-udhcpc timing facts documented in `failure_test.go`'s header (no leasefail event until ~10s past expiry; ~30s retry period; defaults `-t 3 -T 3 -A 20`).

## Verification

- Verified locally: `go test -race ./...` green (incl. 12 new BuildEvent cases), `go vet -tags integration`, staticcheck (integration tag), gofmt, actionlint all clean.
- **Untested until this PR's own CI run:** the three `TestFailure_*` tests themselves and the EphemeralFixture lifecycle — they need the root runner and this PR's plugin build. This PR's `integration` check is their first execution; expect possible timing-calibration iteration.

- [x] naks_received wired: plugin field → event switch → HealthResponse → harness mirror → docs
- [x] Main-suite feedback speed unchanged (`-skip 'TestFailure_'`)
- [x] `TestFailure_*` green on the integration runner (run 4: ServerLoss, LeaseRefusedOnRenewal, LeaseExpiry all pass — the latter end-to-end validating the renew() re-address fix)
- [x] `docs/reference.md` Health table `naks_received` row — **deferred to the release branch's documentation-review step** (runbook step 3): this branch predates reference.md, adding it here would cost a full CI respin; tracked in the release task
