### PR TITLE
feature: DHCPv6 polish — dual-stack fixtures, first v6 coverage, DUID audit

### DIFF
--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -341,6 +341,14 @@ What you get, and the boundaries (v1.0.0 audit, #103):
 - `propagate_dns=true` also covers v6: the DHCPv6 option-23 server
   list is written to `resolv.conf` on v6 bind/renew. The two
   families are last-writer-wins on that file.
+- **Known boundary (v1.0.0): the v6 address Docker reports is not
+  yet renewed.** The initial-lease client and the persistent renewal
+  client negotiate separate identity associations (same DUID,
+  different IAID), so the persistent client maintains a second lease
+  rather than renewing the one on the container's interface. The
+  initial v6 lease and addressing work; on networks with short v6
+  lease times, be aware the interface address can outlive its
+  server-side lease. IA unification is tracked in #152.
 - DHCPv6-PD (prefix delegation) is out of scope (tracked separately).
 
 ## DHCP identity

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -89,7 +89,7 @@ The host's NIC config (IP, routes, netplan/`systemd-networkd`,
 | `parent`            | macvlan, ipvlan  | yes      | Host NIC to use as the parent (e.g. `ens18`, `eno1`). Must exist and be `UP`. |
 | `bridge`            | bridge           | yes      | Existing Linux bridge to plug veths into.                     |
 | `gateway`           | all              | no       | Override the IPv4 gateway returned by DHCP (e.g. when egress should go through a VPN router instead of the LAN's default gateway). |
-| `ipv6`              | all              | no       | Also run DHCPv6 in addition to DHCPv4.                        |
+| `ipv6`              | all              | no       | Also run stateful DHCPv6 (udhcpc6) in addition to DHCPv4 — see "DHCPv6" below for semantics, DUID identity, and boundaries. |
 | `lease_timeout`     | both      | no       | Initial-lease timeout for the up-front DHCP exchange (default `10s`). |
 | `ignore_conflicts`  | bridge    | no       | Skip the bridge-already-in-use check. No-op in macvlan mode.  |
 | `skip_routes`       | all       | no       | Don't copy non-default static routes from the parent (bridge / macvlan parent NIC / ipvlan parent NIC) into the container. v0.9.0 extended this from bridge-only to all modes for parity (#102) — set `true` to restore pre-v0.9.0 macvlan/ipvlan no-copy behaviour. |
@@ -300,6 +300,48 @@ told apart when the hostname is known on both sides; only when
 neither side knows the hostname does the network-wide
 "exactly one match" rule apply. Sequential restarts (the typical
 case) always satisfy the rule.
+
+## DHCPv6 (`ipv6=true`)
+
+Enabling `-o ipv6=true` runs a second persistent client (busybox
+`udhcpc6`) alongside the v4 one — **stateful DHCPv6**, not SLAAC. The
+exact create incantation (note: the Docker-level `--ipv6` flag does
+NOT work with the null IPAM driver and is not what you want):
+
+```bash
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.9.0 \
+    --ipam-driver null \
+    -o mode=macvlan -o parent=eth0 -o ipv6=true \
+    lan-dhcp6
+```
+
+What you get, and the boundaries (v1.0.0 audit, #103):
+
+- The container's interface carries the DHCPv6-leased address as a
+  `/128` alongside its v4 address; `docker inspect` reports it as
+  `GlobalIPv6Address`. Renewal follows the server's T1 like v4.
+- **The default gateway stays RA-delegated**: DHCPv6 carries no
+  router option by design; the container netns kernel honors Router
+  Advertisements on its own (`accept_ra` default). The plugin's
+  `gateway` override option is v4-only.
+- **Client identity is the DUID, and it's stable.** busybox udhcpc6
+  derives a DUID-LL (type 3) from the interface MAC — no timestamp,
+  so the same MAC always produces the same DUID. Server-side v6
+  reservations therefore stick exactly as far as MAC stability
+  reaches: across plugin restarts/upgrades (the container link keeps
+  its MAC) and across container restarts (tombstones, see "Restart
+  stability"). **ipvlan caveat:** all ipvlan children share the
+  parent's MAC, so they share one DUID too — v6 servers tell them
+  apart only by IAID, and per-container v6 reservations are not
+  practical in ipvlan mode (same shape as the v4 MAC limitation).
+- **No static-v6 hint:** udhcpc6 has no v4-style `-r` request flag,
+  so `--ip6` / static v6 requests are accepted-but-ignored (logged);
+  the lease always arrives server-chosen. Use a DUID-keyed
+  reservation upstream when you need a fixed v6 address.
+- `propagate_dns=true` also covers v6: the DHCPv6 option-23 server
+  list is written to `resolv.conf` on v6 bind/renew. The two
+  families are last-writer-wins on that file.
+- DHCPv6-PD (prefix delegation) is out of scope (tracked separately).
 
 ## DHCP identity
 

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -627,6 +627,34 @@ func (m *dhcpManager) locateContainerLink(ctx context.Context) error {
 	}, pollTime)
 }
 
+// linkLocalDADTimeout caps the wait for the container link's IPv6
+// link-local address to clear duplicate address detection. DAD with
+// kernel defaults is one solicit + 1s; the budget is generous because
+// the only cost of waiting is delaying the first SOLICIT.
+const linkLocalDADTimeout = 10 * time.Second
+
+// awaitLinkLocal blocks until the container-side link has a usable
+// (non-tentative, non-failed) IPv6 link-local address — the
+// precondition for any DHCPv6 exchange in the netns.
+func (m *dhcpManager) awaitLinkLocal(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, linkLocalDADTimeout)
+	defer cancel()
+	return util.AwaitCondition(ctx, func() (bool, error) {
+		addrs, err := m.netHandle.AddrList(m.ctrLink, unix.AF_INET6)
+		if err != nil {
+			return false, fmt.Errorf("failed to list IPv6 addresses: %w", err)
+		}
+		for _, a := range addrs {
+			if a.Scope == unix.RT_SCOPE_LINK &&
+				a.Flags&unix.IFA_F_TENTATIVE == 0 &&
+				a.Flags&unix.IFA_F_DADFAILED == 0 {
+				return true, nil
+			}
+		}
+		return false, nil
+	}, pollTime)
+}
+
 func (m *dhcpManager) Start(ctx context.Context) (err error) {
 	defer func() {
 		m.startErr = err
@@ -686,6 +714,20 @@ func (m *dhcpManager) Start(ctx context.Context) (err error) {
 		}
 
 		if m.opts.IPv6 {
+			// DHCPv6 needs a usable link-local source address. The
+			// link just landed in this netns, so its LL is typically
+			// still DAD-tentative — and a host must NOT answer
+			// neighbor solicitations for a tentative address, so the
+			// server's unicast ADVERTISE/REPLY can never be
+			// delivered: udhcpc6 SOLICITs forever while the server's
+			// neighbor cache records an unreachable client (#103,
+			// found by TestLeaseRenewIPv6_HonorsT1). Wait for DAD to
+			// finish before starting the client. Timeout degrades to
+			// a warn-and-try — DAD normally completes in ~1s.
+			if err := m.awaitLinkLocal(ctx); err != nil {
+				log.WithError(err).WithFields(m.logFields(true)).
+					Warn("No usable link-local address; starting DHCPv6 client anyway")
+			}
 			if m.errChanV6, err = m.setupClient(true); err != nil {
 				close(m.stopChan)
 				return err

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -158,6 +158,27 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 		}
 		mac := fresh.Attrs().HardwareAddr
 
+		// Pin the kernel-assigned MAC (macvlan only — ipvlan rejects
+		// any MAC set with EOPNOTSUPP, and its children share the
+		// parent's MAC anyway). The bridge path has pinned its veth
+		// MACs for ages; macvlan never did, and the gap finally
+		// surfaced (#103): systemd-udevd's MACAddressPolicy=persistent
+		// (Debian default) replaces a *randomly assigned* MAC moments
+		// after link creation, so the initial DHCP exchange ran from
+		// udev's MAC while the link-local kept deriving from ours —
+		// and libnetwork re-applies our reported MAC at Join. v4
+		// survives by client-id matching, but the one-shot DHCPv6
+		// poisons the server's neighbor cache (link-local -> udev's
+		// MAC), blackholing the container's persistent client for the
+		// cache lifetime (~45s on the wire capture). Explicitly
+		// setting the MAC — even to its current value — flips
+		// addr_assign_type to "set", which the udev policy respects.
+		if mode != ModeIPvlan && effectiveMAC == "" {
+			if err := netlink.LinkSetHardwareAddr(fresh, mac); err != nil {
+				return fmt.Errorf("failed to pin %v link MAC: %w", mode, err)
+			}
+		}
+
 		if err := netlink.LinkSetUp(fresh); err != nil {
 			return fmt.Errorf("failed to set %v link up: %w", mode, err)
 		}

--- a/pkg/udhcpc/client.go
+++ b/pkg/udhcpc/client.go
@@ -89,28 +89,40 @@ func NewDHCPClient(iface string, opts *DHCPClientOptions) (*DHCPClient, error) {
 	}
 
 	path := "udhcpc"
+	// The two busybox clients accept DIFFERENT -O vocabularies, and an
+	// unknown option name is a hard startup error (`udhcpc6: unknown
+	// option 'mtu'` → exit 1), not a warning — passing the v4 list to
+	// udhcpc6 broke every `ipv6=true` exchange from v0.9.0 until the
+	// first v6 integration test caught it (#103).
+	//
+	// v4 (beyond udhcpc's default request list 1, 3, 6, 12, 15, 28, 42):
+	//   - mtu     (option 26)  — applied to ctr link when PropagateMTU
+	//   - search  (option 119) — written to resolv.conf when PropagateDNS
+	//   - tftp    (option 66)  — surfaced via plugin log
+	//   - bootfile(option 67)  — surfaced via plugin log
+	//
+	// v6 (udhcpc6 knows: dns search fqdn tz timezone bootfile_url
+	// bootfile_param pxeconffile pxepathprefix; dns/option 23 is
+	// requested by default):
+	//   - search  (option 24, domain search list) — resolv.conf when
+	//     PropagateDNS. There is no DHCPv6 MTU option (MTU comes from
+	//     RA) and no v6 equivalents of tftp/bootfile in udhcpc6's
+	//     vocabulary.
+	//
+	// dnsmasq / RFC-conformant servers only return options the client
+	// asked for. Always-on; the per-option propagate_* gates decide
+	// whether to *act* on the values.
+	reqOpts := []string{"-O", "mtu", "-O", "search", "-O", "tftp", "-O", "bootfile"}
 	if opts.V6 {
 		path = "udhcpc6"
+		reqOpts = []string{"-O", "search"}
 	}
+	args := append([]string{"-f", "-i", iface, "-s", opts.HandlerScript}, reqOpts...)
 	c := &DHCPClient{
 		Opts: opts,
-		// Foreground, set interface and handler "script". Also
-		// explicitly request the options not in busybox udhcpc's
-		// default list (1, 3, 6, 12, 15, 28, 42):
-		//
-		//   - mtu     (option 26)  — applied to ctr link when PropagateMTU
-		//   - search  (option 119) — written to resolv.conf when PropagateDNS
-		//   - tftp    (option 66)  — surfaced via plugin log
-		//   - bootfile(option 67)  — surfaced via plugin log
-		//
-		// Note: busybox already requests option 42 (ntpsrv) by default,
-		// so there's no -O for it. dnsmasq / RFC-conformant servers
-		// only return options the client asked for. This block is
-		// always-on; the per-option propagate_* gates decide whether
-		// to *act* on the values, but capturing them is free and
-		// harmless if the server doesn't supply them.
-		cmd: exec.Command(path, "-f", "-i", iface, "-s", opts.HandlerScript,
-			"-O", "mtu", "-O", "search", "-O", "tftp", "-O", "bootfile"),
+		// Foreground, set interface and handler "script", plus the
+		// family-specific option requests above.
+		cmd: exec.Command(path, args...),
 	}
 
 	stderrPipe, err := c.cmd.StderrPipe()

--- a/pkg/udhcpc/client_args_test.go
+++ b/pkg/udhcpc/client_args_test.go
@@ -1,6 +1,7 @@
 package udhcpc
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -264,4 +265,47 @@ func TestNewDHCPClient_ForegroundAndInterface(t *testing.T) {
 		}
 	}
 	t.Errorf("no -i flag found; args: %v", c.cmd.Args)
+}
+
+// TestNewDHCPClient_OptionRequestsPerFamily pins the family-specific
+// -O vocabularies (#103). The two busybox clients accept DIFFERENT
+// option names and an unknown name is a hard startup error, not a
+// warning — the v4 list fed to udhcpc6 ("unknown option 'mtu'",
+// exit 1) silently broke every ipv6=true exchange from v0.9.0 until
+// the first v6 integration test caught it. udhcpc6's vocabulary:
+// dns search fqdn tz timezone bootfile_url bootfile_param
+// pxeconffile pxepathprefix.
+func TestNewDHCPClient_OptionRequestsPerFamily(t *testing.T) {
+	requested := func(args []string) []string {
+		var got []string
+		for i := 0; i < len(args)-1; i++ {
+			if args[i] == "-O" {
+				got = append(got, args[i+1])
+			}
+		}
+		return got
+	}
+
+	c4, err := NewDHCPClient("eth0", &DHCPClientOptions{})
+	if err != nil {
+		t.Fatalf("NewDHCPClient v4: %v", err)
+	}
+	want4 := []string{"mtu", "search", "tftp", "bootfile"}
+	if got := requested(c4.cmd.Args); !reflect.DeepEqual(got, want4) {
+		t.Errorf("v4 -O requests = %v, want %v", got, want4)
+	}
+
+	c6, err := NewDHCPClient("eth0", &DHCPClientOptions{V6: true})
+	if err != nil {
+		t.Fatalf("NewDHCPClient v6: %v", err)
+	}
+	want6 := []string{"search"}
+	if got := requested(c6.cmd.Args); !reflect.DeepEqual(got, want6) {
+		t.Errorf("v6 -O requests = %v, want %v", got, want6)
+	}
+	for _, banned := range []string{"mtu", "tftp", "bootfile"} {
+		if hasArg(c6.cmd.Args, banned) {
+			t.Errorf("udhcpc6 got -O %s, which it rejects at startup; args: %v", banned, c6.cmd.Args)
+		}
+	}
 }

--- a/test/integration/harness/bridge.go
+++ b/test/integration/harness/bridge.go
@@ -40,6 +40,14 @@ const (
 	BridgeDHCPPoolStart = "192.168.100.10"
 	BridgeDHCPPoolEnd   = "192.168.100.99"
 	BridgeSubnetCIDR    = "192.168.100.0/24"
+
+	// Dual-stack constants for the bridge fixture (#103) — a distinct
+	// ULA prefix from the macvlan fixture's fd00:6470:6863::/64, same
+	// isolation rationale as the distinct v4 subnets above.
+	BridgeAddrV6          = "fd00:6470:6864::1/64"
+	BridgeDHCPv6PoolStart = "fd00:6470:6864::10"
+	BridgeDHCPv6PoolEnd   = "fd00:6470:6864::99"
+	BridgeSubnetV6CIDR    = "fd00:6470:6864::/64"
 )
 
 // startBridge brings up the bridge fixture: a Linux bridge with a
@@ -84,6 +92,13 @@ func (f *Fixture) startBridge() error {
 	if err := netlink.AddrAdd(link, addr); err != nil {
 		return fmt.Errorf("AddrAdd bridge: %w", err)
 	}
+	addrV6, err := netlink.ParseAddr(BridgeAddrV6)
+	if err != nil {
+		return fmt.Errorf("ParseAddr bridge v6: %w", err)
+	}
+	if err := netlink.AddrAdd(link, addrV6); err != nil {
+		return fmt.Errorf("AddrAdd bridge v6: %w", err)
+	}
 
 	// docker's default FORWARD policy is DROP. With br_netfilter
 	// loaded, even pure-bridge DHCP traffic (UDP 67/68 broadcast on
@@ -93,8 +108,14 @@ func (f *Fixture) startBridge() error {
 		{"-I", "FORWARD", "-i", BridgeName, "-j", "ACCEPT"},
 		{"-I", "FORWARD", "-o", BridgeName, "-j", "ACCEPT"},
 	} {
+		// Both families: bridge-nf-call-ip6tables routes bridged
+		// DHCPv6 (UDP 546/547) through ip6tables FORWARD the same
+		// way bridge-nf-call-iptables does for v4 (#103).
 		if out, err := exec.Command("iptables", args...).CombinedOutput(); err != nil {
 			return fmt.Errorf("iptables %v: %w (%s)", args, err, out)
+		}
+		if out, err := exec.Command("ip6tables", args...).CombinedOutput(); err != nil {
+			return fmt.Errorf("ip6tables %v: %w (%s)", args, err, out)
 		}
 	}
 	f.iptablesInstalled = true
@@ -119,6 +140,9 @@ func (f *Fixture) startBridge() error {
 		"--bind-interfaces",
 		"--except-interface=lo",
 		"--dhcp-range="+BridgeDHCPPoolStart+","+BridgeDHCPPoolEnd+","+LeaseTime,
+		"--dhcp-range="+BridgeDHCPv6PoolStart+","+BridgeDHCPv6PoolEnd+","+LeaseTime,
+		"--enable-ra",
+		"--dhcp-option=option6:dns-server,["+TestDNS6Server+"]",
 		"--dhcp-leasefile="+f.bridgeLeaseFile,
 		"--dhcp-no-override",
 		"--dhcp-broadcast",
@@ -192,6 +216,7 @@ func (f *Fixture) stopBridge() {
 			{"-D", "FORWARD", "-o", BridgeName, "-j", "ACCEPT"},
 		} {
 			_ = exec.Command("iptables", args...).Run()
+			_ = exec.Command("ip6tables", args...).Run()
 		}
 		f.iptablesInstalled = false
 	}

--- a/test/integration/harness/fixture.go
+++ b/test/integration/harness/fixture.go
@@ -48,6 +48,25 @@ const (
 	// SubnetCIDR is what callers expect IP assertions to fall inside.
 	SubnetCIDR = "192.168.99.0/24"
 
+	// DHCPServerAddrV6 / DHCPv6PoolStart / DHCPv6PoolEnd dual-stack
+	// the macvlan fixture (#103): the same dnsmasq serves stateful
+	// DHCPv6 from a ULA prefix alongside the v4 pool. The prefix
+	// spells "dhc"/"dhcp" in hex-ish (6470:6863) and is RFC 4193
+	// private, so a leak onto a real LAN is both unroutable and
+	// recognisable. Lease time shares LeaseTime, so DHCPv6 T1 (which
+	// dnsmasq derives as lease/2) lands at 1m like v4.
+	DHCPServerAddrV6 = "fd00:6470:6863::1/64"
+	DHCPv6PoolStart  = "fd00:6470:6863::10"
+	DHCPv6PoolEnd    = "fd00:6470:6863::99"
+	SubnetV6CIDR     = "fd00:6470:6863::/64"
+
+	// TestDNS6Server is advertised as DHCPv6 option 23 (DNS servers).
+	// busybox udhcpc6 requests option 23 by default, so it lands in
+	// the handler's `dns6` env without any -O flag. Like
+	// TestDNSServer, nothing actually serves DNS there — tests assert
+	// propagation, not resolution.
+	TestDNS6Server = "fd00:6470:6863::53"
+
 	// TestDNSServer / TestMTU are the values the macvlan-fixture
 	// dnsmasq advertises via DHCP options 6 and 26 respectively.
 	// Tests that exercise PropagateDNS / PropagateMTU assert these
@@ -159,6 +178,15 @@ func New() (*Fixture, error) {
 	if err := netlink.AddrAdd(dhcpLink, addr); err != nil {
 		return nil, wrapTeardown(fmt.Errorf("AddrAdd dhcp: %w", err))
 	}
+	// The ULA must be on the interface before dnsmasq starts, or it
+	// refuses the v6 dhcp-range with "no address range available".
+	addrV6, err := netlink.ParseAddr(DHCPServerAddrV6)
+	if err != nil {
+		return nil, wrapTeardown(fmt.Errorf("ParseAddr v6: %w", err))
+	}
+	if err := netlink.AddrAdd(dhcpLink, addrV6); err != nil {
+		return nil, wrapTeardown(fmt.Errorf("AddrAdd dhcp v6: %w", err))
+	}
 
 	// Per-run temp dir for dnsmasq lease file + log.
 	tmp, err := os.MkdirTemp("", "dh-itest-")
@@ -207,6 +235,13 @@ func (f *Fixture) startDnsmasq() error {
 		"--bind-interfaces",     // don't open sockets on others
 		"--except-interface=lo", // belt + braces
 		"--dhcp-range="+DHCPPoolStart+","+DHCPPoolEnd+","+LeaseTime,
+		// Stateful DHCPv6 on the ULA prefix (#103). --enable-ra makes
+		// dnsmasq emit Router Advertisements with the M (managed) flag
+		// for this range — RA handling stays kernel-delegated in the
+		// container netns; the plugin only drives udhcpc6.
+		"--dhcp-range="+DHCPv6PoolStart+","+DHCPv6PoolEnd+","+LeaseTime,
+		"--enable-ra",
+		"--dhcp-option=option6:dns-server,["+TestDNS6Server+"]",
 		"--dhcp-leasefile="+f.leaseFile,
 		"--dhcp-no-override",
 		// DHCP options every test gets to opt-into via PropagateDNS /
@@ -345,3 +380,26 @@ func IsInPool(ip net.IP) bool {
 
 func bytesGE(a, b net.IP) bool { return bytes.Compare(a, b) >= 0 }
 func bytesLE(a, b net.IP) bool { return bytes.Compare(a, b) <= 0 }
+
+// IsInPoolV6 returns whether ip is in the macvlan fixture's DHCPv6
+// range [DHCPv6PoolStart, DHCPv6PoolEnd]. Mirrors IsInPool's
+// stricter-than-subnet semantics: the ::1 server address is in subnet
+// but not in pool.
+func IsInPoolV6(ip net.IP) bool {
+	return inV6Range(ip, DHCPv6PoolStart, DHCPv6PoolEnd)
+}
+
+// IsInBridgePoolV6 is IsInPoolV6 for the bridge fixture's v6 range.
+func IsInBridgePoolV6(ip net.IP) bool {
+	return inV6Range(ip, BridgeDHCPv6PoolStart, BridgeDHCPv6PoolEnd)
+}
+
+func inV6Range(ip net.IP, start, end string) bool {
+	v6 := ip.To16()
+	if v6 == nil || ip.To4() != nil {
+		return false
+	}
+	s := net.ParseIP(start).To16()
+	e := net.ParseIP(end).To16()
+	return bytesGE(v6, s) && bytesLE(v6, e)
+}

--- a/test/integration/ipv6_test.go
+++ b/test/integration/ipv6_test.go
@@ -269,11 +269,11 @@ func TestLeaseRenewIPv6_HonorsT1(t *testing.T) {
 		}
 	})
 
-	// TEMPORARY CI diagnostics (#103): the persistent udhcpc6 SOLICITs
-	// forever in the container netns while dnsmasq logs matching
-	// ADVERTISEs that never arrive — local replication of the exact
-	// topology works, so capture the wire + neighbor state in the real
-	// environment. Dumped only on failure; remove once root-caused.
+	// Wire + neighbor diagnostics, dumped only on failure. These are
+	// what root-caused the udev MACAddressPolicy neighbor-cache
+	// poisoning (#103) — DHCPv6 failures in this environment tend to
+	// be L2-delivery problems that no application log can show, so
+	// the capture stays.
 	var dumps []*os.File
 	for _, iface := range []string{harness.HostVeth, harness.DhcpVeth} {
 		f, err := os.CreateTemp("", "v6dbg-"+iface+"-*.txt")

--- a/test/integration/ipv6_test.go
+++ b/test/integration/ipv6_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -268,8 +269,53 @@ func TestLeaseRenewIPv6_HonorsT1(t *testing.T) {
 		}
 	})
 
+	// TEMPORARY CI diagnostics (#103): the persistent udhcpc6 SOLICITs
+	// forever in the container netns while dnsmasq logs matching
+	// ADVERTISEs that never arrive — local replication of the exact
+	// topology works, so capture the wire + neighbor state in the real
+	// environment. Dumped only on failure; remove once root-caused.
+	var dumps []*os.File
+	for _, iface := range []string{harness.HostVeth, harness.DhcpVeth} {
+		f, err := os.CreateTemp("", "v6dbg-"+iface+"-*.txt")
+		if err != nil {
+			t.Fatalf("tcpdump capture file: %v", err)
+		}
+		td := exec.Command("tcpdump", "-i", iface, "-l", "-n", "-e",
+			"udp port 546 or udp port 547 or icmp6")
+		td.Stdout, td.Stderr = f, f
+		if err := td.Start(); err != nil {
+			t.Logf("tcpdump unavailable (%v); continuing without capture", err)
+			break
+		}
+		dumps = append(dumps, f)
+		t.Cleanup(func() {
+			_ = td.Process.Kill()
+			_, _ = td.Process.Wait()
+		})
+	}
+	t.Cleanup(func() {
+		for _, f := range dumps {
+			if t.Failed() {
+				data, _ := os.ReadFile(f.Name())
+				t.Logf("--- tcpdump %s ---\n%s", f.Name(), data)
+			}
+			_ = os.Remove(f.Name())
+		}
+		if t.Failed() {
+			neigh, _ := exec.Command("ip", "-6", "neigh", "show").CombinedOutput()
+			t.Logf("--- host ip -6 neigh ---\n%s", neigh)
+		}
+	})
+
 	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{"ipv6": "true"})
 	id, _, _ := harness.RunContainer(t, ctx, netName, "dh-itest-v6renew-ctr")
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("--- container ip -6 addr ---\n%s", harness.ExecOutput(t, context.Background(), id, "ip", "-6", "addr"))
+			t.Logf("--- container ip -6 neigh ---\n%s", harness.ExecOutput(t, context.Background(), id, "ip", "-6", "neigh"))
+		}
+	})
 
 	v6 := linkGlobalV6(t, ctx, id, harness.IPAcquisitionBudget)
 	if v6 == "" {

--- a/test/integration/ipv6_test.go
+++ b/test/integration/ipv6_test.go
@@ -1,0 +1,450 @@
+//go:build integration
+
+// DHCPv6 coverage (#103) — the suite's first v6 tests. The fixture
+// dnsmasq instances are dual-stack (stateful DHCPv6 on ULA prefixes,
+// --enable-ra); `ipv6=true` networks run udhcpc6 alongside udhcpc.
+//
+// Audit findings these tests encode (from the busybox source,
+// networking/udhcp/d6_dhcpc.c):
+//   - udhcpc6's CLIENTID is a DUID-LL (type 3) derived from the
+//     interface MAC — NOT a per-process timestamped DUID-LLT. DUID
+//     stability across plugin restarts therefore follows from MAC
+//     stability, which the plugin already guarantees (the container
+//     link keeps its MAC across a plugin disable/enable; tombstones
+//     pin it across container restarts). TestDUID_PersistsAcross-
+//     PluginRestart asserts this end-to-end.
+//   - option 23 (DNS servers) is requested by default — the `dns6`
+//     env arrives without any -O flag.
+//   - there is no "request this address" flag for v6 (`-r` is v4
+//     only), so v6 leases always come unhinted; continuity relies on
+//     the server recognising the stable DUID.
+package integration
+
+import (
+	"context"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	docker "github.com/docker/docker/client"
+)
+
+// inspectV6 returns the endpoint's GlobalIPv6Address from docker
+// inspect, or "".
+func inspectV6(t *testing.T, ctx context.Context, cli *docker.Client, ctrID, netName string) string {
+	t.Helper()
+	ins, err := cli.ContainerInspect(ctx, ctrID)
+	if err != nil {
+		t.Fatalf("ContainerInspect: %v", err)
+	}
+	if ep := ins.NetworkSettings.Networks[netName]; ep != nil {
+		return ep.GlobalIPv6Address
+	}
+	return ""
+}
+
+// linkGlobalV6 returns the first global-scope IPv6 address on the
+// container's interface, polled until present or the budget is spent.
+func linkGlobalV6(t *testing.T, ctx context.Context, ctrID string, budget time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		out := harness.ExecOutput(t, ctx, ctrID, "ip", "-6", "addr", "show", "scope", "global")
+		for _, f := range strings.Fields(out) {
+			if strings.Contains(f, ":") && strings.Contains(f, "/") {
+				bare := strings.SplitN(f, "/", 2)[0]
+				if ip := net.ParseIP(bare); ip != nil && ip.To4() == nil {
+					return bare
+				}
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return ""
+}
+
+// countDHCPv6Replies counts DHCPREPLY lines mentioning addr in the
+// given dnsmasq log — the v6 sibling of countDHCPACKs. dnsmasq logs
+// one DHCPREPLY per blessed REQUEST/RENEW, so bind=1, renewal=2.
+func countDHCPv6Replies(t *testing.T, logPath, addr string) int {
+	t.Helper()
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read dnsmasq log: %v", err)
+	}
+	needle := strings.ToLower(addr)
+	count := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		l := strings.ToLower(line)
+		if strings.Contains(l, "dhcpreply") && strings.Contains(l, needle) {
+			count++
+		}
+	}
+	return count
+}
+
+// leaseDUIDForV6 extracts the client DUID from the dnsmasq lease DB
+// line holding addr. v6 lease lines are "<expiry> <iaid> <addr>
+// <hostname> <client-duid>"; the server's own DUID line ("duid <hex>")
+// has fewer fields and never matches an address.
+func leaseDUIDForV6(t *testing.T, leaseFile, addr string) string {
+	t.Helper()
+	data, err := os.ReadFile(leaseFile)
+	if err != nil {
+		t.Fatalf("read lease file: %v", err)
+	}
+	needle := strings.ToLower(addr)
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 5 && strings.EqualFold(fields[2], needle) {
+			return fields[len(fields)-1]
+		}
+	}
+	return ""
+}
+
+// TestLifecycleMacvlan_IPv6_GoldenPath: with ipv6=true, a container
+// gets a v4 lease from the v4 pool AND a v6 lease from the ULA pool;
+// docker inspect's GlobalIPv6Address agrees with the address actually
+// on the link; teardown releases both families cleanly
+// (lease_release_failures stays flat — this exercises the v6 half of
+// dhcpManager.Stop).
+func TestLifecycleMacvlan_IPv6_GoldenPath(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-v6mv"
+	ctrName := "dh-itest-v6mv-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	before, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("Plugin.Health (before): %v", err)
+	}
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{"ipv6": "true"})
+
+	// Lifecycle inlined so ContainerStop (and with it the v4+v6
+	// DHCPRELEASE pair) happens inside the test body, before the
+	// final health assertion.
+	create, err := cli.ContainerCreate(ctx,
+		&container.Config{Image: harness.TestImage, Cmd: []string{"sleep", "infinity"}, Hostname: ctrName},
+		&container.HostConfig{},
+		&network.NetworkingConfig{EndpointsConfig: map[string]*network.EndpointSettings{netName: {}}},
+		nil, ctrName)
+	if err != nil {
+		t.Fatalf("ContainerCreate: %v", err)
+	}
+	id := create.ID
+	t.Cleanup(func() {
+		_ = cli.ContainerRemove(context.Background(), id, container.RemoveOptions{Force: true})
+	})
+	if err := cli.ContainerStart(ctx, id, container.StartOptions{}); err != nil {
+		t.Fatalf("ContainerStart: %v", err)
+	}
+
+	// v4 side: same contract as the existing golden paths.
+	var v4 string
+	deadline := time.Now().Add(harness.IPAcquisitionBudget)
+	for time.Now().Before(deadline) {
+		ins, err := cli.ContainerInspect(ctx, id)
+		if err != nil {
+			t.Fatalf("ContainerInspect: %v", err)
+		}
+		if ep := ins.NetworkSettings.Networks[netName]; ep != nil && ep.IPAddress != "" {
+			v4 = ep.IPAddress
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if v4 == "" {
+		t.Fatalf("no IPv4 within %v", harness.IPAcquisitionBudget)
+	}
+	if !harness.IsInPool(net.ParseIP(v4)) {
+		t.Errorf("IPv4 %s not in fixture pool", v4)
+	}
+
+	// v6 side: the live link must carry a ULA-pool address...
+	liveV6 := linkGlobalV6(t, ctx, id, harness.IPAcquisitionBudget)
+	if liveV6 == "" {
+		t.Fatalf("no global IPv6 appeared on the container link")
+	}
+	if !harness.IsInPoolV6(net.ParseIP(liveV6)) {
+		t.Errorf("live IPv6 %s not in fixture v6 pool [%s, %s]", liveV6, harness.DHCPv6PoolStart, harness.DHCPv6PoolEnd)
+	}
+
+	// ...and inspect must agree with reality. CreateEndpoint returns
+	// AddressIPv6 from the initial one-shot udhcpc6 exchange; the
+	// persistent client re-binds with the same DUID, so the server
+	// must hand back the same address. A mismatch here is the v6
+	// flavour of the #104 divergence — if this fires, the audit found
+	// a real edge: document it and re-scope rather than loosening
+	// silently.
+	insV6 := inspectV6(t, ctx, cli, id, netName)
+	if insV6 == "" {
+		t.Error("docker inspect has empty GlobalIPv6Address for an ipv6=true network")
+	} else if !net.ParseIP(insV6).Equal(net.ParseIP(liveV6)) {
+		t.Errorf("inspect IPv6 %s != live link IPv6 %s", insV6, liveV6)
+	}
+
+	// Teardown: both families release cleanly.
+	if err := cli.ContainerStop(ctx, id, container.StopOptions{}); err != nil {
+		t.Fatalf("ContainerStop: %v", err)
+	}
+	after, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("Plugin.Health (after): %v", err)
+	}
+	if after.LeaseReleaseFailures != before.LeaseReleaseFailures {
+		t.Errorf("lease_release_failures moved %d -> %d over a dual-stack lifecycle; the v6 Stop path is failing",
+			before.LeaseReleaseFailures, after.LeaseReleaseFailures)
+	}
+}
+
+// TestLifecycleBridge_IPv6_GoldenPath: the same dual-stack contract
+// through the bridge wiring path (veth into a Linux bridge instead of
+// a macvlan child).
+func TestLifecycleBridge_IPv6_GoldenPath(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-v6br"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpBridgeLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "bridge", map[string]string{"ipv6": "true"})
+	id, v4, _ := harness.RunContainer(t, ctx, netName, "dh-itest-v6br-ctr")
+
+	if !harness.IsInBridgePool(net.ParseIP(v4)) {
+		t.Errorf("IPv4 %s not in bridge fixture pool", v4)
+	}
+	liveV6 := linkGlobalV6(t, ctx, id, harness.IPAcquisitionBudget)
+	if liveV6 == "" {
+		t.Fatal("no global IPv6 appeared on the container link (bridge mode)")
+	}
+	if !harness.IsInBridgePoolV6(net.ParseIP(liveV6)) {
+		t.Errorf("live IPv6 %s not in bridge fixture v6 pool [%s, %s]", liveV6, harness.BridgeDHCPv6PoolStart, harness.BridgeDHCPv6PoolEnd)
+	}
+}
+
+// TestLeaseRenewIPv6_HonorsT1: the v6 sibling of
+// TestLeaseRenew_HonorsT1 — the direct test for "DHCPv6 renewal is
+// less battle-tested" (#103). dnsmasq derives T1 = lease/2 = 60s; we
+// idle 75s and assert the address survived and a renewal DHCPREPLY
+// landed on top of the bind's.
+func TestLeaseRenewIPv6_HonorsT1(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-v6renew"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{"ipv6": "true"})
+	id, _, _ := harness.RunContainer(t, ctx, netName, "dh-itest-v6renew-ctr")
+
+	v6 := linkGlobalV6(t, ctx, id, harness.IPAcquisitionBudget)
+	if v6 == "" {
+		t.Fatal("no global IPv6 appeared on the container link")
+	}
+	startReplies := countDHCPv6Replies(t, fixture.DnsmasqLog(), v6)
+
+	t.Log("waiting 75s for the DHCPv6 renewal cycle...")
+	select {
+	case <-ctx.Done():
+		t.Fatalf("context cancelled before renewal window: %v", ctx.Err())
+	case <-time.After(75 * time.Second):
+	}
+
+	after := linkGlobalV6(t, ctx, id, 5*time.Second)
+	if after != v6 {
+		t.Errorf("IPv6 changed across renewal window: %s -> %s", v6, after)
+	}
+	endReplies := countDHCPv6Replies(t, fixture.DnsmasqLog(), v6)
+	t.Logf("DHCPREPLYs for %s: start=%d end=%d", v6, startReplies, endReplies)
+	if endReplies-startReplies < 1 {
+		t.Errorf("no renewal DHCPREPLY for %s after crossing T1 — udhcpc6 renewal appears stuck", v6)
+	}
+}
+
+// TestIPv6_DNS6Propagation: propagate_dns=true writes the DHCPv6
+// option-23 server into resolv.conf (the v6 mirror of the existing
+// v4 pair). resolv.conf is last-writer-wins between the families, so
+// the assertion is "the v6 nameserver appears", polled across the
+// bind window.
+func TestIPv6_DNS6Propagation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	t.Run("opt-in writes dns6", func(t *testing.T) {
+		netName := "dh-itest-v6dns"
+		harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{
+			"ipv6": "true", "propagate_dns": "true",
+		})
+		id, _, _ := harness.RunContainer(t, ctx, netName, "dh-itest-v6dns-ctr")
+
+		deadline := time.Now().Add(20 * time.Second)
+		var out string
+		for time.Now().Before(deadline) {
+			out = harness.ExecOutput(t, ctx, id, "cat", "/etc/resolv.conf")
+			if strings.Contains(out, harness.TestDNS6Server) {
+				return
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+		t.Errorf("DHCPv6 DNS server %s never appeared in resolv.conf\nlast contents:\n%s", harness.TestDNS6Server, out)
+	})
+
+	t.Run("default leaves resolv.conf alone", func(t *testing.T) {
+		netName := "dh-itest-v6dnsoff"
+		harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{"ipv6": "true"})
+		id, _, _ := harness.RunContainer(t, ctx, netName, "dh-itest-v6dnsoff-ctr")
+
+		// Wait for the v6 bind (the moment a propagating network
+		// would have written), then assert absence.
+		if v6 := linkGlobalV6(t, ctx, id, harness.IPAcquisitionBudget); v6 == "" {
+			t.Fatal("no global IPv6 appeared on the container link")
+		}
+		out := harness.ExecOutput(t, ctx, id, "cat", "/etc/resolv.conf")
+		if strings.Contains(out, harness.TestDNS6Server) {
+			t.Errorf("propagate_dns off but %s ended up in resolv.conf:\n%s", harness.TestDNS6Server, out)
+		}
+	})
+}
+
+// TestDUID_PersistsAcrossPluginRestart: the acceptance test for
+// #103's "persistent DUID" item, resolved by the audit: busybox
+// udhcpc6 derives a DUID-LL from the interface MAC (d6_dhcpc.c), so
+// the DUID is stable as long as the MAC is — and the container link's
+// MAC survives a plugin disable/enable. The dnsmasq lease DB must
+// show the SAME client DUID for the container's address after the
+// plugin restarts and its recovered udhcpc6 re-binds. This is what
+// makes server-side v6 reservations stick across plugin upgrades.
+func TestDUID_PersistsAcrossPluginRestart(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+
+	netName := "dh-itest-v6duid"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{"ipv6": "true"})
+	id, _, _ := harness.RunContainer(t, ctx, netName, "dh-itest-v6duid-ctr")
+
+	v6 := linkGlobalV6(t, ctx, id, harness.IPAcquisitionBudget)
+	if v6 == "" {
+		t.Fatal("no global IPv6 appeared on the container link")
+	}
+
+	// dnsmasq records the lease (with the client DUID) once the
+	// persistent client's REQUEST is REPLYed; poll for the entry.
+	var duidBefore string
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if duidBefore = leaseDUIDForV6(t, fixture.LeaseFile(), v6); duidBefore != "" {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	if duidBefore == "" {
+		t.Fatalf("no v6 lease entry for %s in the dnsmasq lease DB", v6)
+	}
+	repliesBefore := countDHCPv6Replies(t, fixture.DnsmasqLog(), v6)
+
+	// Plugin restart: same belt-and-braces shape as the recovery
+	// tests — re-enable is registered as cleanup before the disable
+	// so a failed assertion can't leave the runner's plugin off.
+	t.Cleanup(func() {
+		bg := context.Background()
+		if err := cli.PluginEnable(bg, harness.PluginRef, types.PluginEnableOptions{Timeout: 30}); err != nil {
+			if !strings.Contains(err.Error(), "already enabled") {
+				t.Logf("WARN: cleanup PluginEnable: %v", err)
+			}
+		}
+	})
+	if err := cli.PluginDisable(ctx, harness.PluginRef, types.PluginDisableOptions{Force: true}); err != nil {
+		t.Fatalf("PluginDisable: %v", err)
+	}
+	if err := harness.WaitPluginEnabled(ctx, cli, false, 30*time.Second); err != nil {
+		t.Fatalf("plugin did not reach disabled state: %v", err)
+	}
+	if err := cli.PluginEnable(ctx, harness.PluginRef, types.PluginEnableOptions{Timeout: 30}); err != nil {
+		t.Fatalf("PluginEnable: %v", err)
+	}
+	if err := harness.WaitPluginEnabled(ctx, cli, true, 30*time.Second); err != nil {
+		t.Fatalf("plugin did not re-enable: %v", err)
+	}
+	t.Log("plugin restarted; awaiting the recovered udhcpc6's re-bind...")
+
+	// The recovered persistent client SOLICITs immediately; a fresh
+	// DHCPREPLY for our address proves the post-restart exchange
+	// happened (so the lease DB entry is post-restart truth, not a
+	// stale leftover).
+	deadline = time.Now().Add(90 * time.Second)
+	rebound := false
+	for time.Now().Before(deadline) {
+		if countDHCPv6Replies(t, fixture.DnsmasqLog(), v6) > repliesBefore {
+			rebound = true
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	if !rebound {
+		t.Fatalf("no post-restart DHCPREPLY for %s within 90s — recovered udhcpc6 never re-bound", v6)
+	}
+
+	duidAfter := leaseDUIDForV6(t, fixture.LeaseFile(), v6)
+	if duidAfter == "" {
+		t.Fatalf("v6 lease entry for %s vanished after plugin restart", v6)
+	}
+	if !strings.EqualFold(duidBefore, duidAfter) {
+		t.Errorf("client DUID changed across plugin restart: %s -> %s — v6 reservations keyed on DUID will not stick",
+			duidBefore, duidAfter)
+	}
+}

--- a/test/integration/ipv6_test.go
+++ b/test/integration/ipv6_test.go
@@ -257,6 +257,8 @@ func TestLifecycleBridge_IPv6_GoldenPath(t *testing.T) {
 // idle 75s and assert the address survived and a renewal DHCPREPLY
 // landed on top of the bind's.
 func TestLeaseRenewIPv6_HonorsT1(t *testing.T) {
+	t.Skip("DHCPv6 IA unification pending (#152): the persistent client negotiates a second IA, so the Docker-visible v6 address is never renewed — this test asserts the intended post-unification semantics")
+
 	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Second)
 	defer cancel()
 
@@ -358,6 +360,8 @@ func TestIPv6_DNS6Propagation(t *testing.T) {
 	})
 
 	t.Run("opt-in writes dns6", func(t *testing.T) {
+		t.Skip("DHCPv6 IA unification pending (#152): the persistent client negotiates a second IA, so the Docker-visible v6 address is never renewed — this test asserts the intended post-unification semantics")
+
 		netName := "dh-itest-v6dns"
 		harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{
 			"ipv6": "true", "propagate_dns": "true",
@@ -402,6 +406,8 @@ func TestIPv6_DNS6Propagation(t *testing.T) {
 // plugin restarts and its recovered udhcpc6 re-binds. This is what
 // makes server-side v6 reservations stick across plugin upgrades.
 func TestDUID_PersistsAcrossPluginRestart(t *testing.T) {
+	t.Skip("DHCPv6 IA unification pending (#152): the persistent client negotiates a second IA, so the Docker-visible v6 address is never renewed — this test asserts the intended post-unification semantics")
+
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	defer cancel()
 


### PR DESCRIPTION
For #103, trimmed v1.0.0 scope (phases 1–3 per the issue comment; closes at release via the release PR).

## Phase 1 — Audit (from busybox source, `networking/udhcp/d6_dhcpc.c`)

The audit **invalidated the issue's premise**: busybox udhcpc6's CLIENTID is a **DUID-LL (type 3) derived from the interface MAC** — not a per-process timestamped DUID. DUID stability therefore follows from MAC stability, which the plugin already guarantees (container link keeps its MAC across plugin disable/enable; tombstones pin it across container restarts). The planned "persistent DUID in STATE_DIR" feature is unnecessary; what was missing was the **assertion** and the **docs**. Further findings:
- option 23 (DNS) is requested by default → `dns6` env needs no `-O` flag;
- `-x 1:hex` would replace the built-in CLIENTID outright if a custom DUID is ever needed;
- ipvlan corollary: shared parent MAC ⇒ shared DUID ⇒ per-container v6 reservations don't work in ipvlan mode (now documented).

## Phase 2 — DUID persistence, resolved by audit

`TestDUID_PersistsAcrossPluginRestart` asserts end-to-end: bind v6 → read the client DUID from the dnsmasq lease DB → `docker plugin disable/enable` → recovered udhcpc6 re-binds (fresh DHCPREPLY observed) → lease DB shows the **same DUID**. Expected green per the audit; if the Alpine busybox build diverges from upstream source, this test is what tells us.

## Phase 3 — Renewal correctness + first v6 coverage in the suite

- **Dual-stack fixtures**: both dnsmasqs now serve stateful DHCPv6 on ULA prefixes (`fd00:6470:6863::/64` macvlan, `fd00:6470:6864::/64` bridge) with `--enable-ra` and option-23 DNS; ip6tables FORWARD rules mirror the v4 ones on the bridge fixture. Per-suite static — no fixture-lifecycle changes.
- `TestLifecycleMacvlan_IPv6_GoldenPath` — v4+v6 pools, **inspect-vs-link agreement** on the v6 address, clean dual-stack release on teardown (`lease_release_failures` flat — exercises the v6 half of `Stop()`).
- `TestLifecycleBridge_IPv6_GoldenPath` — same contract through the bridge wiring path.
- `TestLeaseRenewIPv6_HonorsT1` — idle past T1 (75s), address stable, renewal DHCPREPLY observed. The direct test for "v6 renewal is less battle-tested".
- `TestIPv6_DNS6Propagation` — opt-in writes the option-23 server to resolv.conf; default leaves it alone.
- New harness helpers: `IsInPoolV6`/`IsInBridgePoolV6`, `countDHCPv6Replies`, `leaseDUIDForV6`, `linkGlobalV6`.

## Docs (audit deliverable)

New **"DHCPv6"** section in `parent-attached-modes.md`: the exact create incantation (`--ipv6` does NOT work with null IPAM; `-o ipv6=true` is the way), RA-delegated gateway, DUID identity + ipvlan caveat, the no-static-v6 boundary, dns6 propagation, PD out of scope.

## Out of scope (per the trimming comment)
DHCPv6-PD (own issue when a use case emerges); RA-based gateway selection (stays kernel-delegated — the audit found no golden-path need).

## Verification

- Verified locally: `go test -race ./...`, `go vet -tags integration`, staticcheck, gofmt clean.
- **Untested until this PR's CI run:** the five v6 integration tests and the dual-stack fixture config — first execution is this PR's `integration` check (needs the root runner + this PR's plugin build). The inspect-vs-link strict assertion is the most likely to surface a real edge; if it does, that's an audit finding to document, not silently loosen.

- [x] Audit findings documented (PR + docs section)
- [x] DUID persistence asserted (TDD test; green expected per audit)
- [x] v6 suite disposition (rescope approved 2026-06-12): golden paths + DNS6-default-off **green**; renewal / DNS6-opt-in / DUID-persistence **skipped with reference to #152** — the suite's first v6 runs uncovered the IA-split design defect (one-shot and persistent client negotiate different IAs), which is v1.1.0 design work, plus two production fixes that ship here (udev MACAddressPolicy pin, udhcpc6 -O vocabulary) and one in #138 (renew re-addressing)
- [x] ~+3 min wall-clock budgeted (renewal test dominates; fits the 10m main-suite timeout)
