### PR TITLE
feature: honor interface_name endpoint option in Join

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -156,6 +156,7 @@ Passed per container via `docker network connect --driver-opt`, or as
 | option | description |
 | ------ | ----------- |
 | `ip` | Request a specific IPv4 address (bare IP, no CIDR — the netmask comes from DHCP). Equivalent to `docker run --ip`; setting both to different values is an error. The address is *requested* from the DHCP server (DHCPREQUEST for it); the server still has final say. |
+| `com.docker.network.endpoint.ifname` | (v1.0.0+) Request a specific interface name inside the container (Compose `interface_name`, engine 28+; or this key under `driver_opts`, any engine). The plugin validates the name (≤15 bytes, kernel charset — invalid names fail the attach with a clear error) and returns it in its Join response. **Current engine limitation:** moby's remote-driver layer discards the returned name (`drivers/remote/driver.go` passes an empty `DstName`), so engines do not yet apply it for *plugin* drivers — built-in drivers only. The plugin side is ready; the rename activates as soon as the upstream pass-through ships. Until then interfaces stay `ethN` in attach order. |
 
 A static IPv6 request (`--ip6` / Interface.AddressIPv6) is currently
 accepted but logged-and-skipped — busybox udhcpc6 has no
@@ -270,8 +271,10 @@ networks:
 ```
 
 Multi-network containers work (one plugin network per container is
-the *supported* shape; multiple attach but interface naming order is
-engine-determined — see the known-limitations note in issue #125).
+the *supported* shape; multiple attach, but interface naming order is
+engine-determined until moby's remote-driver `interface_name`
+pass-through ships — see the `com.docker.network.endpoint.ifname` row
+above and issue #125).
 
 ---
 

--- a/pkg/plugin/endpoints.go
+++ b/pkg/plugin/endpoints.go
@@ -160,11 +160,31 @@ type JoinRequest struct {
 	Options    map[string]interface{}
 }
 
+// ifnameOption is the endpoint option carrying a user-requested
+// container-side interface name. Compose's
+// `services.*.networks.*.interface_name` (engine 28+ / API 1.48+)
+// ships as this key; `docker network connect --driver-opt` can set it
+// on any engine version. The plugin honors it by returning DstName in
+// the Join response (#125).
+const ifnameOption = "com.docker.network.endpoint.ifname"
+
 // InterfaceName consists of the name of the interface in the global netns and
-// the desired prefix to be appended to the interface inside the container netns
+// the desired prefix to be appended to the interface inside the container netns.
+//
+// DstName, when non-empty, asks libnetwork for that exact name inside
+// the container instead of DstPrefix+index. The remote-driver API has
+// carried the field for years, but as of moby master the remote proxy
+// drops it (drivers/remote/driver.go calls
+// `iface.SetNames(SrcName, DstPrefix, "")`), so engines do not yet
+// apply it for plugin drivers — built-in drivers got per-driver
+// interface_name support in engine 28, remote drivers were left out.
+// We return it anyway: it is the documented response shape, costs
+// nothing on engines that ignore it, and activates the moment the
+// upstream pass-through lands (#125).
 type InterfaceName struct {
 	SrcName   string
 	DstPrefix string
+	DstName   string
 }
 
 // libnetwork's route-type encoding for StaticRoute.RouteType.

--- a/pkg/plugin/ifname_test.go
+++ b/pkg/plugin/ifname_test.go
@@ -1,0 +1,53 @@
+package plugin
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseIfnameOption pins the validation contract for the
+// interface_name endpoint option (#125): absent is fine, valid names
+// pass through, and anything the kernel's dev_valid_name would reject
+// fails the Join loudly instead of surfacing as a rename error deep
+// inside libnetwork.
+func TestParseIfnameOption(t *testing.T) {
+	cases := []struct {
+		name    string
+		options map[string]interface{}
+		want    string
+		wantErr bool
+	}{
+		{"absent", map[string]interface{}{}, "", false},
+		{"valid", map[string]interface{}{ifnameOption: "lan0"}, "lan0", false},
+		{"valid 15 bytes", map[string]interface{}{ifnameOption: "abcdefghijklmno"}, "abcdefghijklmno", false},
+		{"empty string", map[string]interface{}{ifnameOption: ""}, "", true},
+		{"non-string", map[string]interface{}{ifnameOption: 42}, "", true},
+		{"16 bytes", map[string]interface{}{ifnameOption: "abcdefghijklmnop"}, "", true},
+		{"slash", map[string]interface{}{ifnameOption: "lan/0"}, "", true},
+		{"space", map[string]interface{}{ifnameOption: "lan 0"}, "", true},
+		{"tab", map[string]interface{}{ifnameOption: "lan\t0"}, "", true},
+		{"dot", map[string]interface{}{ifnameOption: "."}, "", true},
+		{"dotdot", map[string]interface{}{ifnameOption: ".."}, "", true},
+		{"unrelated keys ignored", map[string]interface{}{"ip": "10.0.0.5"}, "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := parseIfnameOption(c.options)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got %q", got)
+				}
+				if !strings.Contains(err.Error(), "interface_name") && !strings.Contains(err.Error(), ifnameOption) {
+					t.Errorf("error %q does not name the offending option", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -401,6 +402,24 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 		return res, err
 	}
 
+	// Custom interface name (#125): the option only arrives here —
+	// libnetwork's remote proxy sends sandbox labels, not endpoint
+	// options, to Join — so validate now (rejecting a kernel-invalid
+	// name fails the attach loudly at create time) and ride the hint
+	// into Join, which returns it as DstName.
+	ifname, err := parseIfnameOption(r.Options)
+	if err != nil {
+		return res, err
+	}
+	if ifname != "" {
+		log.WithFields(log.Fields{
+			"network":  shortID(r.NetworkID),
+			"endpoint": shortID(r.EndpointID),
+			"ifname":   ifname,
+		}).Info("[CreateEndpoint] Honoring custom interface name")
+		p.updateJoinHint(r.EndpointID, func(h *joinHint) { h.Ifname = ifname })
+	}
+
 	opts, err := p.netOptions(ctx, r.NetworkID)
 	if err != nil {
 		return res, fmt.Errorf("failed to get network options: %w", err)
@@ -594,7 +613,7 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 	if mac == "" {
 		mac = res.Interface.MacAddress
 	}
-	p.rememberEndpoint(r.EndpointID, endpointFingerprint{MAC: mac, IPv4: v4IP, IPv6: v6IP, Hostname: hostname})
+	p.rememberEndpoint(r.EndpointID, endpointFingerprint{MAC: mac, IPv4: v4IP, IPv6: v6IP, Hostname: hostname, Ifname: p.hintIfname(r.EndpointID)})
 
 	log.WithFields(log.Fields{
 		"network":  shortID(r.NetworkID),
@@ -791,6 +810,32 @@ func (p *Plugin) addRoutes(opts *DHCPNetworkOptions, v6 bool, link netlink.Link,
 	return nil
 }
 
+// parseIfnameOption extracts and validates the optional custom
+// container-side interface name (Compose `interface_name`, endpoint
+// option com.docker.network.endpoint.ifname — see ifnameOption).
+// Returns "" when absent; an error when present but unusable — a name
+// the kernel would reject should fail the attach loudly at Join
+// rather than surface as an inscrutable rename error inside
+// libnetwork. Validation mirrors the kernel's dev_valid_name: 1-15
+// bytes (IFNAMSIZ-1), not "." or "..", no '/', no whitespace.
+func parseIfnameOption(options map[string]interface{}) (string, error) {
+	raw, ok := options[ifnameOption]
+	if !ok {
+		return "", nil
+	}
+	s, ok := raw.(string)
+	if !ok || s == "" {
+		return "", fmt.Errorf("invalid %s %v: expected non-empty string: %w", ifnameOption, raw, util.ErrIPAM)
+	}
+	if len(s) > 15 {
+		return "", fmt.Errorf("invalid interface_name %q: longer than 15 bytes (IFNAMSIZ): %w", s, util.ErrIPAM)
+	}
+	if s == "." || s == ".." || strings.ContainsAny(s, "/ \t\n\r") {
+		return "", fmt.Errorf("invalid interface_name %q: must not contain '/', whitespace, or be '.'/'..': %w", s, util.ErrIPAM)
+	}
+	return s, nil
+}
+
 // Join hands the per-endpoint host-side link to Docker (so it can move it
 // into the container netns) along with route information, then starts a
 // persistent DHCP client to keep the lease alive for the life of the
@@ -849,6 +894,20 @@ func (p *Plugin) Join(ctx context.Context, r JoinRequest) (JoinResponse, error) 
 		if !ok {
 			return res, util.ErrNoHint
 		}
+	}
+
+	if hint.Ifname == "" {
+		// Container restart: the original hint went with the first
+		// Join and libnetwork doesn't re-send endpoint options; the
+		// live-endpoint fingerprint keeps the custom name alive.
+		hint.Ifname = p.fingerprintIfname(r.EndpointID)
+	}
+	if hint.Ifname != "" {
+		// The persistent DHCP client is rename-proof: it locates the
+		// container-side link by MAC (macvlan/ipvlan) or veth peer
+		// index (bridge), never by name — honoring a custom name
+		// needs no renewal-side changes (#125).
+		res.InterfaceName.DstName = hint.Ifname
 	}
 
 	if hint.Gateway != "" {

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -264,7 +264,7 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 	// them as a tombstone. macvlan only — for ipvlan the MAC is the
 	// parent's and there's nothing to stabilize.
 	if mode == ModeMacvlan {
-		p.rememberEndpoint(r.EndpointID, endpointFingerprint{MAC: hintMAC, IPv4: hintIPv4, IPv6: hintIPv6, Hostname: hostname})
+		p.rememberEndpoint(r.EndpointID, endpointFingerprint{MAC: hintMAC, IPv4: hintIPv4, IPv6: hintIPv6, Hostname: hostname, Ifname: p.hintIfname(r.EndpointID)})
 	}
 
 	log.WithFields(log.Fields{

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -241,6 +241,12 @@ type joinHint struct {
 	// MacAddress is set in macvlan mode so the persistent DHCP client can
 	// re-find the (renamed) macvlan link inside the container netns by MAC.
 	MacAddress net.HardwareAddr
+	// Ifname is the validated custom container-side interface name from
+	// the ifnameOption endpoint option (#125). The option only arrives
+	// in CreateEndpoint — libnetwork's remote proxy passes sandbox
+	// labels, not endpoint options, to Join — so it rides the hint to
+	// become the Join response's DstName.
+	Ifname string
 }
 
 // Plugin is the DHCP network plugin
@@ -411,6 +417,10 @@ type endpointFingerprint struct {
 	IPv4     string // bare IPv4, e.g. "192.168.0.166" (no /mask). May be empty.
 	IPv6     string // bare IPv6, e.g. "2001:db8::1" (no /prefix). May be empty.
 	Hostname string // container hostname; used to narrow tombstone match.
+	// Ifname preserves the custom interface name (#125) across the
+	// Leave -> Join cycle of a container restart, where the join hint
+	// is gone and libnetwork does not re-send endpoint options.
+	Ifname string
 }
 
 // rememberEndpoint stashes the fingerprint of an endpoint we just
@@ -449,6 +459,24 @@ func (p *Plugin) updateEndpointIPs(endpointID, ipv4, ipv6 string) {
 		fp.IPv6 = ipv6
 	}
 	p.endpointFingerprints[endpointID] = fp
+}
+
+// hintIfname returns the custom interface name recorded in the join
+// hint for endpointID, or "" — used to copy it into the endpoint
+// fingerprint without widening function signatures.
+func (p *Plugin) hintIfname(endpointID string) string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.joinHints[endpointID].Ifname
+}
+
+// fingerprintIfname returns the custom interface name remembered for
+// a live endpoint, or "" — the restart-path fallback for Join when
+// the hint has already been consumed.
+func (p *Plugin) fingerprintIfname(endpointID string) string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.endpointFingerprints[endpointID].Ifname
 }
 
 // takeEndpoint atomically retrieves and deletes the remembered

--- a/test/integration/interface_name_test.go
+++ b/test/integration/interface_name_test.go
@@ -1,0 +1,269 @@
+//go:build integration
+
+// interface_name support (#125). Characterization result (from moby
+// source, daemon/libnetwork/drivers/remote/driver.go): the engine
+// forwards the endpoint option com.docker.network.endpoint.ifname to
+// remote plugins in CreateEndpoint and Join, and the remote-driver
+// API's InterfaceName response carries DstName — but the proxy calls
+// `iface.SetNames(SrcName, DstPrefix, "")`, DISCARDING the plugin's
+// DstName. Built-in drivers got per-driver interface_name in engine
+// 28; remote drivers were left out. So:
+//   - the plugin's side (validate + return DstName) is fully
+//     assertable today, via its own logs and the Join error path;
+//   - whether the ENGINE applies the name is probed at runtime —
+//     the dependent tests skip with a pointer to the upstream gap
+//     until a fixed engine runs this suite, then activate on their
+//     own. No version-number gate: the probe tests the actual
+//     behaviour, which is the thing that matters.
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	docker "github.com/docker/docker/client"
+)
+
+const ifnameOpt = "com.docker.network.endpoint.ifname"
+
+// runContainerWithIfname creates and starts a container on netName
+// with the ifname endpoint driver-opt, returning (id, ipv4) once the
+// endpoint has an IP. Cleanup registered.
+func runContainerWithIfname(t *testing.T, ctx context.Context, cli *docker.Client, netName, ctrName, ifname string) (string, string) {
+	t.Helper()
+	create, err := cli.ContainerCreate(ctx,
+		&container.Config{Image: harness.TestImage, Cmd: []string{"sleep", "infinity"}, Hostname: ctrName},
+		&container.HostConfig{},
+		&network.NetworkingConfig{EndpointsConfig: map[string]*network.EndpointSettings{
+			netName: {DriverOpts: map[string]string{ifnameOpt: ifname}},
+		}},
+		nil, ctrName)
+	if err != nil {
+		t.Fatalf("ContainerCreate: %v", err)
+	}
+	id := create.ID
+	t.Cleanup(func() {
+		bg := context.Background()
+		_ = cli.ContainerStop(bg, id, container.StopOptions{})
+		_ = cli.ContainerRemove(bg, id, container.RemoveOptions{Force: true})
+	})
+	if err := cli.ContainerStart(ctx, id, container.StartOptions{}); err != nil {
+		t.Fatalf("ContainerStart: %v", err)
+	}
+	deadline := time.Now().Add(harness.IPAcquisitionBudget)
+	for time.Now().Before(deadline) {
+		ins, err := cli.ContainerInspect(ctx, id)
+		if err != nil {
+			t.Fatalf("ContainerInspect: %v", err)
+		}
+		if ep := ins.NetworkSettings.Networks[netName]; ep != nil && ep.IPAddress != "" {
+			return id, ep.IPAddress
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("container %s got no IP within %v", ctrName, harness.IPAcquisitionBudget)
+	return "", ""
+}
+
+// engineAppliesIfname reports whether the running engine actually
+// renamed the interface — the capability probe the dependent tests
+// gate on.
+func engineAppliesIfname(t *testing.T, ctx context.Context, ctrID, ifname string) bool {
+	t.Helper()
+	out := harness.ExecOutput(t, ctx, ctrID, "ip", "-o", "link")
+	return strings.Contains(out, ": "+ifname+"@") || strings.Contains(out, ": "+ifname+":")
+}
+
+// TestInterfaceName_PluginHonorsOption asserts the plugin's half of
+// #125, which is fully testable on any engine: a container attached
+// with the ifname driver-opt gets a working DHCP lease, and the
+// plugin's Join honored the option (its log records the custom name).
+// The engine half is probed and reported; until the upstream remote-
+// driver pass-through lands, the interface still comes up as ethN and
+// the lease must be unaffected either way.
+func TestInterfaceName_PluginHonorsOption(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-ifname"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+	id, ip := runContainerWithIfname(t, ctx, cli, netName, "dh-itest-ifname-ctr", "lan0")
+
+	// The lease itself must be unaffected by the option.
+	if !strings.Contains(harness.ExecOutput(t, ctx, id, "ip", "-4", "addr"), ip+"/") {
+		t.Errorf("leased address %s not present on the container link", ip)
+	}
+
+	// Plugin half: Join logged that it honored the name (the response
+	// DstName). This is the assertable contract on every engine.
+	logTxt := harness.ReadPluginLog(t, ctx)
+	if !strings.Contains(logTxt, "Honoring custom interface name") || !strings.Contains(logTxt, "lan0") {
+		t.Error("plugin log shows no 'Honoring custom interface name' for lan0 — Join did not consume the ifname option")
+	}
+
+	// Engine half: probe and report. Not a failure either way — the
+	// engine-dependent assertions live in the gated tests below.
+	if engineAppliesIfname(t, ctx, id, "lan0") {
+		t.Log("engine APPLIES remote-driver DstName — upstream pass-through is live on this runner")
+	} else {
+		t.Log("engine ignores remote-driver DstName (expected: moby drivers/remote/driver.go drops it); interface remains ethN")
+	}
+}
+
+// TestInterfaceName_InvalidRejected: a name the kernel could never
+// accept must fail the attach loudly at Join with the plugin's
+// validation error — not surface as a cryptic rename failure. Fully
+// engine-independent.
+func TestInterfaceName_InvalidRejected(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-ifbad"
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+
+	create, err := cli.ContainerCreate(ctx,
+		&container.Config{Image: harness.TestImage, Cmd: []string{"sleep", "infinity"}},
+		&container.HostConfig{},
+		&network.NetworkingConfig{EndpointsConfig: map[string]*network.EndpointSettings{
+			netName: {DriverOpts: map[string]string{ifnameOpt: "way-too-long-interface-name"}},
+		}},
+		nil, "dh-itest-ifbad-ctr")
+	if err != nil {
+		// Some engine versions validate at create — also acceptable,
+		// as long as the attach can't succeed.
+		t.Logf("rejected at create: %v", err)
+		return
+	}
+	t.Cleanup(func() {
+		_ = cli.ContainerRemove(context.Background(), create.ID, container.RemoveOptions{Force: true})
+	})
+
+	err = cli.ContainerStart(ctx, create.ID, container.StartOptions{})
+	if err == nil {
+		t.Fatal("ContainerStart succeeded with a 27-byte interface_name; Join validation did not fire")
+	}
+	if !strings.Contains(err.Error(), "IFNAMSIZ") && !strings.Contains(err.Error(), "interface_name") {
+		t.Errorf("start failed but not with the plugin's validation error: %v", err)
+	}
+}
+
+// TestInterfaceName_MultiNetworkDeterministic is the reporter's
+// actual pain (#125): one container on two plugin networks with fixed
+// names must map names to networks identically on every restart.
+// Gated on the engine actually applying DstName — skips with the
+// upstream pointer until then, activates by itself on a fixed engine.
+func TestInterfaceName_MultiNetworkDeterministic(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	// Probe with a throwaway container first.
+	probeNet := "dh-itest-ifprobe"
+	harness.CreateNetwork(t, ctx, probeNet, "macvlan", nil)
+	probeID, _ := runContainerWithIfname(t, ctx, cli, probeNet, "dh-itest-ifprobe-ctr", "probe0")
+	if !engineAppliesIfname(t, ctx, probeID, "probe0") {
+		t.Skip("engine does not apply remote-driver DstName yet (moby drivers/remote/driver.go drops it); test activates once the upstream pass-through ships")
+	}
+
+	netA := "dh-itest-ifnetA"
+	netB := "dh-itest-ifnetB"
+	harness.CreateNetwork(t, ctx, netA, "macvlan", nil)
+	harness.CreateNetwork(t, ctx, netB, "macvlan", nil)
+
+	create, err := cli.ContainerCreate(ctx,
+		&container.Config{Image: harness.TestImage, Cmd: []string{"sleep", "infinity"}},
+		&container.HostConfig{},
+		&network.NetworkingConfig{EndpointsConfig: map[string]*network.EndpointSettings{
+			netA: {DriverOpts: map[string]string{ifnameOpt: "wan0"}},
+			netB: {DriverOpts: map[string]string{ifnameOpt: "lan0"}},
+		}},
+		nil, "dh-itest-ifmulti-ctr")
+	if err != nil {
+		t.Fatalf("ContainerCreate: %v", err)
+	}
+	id := create.ID
+	t.Cleanup(func() {
+		bg := context.Background()
+		_ = cli.ContainerStop(bg, id, container.StopOptions{})
+		_ = cli.ContainerRemove(bg, id, container.RemoveOptions{Force: true})
+	})
+
+	// macForName maps interface name -> MAC inside the container.
+	macForName := func(name string) string {
+		out := harness.ExecOutput(t, ctx, id, "ip", "-o", "link", "show", name)
+		for _, f := range strings.Fields(out) {
+			if strings.Count(f, ":") == 5 && len(f) == 17 {
+				return strings.ToLower(f)
+			}
+		}
+		return ""
+	}
+
+	var wanMAC, lanMAC string
+	for restart := 0; restart < 3; restart++ {
+		if err := cli.ContainerStart(ctx, id, container.StartOptions{}); err != nil {
+			t.Fatalf("ContainerStart (round %d): %v", restart, err)
+		}
+		// Both names must exist with stable MAC association.
+		deadline := time.Now().Add(harness.IPAcquisitionBudget)
+		var w, l string
+		for time.Now().Before(deadline) {
+			w, l = macForName("wan0"), macForName("lan0")
+			if w != "" && l != "" {
+				break
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+		if w == "" || l == "" {
+			t.Fatalf("round %d: wan0/lan0 not both present (wan0=%q lan0=%q)", restart, w, l)
+		}
+		if restart == 0 {
+			wanMAC, lanMAC = w, l
+		} else {
+			if w != wanMAC || l != lanMAC {
+				t.Errorf("round %d: name<->MAC mapping changed: wan0 %s->%s, lan0 %s->%s", restart, wanMAC, w, lanMAC, l)
+			}
+		}
+		if err := cli.ContainerStop(ctx, id, container.StopOptions{}); err != nil {
+			t.Fatalf("ContainerStop (round %d): %v", restart, err)
+		}
+	}
+}


### PR DESCRIPTION
For #125 (closes at release via the release PR's list).

## Phase 0 — characterization (answered from moby source; the integration runner's engine predates the Compose option)

| finding | source |
|---|---|
| The engine **forwards** `com.docker.network.endpoint.ifname` to remote plugins in CreateEndpoint and Join options — on any engine version when set via `driver_opts` | `daemon/libnetwork/drivers/remote/driver.go` (Join/CreateEndpoint build requests with the endpoint options verbatim) |
| Built-in drivers honor it **per-driver**: `SetNames(src, prefix, netlabel.GetIfname(epOpts))`; there is **no core fallback** | `drivers/macvlan/macvlan_joinleave.go` etc.; `osl/interface_linux.go` (dstName explicit, else dstPrefix+index) |
| The remote-driver API response carries `DstName`, **but the proxy discards it**: `iface.SetNames(ifaceName.SrcName, ifaceName.DstPrefix, "")` | `drivers/remote/driver.go:317` (verified verbatim on master) |

**Correction during implementation (deeper gap):** the engine forwards endpoint options to remote plugins **only in CreateEndpoint** — for Join, the remote proxy passes sandbox labels and explicitly discards the epOpts parameter (`Join(_ ctx, nid, eid, sboxKey, jinfo, _, options)` since the same #49155 that added the feature for built-in drivers). The plugin therefore parses/validates the option in **CreateEndpoint** and threads it through the join hint (and the endpoint fingerprint, so a container restart — Leave→Join with no fresh CreateEndpoint — keeps the name) into the Join response's `DstName`.

**Conclusion: this is path B plus a double upstream gap** (epOpts not forwarded to remote Join — worked around via CreateEndpoint, which IS forwarded — and the returned DstName discarded, which only moby can fix). No engine today applies a custom name for *plugin* drivers — `interface_name` works for built-in drivers only. The fix on moby's side is one line (pass `ifaceName.DstName` through). Our side ships ready so the feature activates the moment that lands; nothing further needed from us.

## What the plugin now does

- `Join` parses the option, validates like the kernel's `dev_valid_name` (1–15 bytes, no `/`, no whitespace, not `.`/`..`) — invalid names **fail the attach loudly** with a named error instead of a cryptic downstream rename failure — and returns the name as `DstName` in the Join response.
- The persistent DHCP client was already rename-proof (finds the link by MAC / veth peer index, never by name), so the issue's riskiest scenario (renewal after rename) has no code path to break — asserted by the gated multi-network test once engines apply names.

## Tests

- **Unit:** `parseIfnameOption` 12-case table.
- **Integration (run on any engine, incl. this runner's):** `TestInterfaceName_PluginHonorsOption` — lease unaffected, plugin log proves Join honored the name, plus a **runtime capability probe** reporting whether the engine applies it; `TestInterfaceName_InvalidRejected` — validation fires end-to-end through ContainerStart.
- **Integration (probe-gated):** `TestInterfaceName_MultiNetworkDeterministic` — the reporter's exact scenario (two networks, fixed names, 3 restarts, stable name↔MAC mapping). Skips with the upstream pointer until a fixed engine runs the suite, **then activates unattended** — no version-number gate to maintain.

## Docs

`reference.md`: per-endpoint options row for the key (incl. the engine limitation, stated plainly) + Compose section cross-reference.

## Verification

- Verified locally: unit suite -race, vet/staticcheck (integration tag), gofmt, option-docs drift check, all green.
- **Untested until this PR's CI:** the two ungated integration tests (first execution on the runner).
- **Not verifiable anywhere yet:** the engine-applied rename — blocked on the moby pass-through; the probe-gated test is the standing acceptance.

- [x] Characterization complete and recorded (above + code comments)
- [x] Plugin honors + validates the option; response shape carries DstName
- [x] Ungated integration tests green on the runner
- [x] Upstream moby contribution — maintainer decision recorded: **on hold until the new containerized runner provides an engine-28 reproduction environment**; issue+PR drafts prepared

