### PR TITLE
ci: OpenSSF Scorecard, security policy, Go Report Card badge, token narrowing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,14 +39,19 @@ on:
         description: "Tag to release (e.g. v0.8.0). Must already exist on the remote."
         required: true
 
+# Top-level token is read-only; write scopes are granted per-job below
+# (Scorecard Token-Permissions: a workflow-wide write scope leaks into
+# every job, including ones that only need to pull).
 permissions:
   contents: read
-  packages: write   # GHCR push needs this on GITHUB_TOKEN
 
 jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write   # GHCR push needs this on GITHUB_TOKEN
 
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
@@ -218,6 +223,9 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: read   # pulls the just-published plugin from GHCR
     env:
       GHCR_NAME: ghcr.io/claymore666/docker-net-dhcp
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,58 @@
+name: Scorecard
+
+# OpenSSF Scorecard supply-chain self-assessment. Runs on the hosted
+# runners (zero load on the integration runner), publishes results to
+# the public Scorecard API (that's what feeds the README badge), and
+# uploads the SARIF so findings appear under Security → Code scanning.
+#
+# Actions in THIS workflow are SHA-pinned (the comment carries the
+# human-readable tag): scorecard's own Pinned-Dependencies check
+# scores tag-pinning down, and the publishing workflow that signs our
+# results should lead by example. Repo-wide SHA-pinning is tracked in
+# the hardening follow-up issue; Dependabot maintains these pins.
+on:
+  # Like Dependabot and cron triggers, only active once this file is
+  # on the default branch.
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '41 7 * * 2'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      # Needed to upload SARIF to code scanning.
+      security-events: write
+      # Needed by scorecard-action to publish signed results.
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish to the Scorecard REST API — feeds the README badge
+          # and https://scorecard.dev/viewer/?uri=github.com/claymore666/docker-net-dhcp
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Integration](https://github.com/claymore666/docker-net-dhcp/actions/workflows/integration.yml/badge.svg)](https://github.com/claymore666/docker-net-dhcp/actions/workflows/integration.yml)
 [![Dependencies](https://img.shields.io/badge/dependencies-Dependabot%20%2B%20govulncheck-brightgreen?logo=dependabot)](https://github.com/claymore666/docker-net-dhcp/network/updates)
 [![Release](https://img.shields.io/github/v/release/claymore666/docker-net-dhcp?sort=semver)](https://github.com/claymore666/docker-net-dhcp/releases)
+[![Go Report Card](https://goreportcard.com/badge/github.com/claymore666/docker-net-dhcp)](https://goreportcard.com/report/github.com/claymore666/docker-net-dhcp)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/claymore666/docker-net-dhcp/badge)](https://scorecard.dev/viewer/?uri=github.com/claymore666/docker-net-dhcp)
 
 > **This is a maintained fork** of [`devplayer0/docker-net-dhcp`][upstream].
 > The upstream repository has been quiet since 2021 and no longer builds on

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities **privately** via GitHub's
+security advisory form:
+
+**<https://github.com/claymore666/docker-net-dhcp/security/advisories/new>**
+
+Do not open a public issue for anything you believe is exploitable.
+You can expect an initial response within a few days; this is a
+solo-maintained project, so please allow a reasonable window for a
+fix before any public disclosure (90 days is a fine default).
+
+## Scope — what this plugin is
+
+`docker-net-dhcp` is a privileged Docker network plugin: it runs with
+`CAP_NET_ADMIN`/`CAP_SYS_ADMIN`, the host PID namespace, host
+networking, and the Docker socket mounted. Reports are especially
+welcome for:
+
+- container → host or container → plugin escapes through the netns /
+  mount-ns handling (`pkg/plugin`, `pkg/udhcpc`);
+- parsing of untrusted DHCP-server responses (the udhcpc event path:
+  `cmd/udhcpc-handler`, `pkg/udhcpc.BuildEvent`, lease/option
+  propagation into containers);
+- anything that lets one container influence another container's
+  lease, address, or DNS (cross-endpoint identity confusion).
+
+A hostile **LAN DHCP server** is partially in scope: the plugin
+necessarily trusts the server for addressing (that is its job), but
+memory-unsafe or injection-style handling of server-supplied bytes is
+a bug.
+
+## Supported versions
+
+Only the latest released version is supported with security fixes.
+There is no backport policy — upgrades are cheap (`docker plugin
+install` of the new tag).
+
+## Known accepted findings
+
+Vulnerabilities detected in dependencies that have **no fixed
+release** are documented with justification and a review date in
+[`.github/vuln-allowlist.txt`](.github/vuln-allowlist.txt) and
+re-evaluated by CI on every PR (govulncheck gate) plus a weekly
+scheduled scan. Entries there are deliberate, reviewed acceptances —
+not oversights.


### PR DESCRIPTION
Supply-chain posture round, prompted by a local baseline Scorecard run: **aggregate 4.2/10**. This PR takes the actionable wins; the rest is either time-gated or deliberate.

## What

| change | Scorecard check addressed |
|---|---|
| `.github/workflows/scorecard.yml` — weekly + push-to-main, hosted runners, `publish_results: true` (feeds badge + public viewer), SARIF → code scanning. Actions **SHA-pinned** with tag comments. | the badge itself; leads Pinned-Dependencies by example |
| `SECURITY.md` — private reporting via GitHub advisories, threat-model scope for a privileged network plugin, latest-only support, allowlist stance | Security-Policy 0 → 10 |
| `release.yml` token narrowing — top-level `GITHUB_TOKEN` read-only; `packages: write` scoped to the release job, `packages: read` to verify-install | Token-Permissions 0 → high |
| README badges: **Go Report Card (A+** today, verified**)** + OpenSSF Scorecard | CII/visibility |

## Known-remaining (deliberate or time-gated, no action in this PR)

- **Maintained 0/10** — repo is <90 days old; heals on its own.
- **Code-Review 0/10** — solo maintainer merging own PRs; structural.
- **Branch-Protection 4/10** — `enforce_admins` off is a documented feature (runner-outage bypass), required-reviews don't fit a solo repo.
- **Pinned-Dependencies 1/10** — repo-wide SHA-pinning tracked in the hardening follow-up issue; Dependabot (live) maintains pins.
- **SAST 0/10** — CodeQL default setup was enabled today; the check starts scoring once analyses accumulate on commits.
- **Vulnerabilities 4/10** — the 6 findings are the documented, justification-carrying allowlist entries (daemon-side moby advisories with no fixed release) — see `.github/vuln-allowlist.txt` / SECURITY.md.
- **Fuzzing 0/10** — candidate for the follow-up issue (`BuildEvent` is a natural native-fuzzing target).
- **OpenSSF Best Practices (CII) 0/10** — needs the maintainer to register the project at bestpractices.dev (self-certification questionnaire); assessment prep exists.

## Verification

- actionlint clean (incl. the new workflow).
- Badge URLs verified serving (Go Report Card grade A+ generated and cached; Scorecard badge renders "no score" until the workflow first publishes from main — same self-healing-at-release pattern as the Integration badge).
- **Untested until exercised:** the release.yml permission narrowing — release-path change, gets its mandatory pre-tag exercise in the v1.0.0 rc dry-run.
- Scorecard workflow itself can't run until it reaches main (push/schedule triggers) — `workflow_dispatch` included for a manual first run after the release merge.

- [x] Baseline measured and quick wins applied
- [x] Badges verified
- [ ] rc dry-run exercises the narrowed release.yml token (release procedure, before the real tag)
- [ ] First Scorecard publish after release PR reaches main (then the badge shows a number)