### PR TITLE
ci: raise integration suite timeout headroom for slower runners

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   coverage:
     runs-on: [self-hosted, gpu1]
-    timeout-minutes: 20
+    timeout-minutes: 25
     env:
       COVER_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:golang-cover
       COVER_DIR: /var/lib/dh-cover

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   integration:
     runs-on: [self-hosted, gpu1]
-    timeout-minutes: 20
+    timeout-minutes: 25
     env:
       INTEGRATION_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:integration
     steps:

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ integration-test:
 		echo "integration-test must run as root. Re-run with sudo."; \
 		exit 1; \
 	fi
-	go test -v -tags integration -count=1 -timeout 10m ./test/integration/...
+	go test -v -tags integration -count=1 -timeout 15m ./test/integration/...
 
 # Manual orphan cleanup for when an integration test panics mid-setup
 # and leaves dh-itest-* interfaces / containers / networks behind.


### PR DESCRIPTION
Refs #146 (kept open per release flow — batch-closed by the release PR).

## What

- `Makefile` `integration-test` target: `go test -timeout` `10m` → `15m`
- `integration.yml` and `coverage.yml` job `timeout-minutes`: `20` → `25`

## Why

The full suite measured **558 s** against the 10-minute go-test timeout on 8-vCPU runner-class hardware (see #146) — ~40 s of headroom. The suite is wall-clock-bound on DHCP protocol timing (dnsmasq's 2-minute lease floor, deliberate timeout scenarios), so it degrades roughly linearly under contention once multiple runners share a host; spurious timeout failures would look like flaky tests.

The job-level guard stays 10 minutes above the go-test budget — still tight enough to catch genuine hangs (the go-test timeout fires first with a usable panic dump; the job timeout remains the backstop).

## Scope

Timeout budget only. No test changes, no behavior changes. The coverage workflow's suite run goes through `make integration-test` and inherits the Makefile bump; its separate unit-test invocation is untouched (runs in seconds, default timeout ample).