### PR TITLE
tests: supervisor-agnostic daemon restart in the integration harness

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -58,7 +58,9 @@ for the umbrella scope. Tests so far:
 - `recovery_test.go` — `docker plugin disable -f` + `enable` while
   a container is attached; asserts Plugin.Health.recovered_ok ≥ 1
   and the container's IP/MAC survive the recycle.
-- `recovery_daemon_test.go` — `systemctl restart docker` mid-suite
+- `recovery_daemon_test.go` — full daemon restart mid-suite (via
+  `harness.RestartDockerDaemon`: `systemctl` on systemd hosts,
+  supervised-dockerd signal on containerized runners)
   with a `--restart=always` container attached; asserts the daemon
   comes back, the container restarts, and the IP/MAC are
   preserved. Empirically the IP is preserved via the tombstone
@@ -69,7 +71,7 @@ for the umbrella scope. Tests so far:
 Tests run **serially** by design. None of the current cases call
 `t.Parallel()`, even though most would be safe — the recovery and
 daemon-restart tests planned for #56 will mutate global daemon
-state (plugin disable/enable, `systemctl restart docker`), and
+state (plugin disable/enable, a full daemon restart), and
 those have to run alone. Keeping the suite serial avoids designing
 in a foot-gun where a future test inadvertently runs concurrently
 with one that drops the docker socket.

--- a/test/integration/harness/daemon.go
+++ b/test/integration/harness/daemon.go
@@ -1,0 +1,145 @@
+//go:build integration
+
+package harness
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// dockerdPidFile is where dockerd writes its PID by default. Used by
+// the direct restart path to find and then fence the old daemon.
+const dockerdPidFile = "/var/run/docker.pid"
+
+// RestartDockerDaemon restarts the Docker daemon in a
+// supervisor-agnostic way and blocks until a *new* daemon process
+// exists. It does NOT wait for the API to answer — callers poll the
+// socket themselves (the daemon-restart test already does), because
+// how long "ready" takes is part of what that test measures.
+//
+// Two environments are supported, detected at runtime:
+//
+//   - systemd host (bare-metal runner): `systemctl restart docker`.
+//     systemctl itself blocks until the unit is started again.
+//
+//   - containerized runner (no systemd): SIGTERM the running dockerd
+//     and rely on the container's process supervisor to relaunch it.
+//     This requires the runner image to run dockerd as a *supervised
+//     child* — NOT as the container's main process the way stock
+//     docker:dind does, where dockerd's exit tears down the whole
+//     environment. See issue #145 for the runner-image requirement.
+//
+// If neither environment is detected, or the supervisor fails to
+// produce a new daemon process (PID must change), the test fails
+// loudly. There is deliberately no skip path: silently dropping the
+// daemon-restart recovery scenario on containerized runners would
+// remove coverage of a core recovery path exactly where all CI runs.
+func RestartDockerDaemon(t *testing.T, ctx context.Context) {
+	t.Helper()
+
+	if _, err := os.Stat("/run/systemd/system"); err == nil {
+		if _, err := exec.LookPath("systemctl"); err == nil {
+			t.Log("daemon restart: systemd path (systemctl restart docker)")
+			out, err := exec.CommandContext(ctx, "systemctl", "restart", "docker").CombinedOutput()
+			if err != nil {
+				t.Fatalf("systemctl restart docker: %v\n%s", err, out)
+			}
+			return
+		}
+	}
+
+	oldPID, err := dockerdPID()
+	if err != nil {
+		t.Fatalf("daemon restart: no systemd and no running dockerd found (%v) — "+
+			"this environment cannot restart the daemon. Containerized runners "+
+			"must supervise dockerd as a restartable child process (issue #145).", err)
+	}
+	t.Logf("daemon restart: direct path (no systemd) — SIGTERM dockerd pid %d, "+
+		"relying on the container's process supervisor to relaunch it", oldPID)
+
+	if err := syscall.Kill(oldPID, syscall.SIGTERM); err != nil {
+		t.Fatalf("SIGTERM dockerd (pid %d): %v", oldPID, err)
+	}
+
+	// Phase 1: the old daemon must actually exit. dockerd's graceful
+	// shutdown (lease releases, plugin teardown) is normally a few
+	// seconds; 15s absorbs a slow containerd drain.
+	exitDeadline := time.Now().Add(15 * time.Second)
+	for processAlive(oldPID) {
+		if time.Now().After(exitDeadline) {
+			t.Fatalf("dockerd (pid %d) still alive 15s after SIGTERM", oldPID)
+		}
+		if err := sleepCtx(ctx, 200*time.Millisecond); err != nil {
+			t.Fatalf("daemon restart interrupted: %v", err)
+		}
+	}
+
+	// Phase 2: the supervisor must bring up a replacement. A PID equal
+	// to the old one means nothing was restarted — fail, don't loop.
+	spawnDeadline := time.Now().Add(30 * time.Second)
+	for {
+		if newPID, err := dockerdPID(); err == nil {
+			if newPID == oldPID {
+				t.Fatalf("dockerd PID unchanged (%d) after restart — stale pidfile or nothing actually restarted", oldPID)
+			}
+			t.Logf("daemon restart: new dockerd pid %d", newPID)
+			return
+		}
+		if time.Now().After(spawnDeadline) {
+			t.Fatalf("no new dockerd appeared within 30s of the old one (pid %d) exiting — "+
+				"the environment does not supervise dockerd. Containerized runners must "+
+				"run dockerd as a restartable child process (issue #145).", oldPID)
+		}
+		if err := sleepCtx(ctx, 300*time.Millisecond); err != nil {
+			t.Fatalf("daemon restart interrupted: %v", err)
+		}
+	}
+}
+
+// dockerdPID locates the running dockerd: pidfile first (authoritative
+// when present and alive), /proc comm scan as fallback for daemons
+// started with a non-default --pidfile.
+func dockerdPID() (int, error) {
+	if b, err := os.ReadFile(dockerdPidFile); err == nil {
+		if pid, err := strconv.Atoi(strings.TrimSpace(string(b))); err == nil && processAlive(pid) {
+			return pid, nil
+		}
+	}
+	matches, _ := filepath.Glob("/proc/[0-9]*/comm")
+	for _, comm := range matches {
+		b, err := os.ReadFile(comm)
+		if err != nil || strings.TrimSpace(string(b)) != "dockerd" {
+			continue
+		}
+		pid, err := strconv.Atoi(filepath.Base(filepath.Dir(comm)))
+		if err == nil {
+			return pid, nil
+		}
+	}
+	return 0, os.ErrProcessDone
+}
+
+// processAlive reports whether pid exists (signal 0 probe). EPERM
+// counts as alive: the process exists but isn't ours.
+func processAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}
+
+// sleepCtx sleeps for d or until ctx is done, returning ctx.Err() in
+// the latter case so pollers fail fast on test timeout.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
+}

--- a/test/integration/recovery_daemon_test.go
+++ b/test/integration/recovery_daemon_test.go
@@ -66,6 +66,14 @@ func TestRecovery_DaemonRestart_PreservesContainer(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = cli.Close() })
 
+	// Baseline before the container exists: leases_obtained is
+	// cumulative across the (serial) suite, so the wait below is
+	// relative to this snapshot.
+	healthBefore, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("Plugin.Health before container start: %v", err)
+	}
+
 	// We can't use harness.RunContainer because it doesn't take a
 	// RestartPolicy. Inlining keeps the harness API stable.
 	create, err := cli.ContainerCreate(ctx,
@@ -110,6 +118,18 @@ func TestRecovery_DaemonRestart_PreservesContainer(t *testing.T) {
 
 	ipBefore, macBefore := waitForEndpoint(t, ctx, cli, id, harness.IPAcquisitionBudget)
 	t.Logf("before restart: ip=%s mac=%s", ipBefore, macBefore)
+
+	// The IP above appears as soon as CreateEndpoint's one-shot DHCP
+	// completes — *before* Join has started the persistent client. If
+	// the daemon goes down inside that window, no client exists to
+	// RELEASE the lease on shutdown; the DHCP server then keeps the
+	// old lease (keyed on the old endpoint's client-id) and hands the
+	// post-restart endpoint a *different* IP, failing the IP-stability
+	// assertion below for reasons that have nothing to do with restart
+	// recovery. Fast hosts never see this window; slower runner-class
+	// hardware does. Wait for the persistent client's first "bound"
+	// event (leases_obtained) before pulling the daemon down.
+	waitLeaseObtained(t, ctx, cli, healthBefore.LeasesObtained, 30*time.Second)
 
 	harness.RestartDockerDaemon(t, ctx)
 
@@ -174,6 +194,28 @@ func TestRecovery_DaemonRestart_PreservesContainer(t *testing.T) {
 	if macAfter != macBefore {
 		t.Errorf("MAC changed across daemon restart: before=%s after=%s", macBefore, macAfter)
 	}
+}
+
+// waitLeaseObtained polls Plugin.Health until leases_obtained moves
+// past the pre-container baseline, i.e. the endpoint's persistent
+// DHCP client has fired its first udhcpc "bound" event and lease
+// release-on-shutdown is armed.
+func waitLeaseObtained(t *testing.T, ctx context.Context, cli *docker.Client, baseline int32, budget time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(budget)
+	last := baseline
+	for time.Now().Before(deadline) {
+		h, err := harness.PluginHealth(ctx, cli)
+		if err == nil {
+			last = h.LeasesObtained
+			if last > baseline {
+				t.Logf("persistent DHCP client bound (leases_obtained %d -> %d)", baseline, last)
+				return
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("persistent DHCP client did not bind within %v (leases_obtained stuck at %d)", budget, last)
 }
 
 // waitForEndpoint mirrors RunContainer's polling loop but works on

--- a/test/integration/recovery_daemon_test.go
+++ b/test/integration/recovery_daemon_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"context"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -16,8 +15,9 @@ import (
 
 // TestRecovery_DaemonRestart_PreservesContainer is the integration
 // counterpart to Phase D step 9 of the manual smoke test: bounce the
-// whole docker daemon (systemctl restart docker) while a plugin-managed
-// container is attached, and verify that
+// whole docker daemon (harness.RestartDockerDaemon — systemctl on
+// systemd hosts, supervised-dockerd signal on containerized runners)
+// while a plugin-managed container is attached, and verify that
 //
 //   - the daemon comes back up (no hang on plugin re-enable — the
 //     historical upstream failure mode this fork modernized away from)
@@ -34,7 +34,7 @@ import (
 // Both paths yield the same user-visible invariant — same IP and
 // MAC — so we test on that, not on which internal codepath fired.
 //
-// **Do not parallelize.** systemctl restart docker drops every docker
+// **Do not parallelize.** Restarting the daemon drops every docker
 // connection on the host, including those of any other test running
 // concurrently. Per the rule documented in test/integration/README.md
 // the suite is serial; this test relies on that.
@@ -111,11 +111,7 @@ func TestRecovery_DaemonRestart_PreservesContainer(t *testing.T) {
 	ipBefore, macBefore := waitForEndpoint(t, ctx, cli, id, harness.IPAcquisitionBudget)
 	t.Logf("before restart: ip=%s mac=%s", ipBefore, macBefore)
 
-	t.Log("systemctl restart docker — runner host's docker daemon is going down briefly")
-	out, err := exec.CommandContext(ctx, "systemctl", "restart", "docker").CombinedOutput()
-	if err != nil {
-		t.Fatalf("systemctl restart docker: %v\n%s", err, out)
-	}
+	harness.RestartDockerDaemon(t, ctx)
 
 	// The pre-restart cli's TCP connection is dead. Build a new one.
 	_ = cli.Close()


### PR DESCRIPTION
Refs #145 (kept open per release flow — batch-closed by the release PR). Test design: see the issue comment.

## What

1. **`harness.RestartDockerDaemon`** (new `harness/daemon.go`): restarts the Docker daemon in a supervisor-agnostic way.
   - systemd host → `systemctl restart docker` (unchanged behavior)
   - no systemd → SIGTERM the running dockerd (pidfile, `/proc` comm-scan fallback), wait for the old PID to exit (15 s), wait for a supervisor-relaunched replacement with a **different** PID (30 s)
   - neither environment, missed deadline, or unchanged PID → `t.Fatalf` naming the runner-image supervision requirement. **No skip path.**
2. **`recovery_daemon_test.go`** uses the helper instead of hard-coding `systemctl` (#145's failure mode).
3. **Race fix surfaced by the slower restart path:** `waitForEndpoint` returns on CreateEndpoint's one-shot DHCP IP — *before* Join starts the persistent client. Restarting inside that window skips the lease RELEASE, the DHCP server keeps the old lease under the old endpoint's client-id, and the rebuilt endpoint gets a different IP — a false failure of the IP-stability assertion. The test now gates on `leases_obtained` advancing past a pre-container baseline (the counter increments exactly on the persistent client's first `bound` event). Fast hosts never saw this window; it reproduced deterministically on slower runner-class hardware.

## Verification matrix (per the test design in #145)

| Environment | Result |
|---|---|
| systemd host (bare-metal runner) | exercised by this PR's own `integration` check — systemd path, behavior unchanged |
| containerized runner, **supervised** dockerd (DinD, relaunch-loop entrypoint) | **PASS** — direct path: old pid SIGTERMed, new pid spawned, daemon-restart recovery ran, IP and MAC preserved (`leases_obtained` gate fired first) |
| stock `docker:dind` (dockerd = main process, unsupervised) | environment exits 4 s after SIGTERM — the job fails visibly with its environment; the helper's in-process deadline `Fatalf` covers the supervised-but-broken-relaunch case |

Supervised-container runs also confirmed the informational counters land on the documented alternate path (`recovered_ok=0 recovery_failed=1` — the test header is explicit that either internal path is acceptable; the user-visible IP/MAC invariant is the assertion).

## Runner-image requirement (forward-looking)

Containerized runner images must run `dockerd` as a supervised, restartable child — not as the container's main process. Documented in the helper's doc comment; the row-3 result above is what happens otherwise.