### PR TITLE
ci: ephemeral runner container image

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -1,0 +1,60 @@
+name: Runner image
+
+# Build + publish the ephemeral CI runner image (ci/runner-image/).
+# Runs on the GitHub-hosted pool — this is a plain docker build, none
+# of the privileged self-hosted requirements apply. The image is
+# consumed by the runner orchestrator, not by workflows in this repo.
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - ci/runner-image/**
+      - .github/workflows/runner-image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/claymore666/dhcp-ci-runner
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      # Pin-by-resolution: always build with the current runner agent
+      # release. Outdated agents refuse jobs after GitHub's grace
+      # window, so "latest at build time" + rebuild-on-dispatch is the
+      # right freshness model for an agent we ship inside an image.
+      - name: Resolve runner agent version
+        id: agent
+        run: |
+          ver=$(curl -fsSL https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name[1:]')
+          echo "version=${ver}" >> "$GITHUB_OUTPUT"
+          echo "Building with actions/runner v${ver}"
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build
+        run: |
+          docker build -f ci/runner-image/Dockerfile \
+            --build-arg RUNNER_VERSION="${{ steps.agent.outputs.version }}" \
+            -t "${IMAGE}:latest" \
+            -t "${IMAGE}:${GITHUB_SHA::7}" \
+            .
+
+      # The selftest needs --privileged, which GitHub-hosted runners
+      # allow for containers started by the job itself.
+      - name: Selftest
+        run: docker run --rm --privileged "${IMAGE}:latest" selftest
+
+      - name: Push
+        run: |
+          docker push "${IMAGE}:latest"
+          docker push "${IMAGE}:${GITHUB_SHA::7}"

--- a/ci/runner-image/Dockerfile
+++ b/ci/runner-image/Dockerfile
@@ -1,0 +1,83 @@
+# Ephemeral CI runner image — one container, one job, own nested
+# Docker daemon. See README.md in this directory for the orchestrator
+# contract and issue #149 for the design record.
+#
+# Build context is the REPO ROOT (caches are baked from go.mod and the
+# source tree):
+#   docker build -f ci/runner-image/Dockerfile \
+#     --build-arg RUNNER_VERSION=<x.y.z> -t dhcp-ci-runner .
+
+# ---- seed stage: fetch images the jobs would otherwise pull on every
+# run. skopeo needs no docker daemon, so this works in a plain build.
+# The plugin's digest-pinned base (alpine:3.20.3@sha256:...) is NOT
+# seeded: `docker load` can't satisfy digest references, and at 3.5 MB
+# the per-job pull is noise. The golang builder is the one that hurts.
+FROM debian:trixie-slim AS seeder
+RUN apt-get update && apt-get install -y --no-install-recommends skopeo ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN mkdir /seed \
+    && skopeo copy docker://docker.io/library/golang:1.25-alpine \
+         docker-archive:/seed/golang-builder.tar:golang:1.25-alpine \
+    && skopeo copy docker://docker.io/library/alpine:3.20 \
+         docker-archive:/seed/alpine-testimage.tar:alpine:3.20
+
+# ---- runner image
+FROM debian:trixie-slim
+
+ARG GO_VERSION=1.25.9
+# Resolved by the build workflow from actions/runner's latest release;
+# no default on purpose so a stale pin can't hide in this file.
+ARG RUNNER_VERSION
+
+# Base tooling + Docker Engine from download.docker.com (Debian 13's
+# docker.io is 26.x; the nested daemon must be >= 28 — engine-gated
+# tests, #125). dnsmasq is the test fixture's DHCP server: binary
+# only, there is no init system in here to start it.
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates curl git make jq procps tini xz-utils \
+        iproute2 iptables dnsmasq \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+    && printf 'Types: deb\nURIs: https://download.docker.com/linux/debian\nSuites: trixie\nComponents: stable\nSigned-By: /etc/apt/keyrings/docker.asc\n' \
+         > /etc/apt/sources.list.d/docker.sources \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        docker-ce docker-ce-cli containerd.io docker-buildx-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
+# Go toolchain, same procedure as test/integration/install-go-runner.sh.
+RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xz -C /usr/local \
+    && ln -sf /usr/local/go/bin/go /usr/local/bin/go \
+    && ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+
+# Actions runner agent. Jobs run as root by requirement (CAP_NET_ADMIN,
+# netns/mount ops, UDP/67) — RUNNER_ALLOW_RUNASROOT is set in the
+# entrypoint.
+RUN test -n "${RUNNER_VERSION}" || { echo "RUNNER_VERSION build-arg is required" >&2; exit 1; } \
+    && mkdir -p /opt/runner \
+    && curl -fsSL "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" \
+       | tar -xz -C /opt/runner \
+    && /opt/runner/bin/installdependencies.sh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Baked Go caches: module cache from go.mod/go.sum, then a warm compile
+# cache from building the tree (integration tag pulls in the docker SDK
+# test deps). PR source will differ, but stdlib and dependency compile
+# units still hit. Source is dropped afterwards; only caches stay.
+COPY go.mod go.sum /tmp/cache-src/
+RUN cd /tmp/cache-src && go mod download
+COPY pkg/ /tmp/cache-src/pkg/
+COPY cmd/ /tmp/cache-src/cmd/
+COPY test/ /tmp/cache-src/test/
+RUN cd /tmp/cache-src && go build -tags integration ./... && go vet -tags integration ./... || true; \
+    rm -rf /tmp/cache-src
+
+COPY --from=seeder /seed /seed
+COPY ci/runner-image/entrypoint.sh /entrypoint.sh
+RUN chmod 755 /entrypoint.sh
+
+# The nested daemon's data root must be a real filesystem — overlay2 on
+# top of the container's own overlayfs silently degrades to vfs. An
+# anonymous volume per container; the orchestrator's --rm reaps it.
+VOLUME /var/lib/docker
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]

--- a/ci/runner-image/README.md
+++ b/ci/runner-image/README.md
@@ -1,0 +1,76 @@
+# Ephemeral CI runner image
+
+Self-contained GitHub Actions runner for this repository's
+privileged integration workloads: one container = one job, each with
+its own nested Docker daemon. Design record: issue #149; the
+nested-daemon approach was validated end-to-end before this image
+existed (full integration suite green inside DinD — #145 carries the
+one harness fix that validation surfaced).
+
+Published as `ghcr.io/claymore666/dhcp-ci-runner` by the
+`runner-image` workflow on changes under `ci/runner-image/`.
+
+## Orchestrator contract
+
+```
+docker run --rm --privileged \
+  -e RUNNER_JIT_CONFIG=<encoded_jit_config> \
+  ghcr.io/claymore666/dhcp-ci-runner:latest
+```
+
+- **`--privileged` is required**: the nested daemon plus the
+  integration suite's netns/mount operations, CAP_NET_ADMIN, and
+  UDP/67 binding. The trust boundary is the host this runs on, not
+  the container — run it on an isolated machine.
+- **`--rm` is required**: `/var/lib/docker` is an anonymous volume
+  (the nested daemon needs a real filesystem to get overlay2 instead
+  of vfs); `--rm` reaps it. Nothing else should be mounted in.
+- **One container, one job.** JIT configs are single-use and the
+  runner exits after its job; the container's exit code is the
+  runner's. Relaunch with a fresh JIT config for the next job.
+- JIT configs come from
+  `POST /repos/<owner>/<repo>/actions/runners/generate-jitconfig`
+  (GitHub App credential with repo-scoped **Administration: write**).
+  Suggested fields: `name` unique per instance, `labels` matching the
+  workflows' `runs-on`, `runner_group_id: 1`.
+- **No inbound network, no LAN dependencies.** The runner long-polls
+  GitHub over outbound 443; the test DHCP traffic stays on virtual
+  interfaces inside the container. Outbound allowlist: `github.com`,
+  `api.github.com`, `*.actions.githubusercontent.com`,
+  `objects.githubusercontent.com`, `ghcr.io`,
+  `pkg-containers.githubusercontent.com`, `registry-1.docker.io`,
+  `auth.docker.io`, `production.cloudflare.docker.com`,
+  `proxy.golang.org`, `sum.golang.org`, `go.dev`, `dl.google.com`.
+
+## Self-test (no GitHub contact)
+
+```
+docker run --rm --privileged ghcr.io/claymore666/dhcp-ci-runner:latest selftest
+```
+
+Verifies: nested daemon comes up with overlay2, seed images load, and
+a SIGTERM'd dockerd is relaunched by the supervisor — the property the
+daemon-restart integration test depends on (`harness.RestartDockerDaemon`,
+#145). Run it after any change to this directory and on any new host.
+
+## What's baked in, and why
+
+| Piece | Why |
+|---|---|
+| Docker Engine ≥ 28 (docker-ce) | nested daemon runs the plugin under test; ≥ 28 unblocks engine-gated tests (#125) |
+| supervised dockerd (relaunch loop under tini) | daemon-restart recovery test must be able to bounce the daemon without killing the environment (#145) |
+| Go toolchain (go.mod's version) | test compilation on the runner, mirrors `install-go-runner.sh` |
+| dnsmasq, iproute2, iptables | integration fixtures (test-spawned DHCP server on veth pairs) |
+| Go module + compile caches | ephemeral containers start cold; baking turns minutes of per-job downloads/compiles into cache hits |
+| seed image tars (golang builder, alpine test image) | `docker load` at start beats pulling ~250 MB per job. The plugin's digest-pinned base still pulls (3.5 MB — `docker load` can't satisfy digest references) |
+
+## Known limits
+
+- The plugin build's `go mod download` inside its builder stage still
+  fetches modules from the network per job (the baked cache helps the
+  runner-side test compile, not the docker-build stage). Acceptable at
+  current module sizes; a host-side GOPROXY cache is the upgrade path
+  if it ever isn't.
+- Image rebuilds don't track `go.mod` bumps automatically — the
+  workflow triggers on `ci/runner-image/**` changes and manual
+  dispatch. A stale cache costs seconds, not correctness.

--- a/ci/runner-image/entrypoint.sh
+++ b/ci/runner-image/entrypoint.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Entrypoint for the ephemeral CI runner container. tini is PID 1;
+# this script brings up a SUPERVISED nested dockerd (the daemon-restart
+# integration test depends on the daemon being a restartable child —
+# see harness.RestartDockerDaemon and issue #145), seeds the image
+# store, then execs the Actions runner with its single-use JIT config.
+#
+# Modes:
+#   (default)   needs RUNNER_JIT_CONFIG; runs exactly one job and exits
+#   selftest    infra check without contacting GitHub: daemon up with
+#               a real storage driver, seeds loaded, one supervised
+#               daemon restart survives
+set -euo pipefail
+
+log() { echo "[entrypoint] $*" >&2; }
+
+# --- supervised dockerd ------------------------------------------------
+# Plain relaunch loop. dockerd must NOT be the container's main
+# process: the daemon-restart test SIGTERMs it and expects a fresh
+# daemon to appear while the environment stays up.
+supervise_dockerd() {
+    while :; do
+        dockerd >>/var/log/dockerd.log 2>&1 || true
+        log "dockerd exited; relaunching in 1s"
+        sleep 1
+    done
+}
+supervise_dockerd &
+
+wait_daemon() {
+    local deadline=$((SECONDS + 60))
+    until docker info >/dev/null 2>&1; do
+        if ((SECONDS >= deadline)); then
+            log "dockerd did not become ready within 60s; tail of its log:"
+            tail -20 /var/log/dockerd.log >&2 || true
+            return 1
+        fi
+        sleep 1
+    done
+}
+wait_daemon
+
+# --- seed images -------------------------------------------------------
+# Baked at image build (skopeo); loading locally beats pulling the
+# golang builder over the network on every ephemeral job.
+for tarball in /seed/*.tar; do
+    [ -e "$tarball" ] || break
+    docker load -qi "$tarball" || log "seed load failed for $tarball (continuing; job will pull)"
+done
+
+# --- selftest ----------------------------------------------------------
+if [[ "${1:-}" == "selftest" ]]; then
+    driver=$(docker info --format '{{.Driver}}')
+    [[ "$driver" == "overlay2" ]] || { log "FAIL: storage driver is $driver, want overlay2"; exit 1; }
+    docker image inspect golang:1.25-alpine >/dev/null || { log "FAIL: golang seed missing"; exit 1; }
+    docker image inspect alpine:3.20 >/dev/null || { log "FAIL: alpine seed missing"; exit 1; }
+
+    old_pid=$(cat /var/run/docker.pid)
+    log "selftest: SIGTERM dockerd (pid ${old_pid}), expecting supervised relaunch"
+    kill "$old_pid"
+    deadline=$((SECONDS + 45))
+    while :; do
+        new_pid=$(cat /var/run/docker.pid 2>/dev/null || true)
+        if [[ -n "$new_pid" && "$new_pid" != "$old_pid" ]] && docker info >/dev/null 2>&1; then
+            break
+        fi
+        ((SECONDS >= deadline)) && { log "FAIL: no relaunched daemon within 45s"; exit 1; }
+        sleep 1
+    done
+    docker image inspect golang:1.25-alpine >/dev/null || { log "FAIL: seed lost across restart"; exit 1; }
+    log "selftest OK: driver=overlay2, seeds present, supervised restart ${old_pid} -> ${new_pid}"
+    exit 0
+fi
+
+# --- run exactly one job -----------------------------------------------
+: "${RUNNER_JIT_CONFIG:?RUNNER_JIT_CONFIG is required (single-use encoded JIT config; see README)}"
+export RUNNER_ALLOW_RUNASROOT=1
+cd /opt/runner
+log "starting Actions runner (single job, then exit)"
+exec ./run.sh --jitconfig "${RUNNER_JIT_CONFIG}"


### PR DESCRIPTION
Refs #149 (kept open per release flow — batch-closed by the release PR).

## What

`ci/runner-image/` — the container image for ephemeral CI runners (one container = one job, dedicated nested Docker daemon each), plus `runner-image.yml` to build and publish it to `ghcr.io/claymore666/dhcp-ci-runner`.

Key properties, each tied to a verified requirement:

| Property | Driven by |
|---|---|
| docker-ce ≥ 28 as the nested daemon | engine-gated `interface_name` tests (#125); validated architecture (#145's DinD run) |
| tini + **supervised dockerd** (relaunch loop, never the main process) | `harness.RestartDockerDaemon`'s direct path (#145) — verified passing against exactly this supervision pattern |
| `VOLUME /var/lib/docker` | nested overlay2-on-overlayfs silently degrades to vfs; an anonymous volume gives a real filesystem (`--rm` reaps it) |
| baked Go module + compile caches, skopeo-fetched seed image tars | ephemeral cold-start cost: turns ~250 MB of per-job pulls and minutes of compiles into local loads/hits |
| `selftest` entrypoint mode | infra verification with zero GitHub contact: overlay2 confirmed, seeds present, one supervised daemon restart survives |

The orchestrator contract (`--rm --privileged`, `RUNNER_JIT_CONFIG`, JIT-config minting, outbound allowlist) is documented in `ci/runner-image/README.md` — consumers of the image get a veto on that interface before it goes live.

## Verified vs. untested — stated plainly

- **Verified:** full local `docker build` passes end-to-end (1.89 GB; agent v2.335.1, all layers including cache baking and the skopeo seed stage). The supervision pattern and the nested-daemon test fidelity were verified on real hardware in the #145 work (full suite green, daemon-restart test passing via the direct path).
- **Untested as of this PR:** the `selftest` entrypoint run and a live registration. The publish workflow makes selftest a **hard gate before push** (build → selftest → push), so the image cannot reach GHCR unexercised; the first `dev` push touching this directory runs it. A live JIT registration additionally needs the orchestrator credential and the runner host, which are intentionally not available here.
- The new workflow runs on GitHub-hosted runners only (plain build), touches nothing self-hosted, and is linted by this PR's `actionlint` check.