### PR TITLE
ci: runner-image selftest accepts containerd overlayfs driver

### DIFF
--- a/ci/runner-image/README.md
+++ b/ci/runner-image/README.md
@@ -48,7 +48,7 @@ docker run --rm --privileged \
 docker run --rm --privileged ghcr.io/claymore666/dhcp-ci-runner:latest selftest
 ```
 
-Verifies: nested daemon comes up with overlay2, seed images load, and
+Verifies: nested daemon comes up with a real overlay storage driver (overlay2 or containerd overlayfs — not the vfs fallback), seed images load, and
 a SIGTERM'd dockerd is relaunched by the supervisor — the property the
 daemon-restart integration test depends on (`harness.RestartDockerDaemon`,
 #145). Run it after any change to this directory and on any new host.

--- a/ci/runner-image/entrypoint.sh
+++ b/ci/runner-image/entrypoint.sh
@@ -50,8 +50,13 @@ done
 
 # --- selftest ----------------------------------------------------------
 if [[ "${1:-}" == "selftest" ]]; then
+    # Accept either real overlay driver: classic overlay2 or the
+    # containerd snapshotter (reported as "overlayfs", docker-ce 29's
+    # default on fresh installs). The check exists to catch the vfs
+    # fallback that hits when /var/lib/docker sits on overlayfs.
     driver=$(docker info --format '{{.Driver}}')
-    [[ "$driver" == "overlay2" ]] || { log "FAIL: storage driver is $driver, want overlay2"; exit 1; }
+    [[ "$driver" == "overlay2" || "$driver" == "overlayfs" ]] \
+        || { log "FAIL: storage driver is $driver, want overlay2/overlayfs (vfs = missing volume)"; exit 1; }
     docker image inspect golang:1.25-alpine >/dev/null || { log "FAIL: golang seed missing"; exit 1; }
     docker image inspect alpine:3.20 >/dev/null || { log "FAIL: alpine seed missing"; exit 1; }
 


### PR DESCRIPTION
Refs #149.

The first publish run's selftest gate failed (and correctly blocked the push): docker-ce 29 defaults fresh installs to the **containerd image store**, which reports `overlayfs` as the driver name instead of classic `overlay2`. Both are real overlay drivers — the check exists to catch the **vfs fallback** (missing /var/lib/docker volume). The selftest now accepts either name and still rejects vfs.

Verified: selftest passes with the fix on a host where the nested daemon picks classic `overlay2` — and the failing run is itself the evidence for the `overlayfs` side; both names observed in practice on different hosts. Publish re-runs on merge via the paths trigger.