### PR TITLE
Release v1.0.0: bump pins, documentation review, release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@
 > internal state, and incorporates several open upstream PRs. As of v0.7.0
 > every PR is gated on a live integration suite that drives real DHCP
 > exchanges through all three modes plus recovery, tombstone-stability,
-> and concurrency scenarios.
+> and concurrency scenarios; v1.0.0 adds dual-stack (DHCPv6) coverage
+> and a failure-injection suite (server loss, refused renewals, lease
+> expiry) asserting the degraded modes, plus a coverage ratchet and
+> supply-chain gates on every release.
 >
 > See [`docs/reference.md`](docs/reference.md) for the complete driver
 > reference (all options, settings, observability, troubleshooting),
@@ -27,7 +30,7 @@
 >
 > Install:
 > ```bash
-> docker plugin install ghcr.io/claymore666/docker-net-dhcp:v0.9.0
+> docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.0.0
 > ```
 >
 > All upstream usage below still applies — bridge mode is unchanged and
@@ -52,17 +55,17 @@ handy for home deployment.
 The plugin can be installed with the `docker plugin install` command:
 
 ```
-$ docker plugin install ghcr.io/claymore666/docker-net-dhcp:v0.9.0
-Plugin "ghcr.io/claymore666/docker-net-dhcp:v0.9.0" is requesting the following privileges:
+$ docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.0.0
+Plugin "ghcr.io/claymore666/docker-net-dhcp:v1.0.0" is requesting the following privileges:
  - network: [host]
  - host pid namespace: [true]
  - mount: [/var/run/docker.sock]
  - capabilities: [CAP_NET_ADMIN CAP_SYS_ADMIN]
 Do you grant the above permissions? [y/N] y
-v0.9.0: Pulling from ghcr.io/claymore666/docker-net-dhcp
+v1.0.0: Pulling from ghcr.io/claymore666/docker-net-dhcp
 Digest: sha256:<some hash>
 <some id>: Complete
-Installed plugin ghcr.io/claymore666/docker-net-dhcp:v0.9.0
+Installed plugin ghcr.io/claymore666/docker-net-dhcp:v1.0.0
 $
 ```
 
@@ -117,13 +120,13 @@ $ sudo dhcpcd my-bridge
 Once the bridge is ready, you can create the network:
 
 ```
-$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.9.0 --ipam-driver null -o bridge=my-bridge my-dhcp-net
+$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.0.0 --ipam-driver null -o bridge=my-bridge my-dhcp-net
 <some network id>
 $
 
 # With IPv6 enabled
 # Although `docker network create` has a `--ipv6` flag, it doesn't work with the null IPAM driver
-$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.9.0 --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
+$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.0.0 --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
 <some network id>
 $
 ```
@@ -184,7 +187,7 @@ services:
       - dhcp
 networks:
   dhcp:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v0.9.0
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.0.0
     driver_opts:
       bridge: my-bridge
       ipv6: 'true'
@@ -213,7 +216,7 @@ Note:
 ## Debugging
 
 To read the plugin's log, do `cat /var/lib/docker/plugins/*/rootfs/var/log/net-dhcp.log` (as `root`). You can also use
-`docker plugin set ghcr.io/claymore666/docker-net-dhcp:v0.9.0 LOG_LEVEL=trace` to increase log verbosity.
+`docker plugin set ghcr.io/claymore666/docker-net-dhcp:v1.0.0 LOG_LEVEL=trace` to increase log verbosity.
 
 `/Plugin.Health` exposes liveness and recovery counters as JSON on the plugin's UNIX socket — useful as a monitoring probe. See [`docs/parent-attached-modes.md`](docs/parent-attached-modes.md#health-endpoint) for the payload schema and a sample `curl` invocation.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,142 @@ vulnerable code path is reachable from the plugin process, so no
 action is required. Recorded here so future audits don't
 re-investigate. (Original report: third-pass code review, 2026-05-04.)
 
+## v1.0.0
+
+The 1.0 milestone: the fork's quality infrastructure is now mechanical
+(coverage ratchet, failure-injection suite, option-docs drift gate,
+dependency automation, supply-chain scanning), runtime failure
+behaviour is asserted rather than assumed, DHCPv6 gets its first test
+coverage — which immediately found and fixed real bugs — and the
+audit/observability surface grew. No breaking changes; bridge-mode
+defaults and all existing options are unchanged.
+
+### New features
+
+- **`audit_log=true` driver option (#109)** — append-only lease ledger
+  (`STATE_DIR/leases.jsonl`, one JSON object per line: timestamp, kind
+  `bound`/`renew`/`release`/`release_failed`, network, endpoint,
+  container, hostname, IP, MAC). Answers "which IP did this container
+  hold last Tuesday?" without DHCP-server-log archaeology. Rotated at
+  16 MB / 30 days, one rotated generation kept (≤ ~32 MB). Off by
+  default (privacy: container↔IP correlation on disk). Append failures
+  bump the new `ledger_write_failures` health counter and never affect
+  lease handling.
+- **`interface_name` support, plugin side (#125)** — the
+  `com.docker.network.endpoint.ifname` endpoint option (Compose
+  `services.*.networks.*.interface_name`, engine 28+) is validated and
+  honored: the plugin returns the requested name as `DstName` in its
+  Join response; kernel-invalid names fail the attach with a clear
+  error. **Engine limitation:** moby's remote-driver layer currently
+  discards both the option (in Join) and the returned name, so the
+  rename does not yet take effect for *plugin* drivers on any engine —
+  built-in drivers only. The plugin side activates automatically once
+  the upstream pass-through ships; acceptance tests are probe-gated
+  and self-activating.
+- **`naks_received` health counter (#128)** — a DHCPNAK was previously
+  a log line only; now it's an operator-visible counter. Climbing
+  alongside `lease_changed` means containers are being re-addressed
+  mid-life.
+
+### Fixes (all found by this release's new test coverage)
+
+- **`ipv6=true` was non-functional in v0.9.0** (#103): the
+  option-request flags added in v0.9.0 (`-O mtu` …) are a v4-only
+  vocabulary; udhcpc6 treats unknown option names as a hard startup
+  error, so every DHCPv6 exchange exited immediately. Option requests
+  are now family-specific.
+- **systemd-udevd MAC rewrites broke DHCP identity** (#103/#128): on
+  hosts with `MACAddressPolicy=persistent` (the Debian default), udev
+  replaced a freshly created macvlan child's randomly-assigned MAC
+  moments after creation — so the initial DHCP exchange ran from a
+  MAC the container never uses (MAC-keyed server reservations could
+  not match the first lease) and the DHCPv6 one-shot poisoned the
+  server's neighbor cache, blackholing the container's v6 client for
+  ~45 s. The plugin now pins the child's MAC at creation
+  (administratively-set MACs are exempt from the udev policy), as the
+  bridge path always did for its veths.
+- **A changed lease was never applied to the container link** (#128):
+  `renew()` updated counters, DNS/MTU, and routes, but not the
+  address itself. After a NAK re-acquisition or a server-side
+  renumbering, the container kept answering on the old (possibly
+  reassigned) address, and the default-route replacement failed with
+  "network is unreachable", black-holing the endpoint. v4 re-binds
+  now apply the new address (then routes); the v6 arm is deliberately
+  deferred to the IA unification (#152).
+- **Test-harness exec output demux** (#130): `docker exec` streams are
+  multiplexed; raw reads embedded frame headers in line-anchored
+  parsing and caused a ~11% golden-path flake.
+
+### DHCPv6 (#103)
+
+- First v6 coverage in the integration suite: dual-stack dnsmasq
+  fixtures (ULA prefixes, RA enabled), golden paths for macvlan and
+  bridge wiring, DNS6 propagation default-off, failure-only
+  wire-capture diagnostics (tcpdump + neighbor tables) that
+  root-caused the udev bug above.
+- Audit finding (premise correction): busybox udhcpc6's DUID is a
+  **DUID-LL derived from the interface MAC** — stable across
+  restarts, so v6 reservations stick wherever MACs are stable (which
+  the plugin guarantees via the new MAC pin + tombstones). No
+  STATE_DIR DUID store needed. New docs section covers the exact
+  create incantation, RA-delegated gateways, the ipvlan shared-DUID
+  caveat, and the no-static-v6 boundary.
+- **Known boundary:** the initial-lease and renewal clients negotiate
+  separate identity associations, so the v6 address Docker reports is
+  not yet the one being renewed. Documented in the DHCPv6 section;
+  unification tracked in #152 with three suite tests skipped-with-
+  reference until then.
+
+### Failure-injection test suite (#128)
+
+Three `TestFailure_*` scenarios against per-test ephemeral DHCP
+servers assert *intended* degraded-mode behaviour: server loss during
+renewal (address retained, Healthy, self-recovery on server return),
+lease refusal on renewal via server renumbering (unattended
+re-acquisition; stale-`docker inspect` as the documented #104
+divergence), and full lease expiry (deliberate retention, endpoint
+stays reachable). Split behind `make integration-test-failure` so
+main-suite feedback speed is unchanged. The udhcpc handler now
+validates v4 lease env (malformed input skips the event instead of
+failing mid-renewal), and every udhcpc lifecycle event's counter
+semantics are pinned in unit tests.
+
+### CI / process / supply chain (#127, #132, #144–#148)
+
+- actionlint + govulncheck (allowlisted findings carry justification
+  + review date) + weekly cron + Dependabot (grouped, weekly) +
+  CodeQL + OpenSSF Scorecard (published results, README badge) +
+  SECURITY.md with private-advisory reporting.
+- **Coverage ratchet**: per-package floors enforced on every release
+  PR; the baseline only moves up.
+- **verify-install**: every release run installs the just-published
+  plugin from GHCR on a clean runner and asserts it enables.
+- **Pre-release rc tags**: `vX.Y.Z-rcN` runs the full publish chain
+  without touching `:latest` — every release is preceded by a
+  zero-impact dry-run.
+- **Driver reference manual** (`docs/reference.md`) — every option,
+  setting, health field, and a troubleshooting table; CI fails if a
+  parsed option key is missing from it.
+- `integration` is a required PR check; the suite is
+  containerized-runner-ready (supervisor-agnostic daemon restart,
+  #145) with timeout budgets sized from slow-hardware measurements
+  (#146) plus the failure suite.
+- Release workflow `GITHUB_TOKEN` narrowed to job-scoped permissions.
+
+### Operator-visible compatibility notes
+
+- `/Plugin.Health` gains `naks_received` and `ledger_write_failures`
+  (neither affects `healthy`).
+- macvlan children now carry an administratively-set MAC (same value
+  the kernel assigned; pinned against udev rewrites). If you run
+  custom `.link` rules keyed on `addr_assign_type`, note the change.
+- v4 re-binds that change the lease now re-address the container link
+  (previously the link silently kept the stale address).
+- The shipped binary is built with the current Go 1.25.x toolchain,
+  curing four stdlib CVEs that affected the v0.9.0 build; two
+  moby-daemon-side advisories remain allowlisted with justification
+  (no fixed release exists) — see `.github/vuln-allowlist.txt`.
+
 ## v0.9.0
 
 DHCP-helper polish: option propagation, parent-attached parity,

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -309,7 +309,7 @@ exact create incantation (note: the Docker-level `--ipv6` flag does
 NOT work with the null IPAM driver and is not what you want):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.9.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.0.0 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 -o ipv6=true \
     lan-dhcp6
@@ -539,7 +539,7 @@ endpoint operation everything is back to disk-served.
 Override the location via the `STATE_DIR` env var on the plugin:
 
 ```bash
-docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v0.9.0 STATE_DIR=/some/other/path
+docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.0.0 STATE_DIR=/some/other/path
 ```
 
 ## Plugin env vars

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,7 +27,7 @@ The plugin publishes to two registries; GHCR is primary:
 for unattended):
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v0.9.0
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.0.0
 ```
 
 Privileges requested: `network: host`, host PID namespace, the Docker
@@ -37,7 +37,7 @@ DHCP on the host's L2 segments, querying the daemon).
 
 **Pin a version.** `:latest` exists and tracks the newest release, but
 networks remember the exact driver string they were created with — a
-network created against `:v0.9.0` needs that tag present to operate.
+network created against `:v1.0.0` needs that tag present to operate.
 Pinning makes upgrades a deliberate step instead of a pull-side
 surprise.
 
@@ -87,7 +87,7 @@ You bring an existing Linux bridge that is L2-connected to the LAN
 bridge setup itself):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.9.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.0.0 \
     --ipam-driver null \
     -o bridge=my-bridge \
     my-dhcp-net
@@ -99,7 +99,7 @@ No host changes — containers get per-container kernel-generated MACs
 as macvlan children of a host NIC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.9.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.0.0 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 \
     lan-dhcp
@@ -113,7 +113,7 @@ security, hostile vSwitches, some Wi-Fi APs). The DHCP server must
 key reservations on DHCP option 61 (client identifier), not MAC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v0.9.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.0.0 \
     --ipam-driver null \
     -o mode=ipvlan -o parent=eth0 \
     lan-dhcp
@@ -137,7 +137,7 @@ Passed as `-o key=value` on `docker network create`, or under
 | `bridge` | bridge | *(required)* | upstream | Existing Linux bridge to plug container veths into. |
 | `parent` | macvlan, ipvlan | *(required)* | v0.2.0 | Host NIC to attach children to (e.g. `eth0`, `ens18`). Must exist and be administratively `UP`. |
 | `gateway` | all | from DHCP | v0.3.0 | Override the IPv4 default gateway returned by the DHCP server — for split-horizon LANs where containers should egress via a different router (e.g. a VPN gateway). |
-| `ipv6` | all | `false` | upstream | Also run DHCPv6 (udhcpc6) alongside DHCPv4. |
+| `ipv6` | all | `false` | upstream; functional again in v1.0.0 | Also run stateful DHCPv6 (udhcpc6) alongside DHCPv4 — see the [DHCPv6 section](parent-attached-modes.md#dhcpv6-ipv6true) for semantics, DUID identity, and the current renewal boundary (#152). |
 | `lease_timeout` | all | `10s` | upstream | Budget for the up-front DHCP exchange at container creation. Raise on slow/relayed networks (`-o lease_timeout=60s`). |
 | `ignore_conflicts` | bridge | `false` | upstream | Skip the bridge-already-in-use check against other Docker networks. No-op in macvlan/ipvlan. |
 | `skip_routes` | all | `false` | upstream; all modes since v0.9.0 | Don't copy non-default static routes from the parent (bridge or NIC) into containers. v0.9.0 extended route-copying from bridge-only to all modes (#102); set `true` to restore the old macvlan/ipvlan no-copy behaviour. |
@@ -192,7 +192,7 @@ Set with `docker plugin set <plugin> NAME=value`; take effect after
 JSON liveness + counters on the plugin's UNIX socket:
 
 ```bash
-PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v0.9.0)
+PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.0.0)
 curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
     http://localhost/Plugin.Health | jq .
 ```
@@ -211,6 +211,7 @@ curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
 | `leases_renewed` | no | udhcpc `renew` events. |
 | `dhcp_timeouts` | no | udhcpc `leasefail` events (no OFFER / no ACK within budget). |
 | `lease_release_failures` | no | Teardown DHCPRELEASE didn't complete cleanly — the server may hold a phantom lease until natural expiry. A pattern points at upstream reachability problems mid-teardown. |
+| `naks_received` | no | (v1.0.0+) The server NAKed a renewal/rebind. udhcpc recovers by re-acquiring, so each NAK is typically followed by `leases_obtained` — and, if the address moved, `lease_changed` — bumps. Climbing alongside `lease_changed` means containers are being re-addressed mid-life. |
 | `ledger_write_failures` | no | Failed `audit_log` ledger appends — degrades forensics, not networking. Operators using `audit_log` alert on this. |
 
 ### Plugin log
@@ -261,7 +262,7 @@ Compose-managed alternative (network lifecycle tied to the project):
 ```yaml
 networks:
   lan:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v0.9.0
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.0.0
     driver_opts:
       mode: macvlan
       parent: eth0

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -33,40 +33,64 @@ here, so the unit-test cadence stays fast.
 ## What's covered
 
 See [#56](https://github.com/claymore666/docker-net-dhcp/issues/56)
-for the umbrella scope. Tests so far:
+for the original umbrella scope. 22 test files, run serially (see
+below). Grouped by what they prove:
 
-- `lifecycle_macvlan_test.go` — full create→run→inspect→leave→delete
-  in macvlan mode.
-- `lifecycle_bridge_test.go` — same, in bridge mode (uses the
-  bridge fixture: separate Linux bridge + second dnsmasq on
-  192.168.100/24).
-- `lifecycle_ipvlan_test.go` — same, in ipvlan-L2 mode. Active as
-  of v0.7.0 — earlier it was `t.Skip`'d on a veth-parent harness
-  bug (broadcast OFFER didn't reach the slave); resolved in
-  [#62](https://github.com/claymore666/docker-net-dhcp/issues/62)
-  by setting the BROADCAST flag in the udhcpc DISCOVER (`-B`) and
-  skipping the MAC-echo at Join time on ipvlan (the kernel rejects
-  MAC changes on slaves with `EOPNOTSUPP`).
-- `tombstone_restart_test.go` — `docker restart <ctr>` preserves
-  MAC + IP via the tombstone mechanism.
-- `concurrency_test.go` — N containers attached simultaneously each
-  get a distinct lease.
-- `errors_test.go`, `errors_netlink_test.go` — option-validation
-  rejections (invalid mode, missing parent, wrong-mode options,
-  IPAM not null) plus netlink-state ones (parent down, parent is
-  a bridge, malformed driver-opt ip).
-- `recovery_test.go` — `docker plugin disable -f` + `enable` while
-  a container is attached; asserts Plugin.Health.recovered_ok ≥ 1
-  and the container's IP/MAC survive the recycle.
-- `recovery_daemon_test.go` — full daemon restart mid-suite (via
-  `harness.RestartDockerDaemon`: `systemctl` on systemd hosts,
-  supervised-dockerd signal on containerized runners)
-  with a `--restart=always` container attached; asserts the daemon
-  comes back, the container restarts, and the IP/MAC are
-  preserved. Empirically the IP is preserved via the tombstone
-  path (graceful shutdown calls Leave) rather than recoverEndpoints
-  — the test logs both paths' counters but tests on the
-  user-visible invariant.
+**Golden paths (per mode)**
+- `lifecycle_macvlan_test.go`, `lifecycle_bridge_test.go`,
+  `lifecycle_ipvlan_test.go` — full create→run→inspect→leave→delete
+  in each attachment mode. ipvlan active since v0.7.0 (#62: `-B`
+  broadcast flag + no MAC-echo on ipvlan).
+- `ipv6_test.go` — dual-stack golden paths (macvlan + bridge) with
+  `ipv6=true`, DNS6 default-off, and failure-only wire diagnostics
+  (tcpdump + neighbor tables). Three deeper tests (v6 renewal,
+  DNS6 opt-in, DUID persistence across plugin restart) are
+  `t.Skip`'d pending the IA unification (#152).
+- `concurrency_test.go` — N simultaneous containers, distinct leases.
+
+**Lease lifecycle & identity**
+- `lease_renew_test.go` — the persistent client renews at T1 without
+  disturbing the address (2m fixture lease floor ⇒ ~70s waits).
+- `tombstone_restart_test.go` — `docker restart` preserves MAC + IP.
+- `static_ip_test.go` — `--ip` / `--driver-opt ip=` request hints.
+- `client_id_test.go` — option 61 stability + `client_id` override.
+- `vendor_class_test.go` — option 60 round-trip via dnsmasq
+  class-tagged gateway override (exact-match route parsing, #130).
+- `audit_log_test.go` — `audit_log=true` ledger lifecycle
+  (bound→release), default-off absence (#109).
+
+**Option propagation**
+- `dns_propagate_test.go`, `mtu_propagate_test.go` — opt-in writes,
+  default-off pairs.
+- `extra_options_test.go` — captured-but-not-applied options (NTP,
+  TFTP, bootfile, search list).
+- `interface_name_test.go` — plugin honors the ifname endpoint
+  option + invalid names rejected at attach; the engine-applied
+  rename tests are capability-probe-gated (engine support pending
+  upstream, #125).
+
+**Failure injection (#128, separate step: `make integration-test-failure`)**
+- `failure_test.go` — `TestFailure_*` against per-test ephemeral
+  DHCP servers (`harness/ephemeral.go`): server loss during renewal
+  (retention + self-recovery), lease refused on renewal via server
+  renumbering (unattended re-acquisition, stale-inspect as the
+  documented #104 divergence), full lease expiry (deliberate
+  retention, endpoint stays reachable).
+
+**Recovery & restart**
+- `recovery_test.go` — plugin disable/enable with a live container.
+- `recovery_daemon_test.go` — daemon restart (supervisor-agnostic:
+  systemctl on bare metal, direct dockerd supervision in
+  containerized runners, #145) with a `--restart=always` container.
+- `preflight_probe_test.go` — `validate_dhcp=true` probe accept/
+  reject + bridge-mode rejection.
+
+**Error surfaces**
+- `errors_test.go`, `errors_netlink_test.go` — create-time
+  validation (modes, options, IPAM) and netlink-state rejections.
+- `health_counters_test.go` — /Plugin.Health counter movement.
+- `static_routes_bridge_test.go`, `static_routes_macvlan_test.go` —
+  route copying + `skip_routes` opt-out.
 
 Tests run **serially** by design. None of the current cases call
 `t.Parallel()`, even though most would be safe — the recovery and
@@ -107,21 +131,25 @@ in. Re-running upgrades in place.
 ```
 [host netns]
 
+
   Macvlan/ipvlan path:
-    dh-itest-host  <─ veth ─>  dh-itest-dhcp  (192.168.99.1/24)
-          │                          │
-     parent= for                dnsmasq #1
-     plugin children            pool 192.168.99.10–99
+    dh-itest-host  <─ veth ─>  dh-itest-dhcp  (192.168.99.1/24 +
+          │                          │          fd00:6470:6863::1/64)
+     parent= for                dnsmasq #1 (dual-stack + RA)
+     plugin children            v4 pool .10–.99, v6 ::10–::99
 
   Bridge path:
-    dh-itest-br2  (192.168.100.1/24)
+    dh-itest-br2  (192.168.100.1/24 + fd00:6470:6864::1/64)
           │
-     bridge= for                dnsmasq #2 bound to br2
-     plugin endpoints           pool 192.168.100.10–99
-                                + iptables FORWARD ACCEPT
-                                  (br_netfilter would otherwise
-                                  drop bridged DHCP under docker's
-                                  default-DROP FORWARD policy)
+     bridge= for                dnsmasq #2 (dual-stack + RA)
+     plugin endpoints           + ip(6)tables FORWARD ACCEPT
+
+  Failure-injection path (per-test, created/destroyed by each
+  TestFailure_*):
+    dh-itest-ehost <─ veth ─>  dh-itest-edhcp (192.168.101.1/24;
+          │                          │          renumbered to
+     parent= for                ephemeral dnsmasq (authoritative)
+     the test's network         Stop/StartAgain/RestartOnSubnet
 ```
 
 A single shared `Fixture` (`test/integration/harness/fixture.go`,
@@ -151,8 +179,10 @@ answered first.
 A second workflow, `.github/workflows/coverage.yml`, runs the same
 suite against a `go build -cover -coverpkg=./...` instrumented
 plugin (tag `:golang-cover`) and reports per-package coverage plus
-an HTML report as a workflow artifact. Manual-only
-(`workflow_dispatch`) — coverage runs aren't a PR gate.
+an HTML report as a workflow artifact. Runs on demand
+(`workflow_dispatch`) and on every release PR into `main`, where the
+coverage ratchet (`scripts/coverage-ratchet.sh` against
+`.github/coverage-baseline.txt`) is a required gate.
 
 Locally:
 


### PR DESCRIPTION
Runbook steps 2–5: version-pin bumps (17 tag references; since-version facts untouched), the release documentation review (reference.md `naks_received` row + DHCPv6/#152 cross-link, integration README rebuilt — 9 of 22 test files were documented — with the failure-injection path in the architecture diagram, README suite blurb), and the `## v1.0.0` RELEASE_NOTES section.

Docs-only — no code. Drift check green locally.

After this merges: release PR `dev` → `main` with the `Closes` list for all ten milestone issues, coverage-ratchet gate, **v1.0.0-rc1 dry-run**, then the real tag (maintainer-approved 2026-06-12).