### PR TITLE
ci: v1.0.0 coverage-ratchet baseline reconciliation + auditIP nil-guard

### DIFF
--- a/.github/coverage-baseline.txt
+++ b/.github/coverage-baseline.txt
@@ -7,8 +7,26 @@
 #   - Never lower a floor without a recorded decision in the PR body.
 #
 # Seeded from the v0.9.0 published numbers (RELEASE_NOTES.md).
-github.com/devplayer0/docker-net-dhcp/pkg/util 87.7
-github.com/devplayer0/docker-net-dhcp/pkg/plugin 82.4
-github.com/devplayer0/docker-net-dhcp/pkg/udhcpc 81.3
+#
+# v1.0.0 recorded decision (release PR #154):
+#   - pkg/udhcpc 81.3 -> 85.5: RAISED, earned by the v6 client-args
+#     and BuildEvent table tests this cycle.
+#   - pkg/plugin 82.4 -> 77.5: LOWERED deliberately. v1.0.0 added a
+#     large amount of new defensive/error-path code to this package
+#     (renew() re-address failure arms, awaitLinkLocal timeout, the
+#     macvlan MAC pin error path, the v6 setupClient arm, ifname
+#     threading through Join/CreateEndpoint). The new *behaviors* are
+#     covered by the expanded integration + failure-injection suites;
+#     the residual gap is `if err != nil { log }` branches that need
+#     fault injection not feasible at integration level. Measured
+#     78.0; floor set at 77.5 for epsilon room. The intent is to
+#     ratchet this back up as error-path coverage is added, not to
+#     normalize the lower number.
+#   - pkg/util 87.7 -> 87.0: LOWERED for run-to-run integration
+#     variance only — no util code changed this cycle; measured 87.1,
+#     0.1 over the old epsilon. New floor leaves variance headroom.
+github.com/devplayer0/docker-net-dhcp/pkg/util 87.0
+github.com/devplayer0/docker-net-dhcp/pkg/plugin 77.5
+github.com/devplayer0/docker-net-dhcp/pkg/udhcpc 85.5
 github.com/devplayer0/docker-net-dhcp/cmd/net-dhcp 75.0
 github.com/devplayer0/docker-net-dhcp/cmd/udhcpc-handler 50.0

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -851,9 +851,12 @@ func (m *dhcpManager) Stop() error {
 }
 
 // auditIP renders a netlink address for a ledger entry, tolerating
-// the nil case (endpoint never completed a bind).
+// the nil case (endpoint never completed a bind). netlink.Addr
+// embeds *net.IPNet, so the IPNet pointer must be checked before
+// reaching the promoted IP field — otherwise an Addr with a nil
+// embedded IPNet panics on the guard itself.
 func auditIP(addr *netlink.Addr) string {
-	if addr == nil || addr.IP == nil {
+	if addr == nil || addr.IPNet == nil || addr.IP == nil {
 		return ""
 	}
 	return addr.IP.String()

--- a/pkg/plugin/ifname_helpers_test.go
+++ b/pkg/plugin/ifname_helpers_test.go
@@ -1,0 +1,65 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+// TestHintIfname covers the join-hint accessor that carries a custom
+// interface name from CreateEndpoint to Join (#125): present, absent,
+// and empty-Ifname hint all return the right string without panicking
+// on a missing key.
+func TestHintIfname(t *testing.T) {
+	p := &Plugin{joinHints: make(map[string]joinHint)}
+	p.storeJoinHint("ep-named", joinHint{Ifname: "lan0"})
+	p.storeJoinHint("ep-unnamed", joinHint{Gateway: "192.168.0.1"})
+
+	if got := p.hintIfname("ep-named"); got != "lan0" {
+		t.Errorf("hintIfname(ep-named) = %q, want %q", got, "lan0")
+	}
+	if got := p.hintIfname("ep-unnamed"); got != "" {
+		t.Errorf("hintIfname(ep-unnamed) = %q, want empty", got)
+	}
+	if got := p.hintIfname("ep-absent"); got != "" {
+		t.Errorf("hintIfname(absent) = %q, want empty", got)
+	}
+}
+
+// TestFingerprintIfname covers the restart-path fallback: when the
+// join hint has already been consumed, Join recovers the custom
+// interface name from the live-endpoint fingerprint (#125).
+func TestFingerprintIfname(t *testing.T) {
+	p := &Plugin{endpointFingerprints: make(map[string]endpointFingerprint)}
+	p.endpointFingerprints["ep-named"] = endpointFingerprint{MAC: "02:00:00:00:00:01", Ifname: "wan0"}
+	p.endpointFingerprints["ep-unnamed"] = endpointFingerprint{MAC: "02:00:00:00:00:02"}
+
+	if got := p.fingerprintIfname("ep-named"); got != "wan0" {
+		t.Errorf("fingerprintIfname(ep-named) = %q, want %q", got, "wan0")
+	}
+	if got := p.fingerprintIfname("ep-unnamed"); got != "" {
+		t.Errorf("fingerprintIfname(ep-unnamed) = %q, want empty", got)
+	}
+	if got := p.fingerprintIfname("ep-absent"); got != "" {
+		t.Errorf("fingerprintIfname(absent) = %q, want empty", got)
+	}
+}
+
+// TestAuditIP pins the bare-address helper the ledger uses for v4/v6
+// release entries (#109): nil addr and nil IP degrade to "" rather
+// than panicking, a real address renders bare.
+func TestAuditIP(t *testing.T) {
+	if got := auditIP(nil); got != "" {
+		t.Errorf("auditIP(nil) = %q, want empty", got)
+	}
+	if got := auditIP(&netlink.Addr{}); got != "" {
+		t.Errorf("auditIP(zero) = %q, want empty", got)
+	}
+	addr, err := netlink.ParseAddr("192.168.0.42/24")
+	if err != nil {
+		t.Fatalf("ParseAddr: %v", err)
+	}
+	if got := auditIP(addr); got != "192.168.0.42" {
+		t.Errorf("auditIP(192.168.0.42/24) = %q, want %q", got, "192.168.0.42")
+	}
+}


### PR DESCRIPTION
**Recorded decision for the v1.0.0 coverage ratchet** (release PR #154), per the runbook's "never lower a floor without a recorded decision" rule. Maintainer-approved 2026-06-13.

This release's merged (unit+integration) coverage: util 87.1, plugin **78.0**, udhcpc 85.8, cmd/net-dhcp 75.4, handler 50.0.

| package | old → new | why |
|---|---|---|
| `pkg/udhcpc` | 81.3 → **85.5** | RAISED — earned by the v6 client-args + BuildEvent tests this cycle |
| `pkg/plugin` | 82.4 → **77.5** | LOWERED deliberately (see below) |
| `pkg/util` | 87.7 → **87.0** | run-to-run integration variance only; no util code changed |

**Why pkg/plugin dropped (and why this isn't a quality regression):** v1.0.0 added a large amount of new *defensive/error-path* code to this package — `renew()` re-address failure arms, `awaitLinkLocal` timeout, the macvlan MAC-pin error path, the v6 `setupClient` arm, ifname threading through `Join`/`CreateEndpoint`. The new **behaviors** are covered by the expanded integration suite and the new failure-injection suite; the residual gap is `if err != nil { log }` branches that need fault injection not feasible at integration level. Floor set at 77.5 (measured 78.0) for epsilon room, **to be ratcheted back up as error-path coverage is added — not to normalize the lower number.** Overall testing posture is stronger this cycle (new failure-injection + v6 suites; udhcpc +4.5).

**Also in this PR:**
- Unit tests for the new pure helpers: `hintIfname`, `fingerprintIfname`, `auditIP`.
- **`auditIP` nil-guard fix** — those tests exposed a latent panic: `netlink.Addr` embeds `*net.IPNet`, so an `Addr` with a nil embedded `IPNet` panicked on the `addr.IP == nil` guard itself. Unreachable on current call sites (always `ParseAddr` results), but hardened.

Verified locally: ratchet self-test green; this release's numbers pass the new baseline with headroom; `go test -race ./pkg/plugin ./pkg/util` green; gofmt + staticcheck clean.