### PR TITLE
ci: make Docker Hub description sync non-fatal (release.yml)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,10 +170,20 @@ jobs:
       # Auth note: DOCKERHUB_TOKEN must be a Personal Access Token with
       # Read & Write scope on this repo (not just Read & Write image
       # push) — Docker Hub gates description-update behind admin scope.
-      # If this step 401s, regenerate the token; image-push tokens
+      # If this step 401s/403s, regenerate the token; image-push tokens
       # alone won't do.
+      #
+      # continue-on-error: the long description is auxiliary metadata —
+      # the published plugin (both registries) is what users pull, and
+      # the runbook already treats the whole Hub path as optional
+      # (GHCR alone still publishes). A description-sync auth failure
+      # (e.g. a rotated / under-scoped token) must NOT fail the release
+      # job or block verify-install; it surfaces as a red step to fix
+      # out-of-band and re-syncs on the next release once the token is
+      # restored. v1.0.0-rc1 caught exactly this: Hub 403 on PATCH.
       - name: Sync Docker Hub description from README
         if: env.HAS_HUB_CREDS == 'true'
+        continue-on-error: true
         uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
**v1.0.0-rc1's dry-run did its job** — caught a Docker Hub **403 on the description PATCH** before any real tag, with zero damage: both registries got `:v1.0.0-rc1`, `:latest` correctly untouched, no bare `v1.0.0`. Cause: the `DOCKERHUB_TOKEN` has lost / was rotated below the admin scope Hub requires for metadata updates (image push still works — both pushes succeeded). The failed step failed the release *job*, cascading to skip **verify-install** (the check that proves users can install what we shipped).

**Fix:** mark the description-sync step `continue-on-error: true`. The long description is auxiliary metadata; the runbook already treats the whole Hub path as optional (GHCR alone publishes). An auth failure now surfaces as a red *step* to fix out-of-band — without failing the release or blocking verify-install — and re-syncs on the next release once the token is restored.

**Follow-up (maintainer, non-blocking):** regenerate the Docker Hub PAT with "Read, Write & Delete" (admin) scope and update the `DOCKERHUB_TOKEN` repo secret to restore description sync.

Release-path change → exercised by **v1.0.0-rc2** before the real tag. actionlint clean. Workflow-file-only; cannot affect test/integration/coverage outcomes.