### PR TITLE
ci: cut integration + coverage over to the ephemeral dhcp-ci runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,14 @@
-# actionlint config (#127). The integration/coverage workflows run on a
-# self-hosted runner with a custom label; declare it so actionlint
-# doesn't flag `runs-on: [self-hosted, gpu1]` as an unknown runner.
+# actionlint config (#127). The integration/coverage workflows run on
+# self-hosted runners with custom labels; declare them so actionlint
+# doesn't flag `runs-on: [self-hosted, <label>]` as an unknown runner.
+#
+#   gpu1     — the original bare-metal runner. Kept declared through
+#              the dhcp-ci cutover's parallel-run/soak window so a
+#              revert stays lint-clean; drop it once gpu1 is retired.
+#   dhcp-ci  — the ephemeral container-in-container runners (image
+#              ghcr.io/claymore666/dhcp-ci-runner; names dhcp-ci-<n>,
+#              pooled 2-4 by the orchestrator). Current target.
 self-hosted-runner:
   labels:
     - gpu1
+    - dhcp-ci

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ name: Coverage
 # plugin build + flush + report); the per-PR production gate stays
 # `integration.yml`.
 #
-# Same self-hosted runner as integration.yml (gpu1), same security
+# Same ephemeral `dhcp-ci` runners as integration.yml, same security
 # posture (outside-collaborator approval required for forked PRs —
 # though only `workflow_dispatch` is wired here, so forks can't trigger
 # this at all).
@@ -26,19 +26,17 @@ on:
     branches:
       - main
 
-# Shared group with integration.yml — both mutate the same runner's
-# docker state. See the note there about GitHub's one-pending-run
-# replacement behaviour (#127).
-concurrency:
-  group: selfhosted-docker
-  cancel-in-progress: false
+# No concurrency group (intentional). Each dhcp-ci job runs in its own
+# ephemeral container with an isolated nested daemon, so coverage and
+# integration no longer contend for one bare-metal Docker state — they
+# run in parallel. See integration.yml for the full rationale.
 
 permissions:
   contents: read
 
 jobs:
   coverage:
-    runs-on: [self-hosted, gpu1]
+    runs-on: [self-hosted, dhcp-ci]
     # 35 = main + failure-injection suites against the instrumented
     # plugin (#128) + cover build + margin.
     timeout-minutes: 35

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,11 +1,17 @@
 name: Integration
 
 # Live integration tests against the plugin. Run on the self-hosted
-# `gpu1` runner because they need privileges (CAP_NET_ADMIN, mount/
-# netns ops, bind UDP/67) and a real DHCP server (dnsmasq) — neither
-# is feasible on free GitHub-hosted runners.
+# `dhcp-ci` runners because they need privileges (CAP_NET_ADMIN,
+# mount/netns ops, bind UDP/67) and a real DHCP server (dnsmasq) —
+# neither is feasible on free GitHub-hosted runners.
 #
-# SECURITY: this workflow runs as root on the maintainer's hardware.
+# The `dhcp-ci` runners are ephemeral: one container = one job, each
+# with its own nested Docker daemon (image ghcr.io/claymore666/
+# dhcp-ci-runner, Docker Engine >= 28). An orchestrator pools 2-4 of
+# them (names dhcp-ci-<n>), so jobs run in PARALLEL and in full
+# isolation — replacing the single serial bare-metal runner.
+#
+# SECURITY: this workflow runs as root inside the runner container.
 # Repo Settings → Actions → General → "Fork pull request workflows
 # from outside collaborators" is set to "Require approval for all
 # outside collaborators" so external PRs sit in pending until manually
@@ -20,23 +26,21 @@ on:
       - main
       - dev
 
-# Serialize against every other workflow that touches the self-hosted
-# runner's shared docker state (the :integration / :golang-cover plugin
-# refs and the dnsmasq fixture ports). Shared group with coverage.yml.
-# Note GitHub keeps at most one running + one pending run per group: a
-# third run replaces the pending one (it shows as cancelled — re-run it
-# if its PR still needs the check). cancel-in-progress stays false so a
-# running suite is never killed mid-test (#127).
-concurrency:
-  group: selfhosted-docker
-  cancel-in-progress: false
+# No concurrency group (intentional — do not re-add). The gpu1-era
+# `selfhosted-docker` group serialized jobs because they shared one
+# bare-metal Docker daemon (the :integration / :golang-cover plugin
+# refs, the dnsmasq fixture's fixed veth names + UDP/67). Each
+# `dhcp-ci` job now runs in its own ephemeral container with an
+# isolated nested daemon, so those collisions can't happen — parallel
+# jobs are safe, and serializing them would throw away the whole point
+# of the move.
 
 permissions:
   contents: read
 
 jobs:
   integration:
-    runs-on: [self-hosted, gpu1]
+    runs-on: [self-hosted, dhcp-ci]
     # 35 = main suite (~10 min here, 558s measured on runner-class
     # hardware, #146) + failure-injection suite (~10 min of mostly
     # deliberate DHCP-timing waits, #128) + plugin build + margin.
@@ -46,17 +50,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # The Go toolchain is pre-installed on the runner via
-      # test/integration/install-go-runner.sh (one-time operator
-      # action). Skipping actions/setup-go saves ~30s per run on
-      # this runner since the version in go.mod (1.25) doesn't ship
-      # in apt anyway. If go is missing, fail loudly so the runner
-      # operator sees the install step they need to run.
+      # The Go toolchain (go.mod's version) is baked into the dhcp-ci
+      # runner image, so actions/setup-go is skipped. Fail loudly if
+      # it's ever missing — that means the runner image drifted from
+      # go.mod and needs a rebuild (ci/runner-image/).
       - name: Verify Go toolchain
         run: |
           if ! command -v go >/dev/null; then
-            echo "go not in PATH on this runner."
-            echo "Run: sudo bash test/integration/install-go-runner.sh"
+            echo "go not in PATH — dhcp-ci runner image is stale vs go.mod; rebuild ci/runner-image/"
             exit 1
           fi
           go version

--- a/ci/runner-image/Dockerfile
+++ b/ci/runner-image/Dockerfile
@@ -32,10 +32,13 @@ ARG RUNNER_VERSION
 # Base tooling + Docker Engine from download.docker.com (Debian 13's
 # docker.io is 26.x; the nested daemon must be >= 28 — engine-gated
 # tests, #125). dnsmasq is the test fixture's DHCP server: binary
-# only, there is no init system in here to start it.
+# only, there is no init system in here to start it. iputils-ping:
+# the failure-injection suite's L2-reachability check shells out to
+# `ping` on the runner host (failure_test.go, TestFailure_LeaseExpiry);
+# the bare-metal runner had it, this slim base does not (#158).
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates curl git make jq procps tini xz-utils \
-        iproute2 iptables dnsmasq \
+        iproute2 iptables dnsmasq iputils-ping \
     && install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
     && printf 'Types: deb\nURIs: https://download.docker.com/linux/debian\nSuites: trixie\nComponents: stable\nSigned-By: /etc/apt/keyrings/docker.asc\n' \

--- a/ci/runner-image/README.md
+++ b/ci/runner-image/README.md
@@ -48,10 +48,12 @@ docker run --rm --privileged \
 docker run --rm --privileged ghcr.io/claymore666/dhcp-ci-runner:latest selftest
 ```
 
-Verifies: nested daemon comes up with a real overlay storage driver (overlay2 or containerd overlayfs — not the vfs fallback), seed images load, and
+Verifies: nested daemon comes up with a real overlay storage driver (overlay2 or containerd overlayfs — not the vfs fallback), seed images load,
 a SIGTERM'd dockerd is relaunched by the supervisor — the property the
 daemon-restart integration test depends on (`harness.RestartDockerDaemon`,
-#145). Run it after any change to this directory and on any new host.
+#145) — and the cgroup root is a clean `domain` with no member processes
+(the cgroup-nesting precondition, #158). Run it after any change to this
+directory and on any new host.
 
 ## What's baked in, and why
 
@@ -59,6 +61,7 @@ daemon-restart integration test depends on (`harness.RestartDockerDaemon`,
 |---|---|
 | Docker Engine ≥ 28 (docker-ce) | nested daemon runs the plugin under test; ≥ 28 unblocks engine-gated tests (#125) |
 | supervised dockerd (relaunch loop under tini) | daemon-restart recovery test must be able to bounce the daemon without killing the environment (#145) |
+| cgroup v2 nesting prep (entrypoint evacuates the root cgroup into an `init` leaf, then delegates controllers) | running dockerd bare leaves every process in the cgroup-namespace root; cgroup v2's no-internal-processes rule then forces the nested daemon's plugin/container cgroups to be *threaded*, and `cgroup.kill` (runc task teardown, docker-ce ≥ 29) is unsupported on threaded cgroups → `docker plugin disable/enable` fails with EOPNOTSUPP (#158). systemd / `docker:dind` do the same evacuation |
 | Go toolchain (go.mod's version) | test compilation on the runner, mirrors `install-go-runner.sh` |
 | dnsmasq, iproute2, iptables | integration fixtures (test-spawned DHCP server on veth pairs) |
 | Go module + compile caches | ephemeral containers start cold; baking turns minutes of per-job downloads/compiles into cache hits |

--- a/ci/runner-image/entrypoint.sh
+++ b/ci/runner-image/entrypoint.sh
@@ -104,6 +104,11 @@ if [[ "${1:-}" == "selftest" ]]; then
     docker image inspect golang:1.25-alpine >/dev/null || { log "FAIL: golang seed missing"; exit 1; }
     docker image inspect alpine:3.20 >/dev/null || { log "FAIL: alpine seed missing"; exit 1; }
 
+    # Host tooling the suites shell out to. The failure-injection suite's
+    # L2-reachability check runs `ping` on the runner itself (not in a
+    # container) — failure_test.go, TestFailure_LeaseExpiry (#158).
+    command -v ping >/dev/null || { log "FAIL: ping missing (failure-injection L2 check needs it on the runner)"; exit 1; }
+
     # cgroup-nesting guard (#158): prepare_cgroups must have evacuated the
     # namespace-root so the nested daemon makes *domain* (not threaded)
     # cgroups — the precondition for runc's cgroup.kill task teardown. An

--- a/ci/runner-image/entrypoint.sh
+++ b/ci/runner-image/entrypoint.sh
@@ -14,6 +14,50 @@ set -euo pipefail
 
 log() { echo "[entrypoint] $*" >&2; }
 
+# --- cgroup v2 nesting prep --------------------------------------------
+# We run dockerd bare (no systemd, no docker:dind entrypoint), so without
+# this every container process lands directly in the cgroup-namespace root.
+# cgroup v2's "no internal processes" rule then forbids that root from being
+# a clean domain parent, so the nested daemon is forced to create plugin /
+# container cgroups as *threaded*. runc (docker-ce >= 29) tears tasks down
+# with cgroup.kill, which the kernel rejects on threaded cgroups with
+# EOPNOTSUPP — breaking `docker plugin disable && enable` and any task whose
+# teardown needs a kill (issue #158, caught by
+# TestRecovery_PluginDisableEnable_PreservesEndpoint on the dhcp-ci runner).
+#
+# Fix, the same move systemd / docker:dind make: evacuate the root cgroup
+# into a leaf so it holds no processes, then delegate every controller to
+# child subtrees. The nested daemon's cgroups are then proper *domain*
+# cgroups and cgroup.kill works. Idempotent; cgroup v2 only.
+prepare_cgroups() {
+    [ "$(stat -fc %T /sys/fs/cgroup 2>/dev/null)" = "cgroup2fs" ] || return 0
+    mkdir -p /sys/fs/cgroup/init
+    # Move our own shell into the leaf FIRST: every command we fork below
+    # (cat, wc, dockerd...) then inherits the leaf instead of repopulating
+    # the root we are trying to empty.
+    echo $$ > /sys/fs/cgroup/init/cgroup.procs 2>/dev/null || true
+    # Sweep the remaining processes (tini, strays) out of the root. The
+    # proc list is a live kernel file, so snapshot it with $(cat) rather
+    # than streaming it, and repeat until the root is empty — a single
+    # pass can miss PIDs that move/fork mid-sweep. Root must be empty
+    # before delegation: a cgroup with member processes can't enable
+    # controllers for its children (cgroup v2 "no internal processes").
+    for _ in 1 2 3 4 5; do
+        moved=0
+        for pid in $(cat /sys/fs/cgroup/cgroup.procs 2>/dev/null); do
+            echo "$pid" > /sys/fs/cgroup/init/cgroup.procs 2>/dev/null || true
+            moved=1
+        done
+        [ "$moved" -eq 0 ] && break
+    done
+    # Delegate all available controllers down to child cgroups.
+    for c in $(cat /sys/fs/cgroup/cgroup.controllers); do
+        echo "+$c" > /sys/fs/cgroup/cgroup.subtree_control 2>/dev/null || true
+    done
+    log "cgroup prep: root type=$(cat /sys/fs/cgroup/cgroup.type), root procs=$(wc -l < /sys/fs/cgroup/cgroup.procs), subtree=[$(cat /sys/fs/cgroup/cgroup.subtree_control)]"
+}
+prepare_cgroups
+
 # --- supervised dockerd ------------------------------------------------
 # Plain relaunch loop. dockerd must NOT be the container's main
 # process: the daemon-restart test SIGTERMs it and expects a fresh
@@ -59,6 +103,19 @@ if [[ "${1:-}" == "selftest" ]]; then
         || { log "FAIL: storage driver is $driver, want overlay2/overlayfs (vfs = missing volume)"; exit 1; }
     docker image inspect golang:1.25-alpine >/dev/null || { log "FAIL: golang seed missing"; exit 1; }
     docker image inspect alpine:3.20 >/dev/null || { log "FAIL: alpine seed missing"; exit 1; }
+
+    # cgroup-nesting guard (#158): prepare_cgroups must have evacuated the
+    # namespace-root so the nested daemon makes *domain* (not threaded)
+    # cgroups — the precondition for runc's cgroup.kill task teardown. An
+    # unprepped root shows "domain threaded" with the container's processes
+    # still in it; that is exactly what made plugin disable/enable EOPNOTSUPP.
+    if [ "$(stat -fc %T /sys/fs/cgroup 2>/dev/null)" = "cgroup2fs" ]; then
+        root_type=$(cat /sys/fs/cgroup/cgroup.type 2>/dev/null || echo unknown)
+        root_procs=$(wc -l < /sys/fs/cgroup/cgroup.procs)
+        [ "$root_type" = "domain" ] && [ "$root_procs" -eq 0 ] \
+            || { log "FAIL: cgroup root type='$root_type' procs=$root_procs (want domain/0); prepare_cgroups did not take — plugin task teardown would EOPNOTSUPP (#158)"; exit 1; }
+        log "selftest: cgroup posture OK (root=domain, root procs=0)"
+    fi
 
     old_pid=$(cat /var/run/docker.pid)
     log "selftest: SIGTERM dockerd (pid ${old_pid}), expecting supervised relaunch"


### PR DESCRIPTION
Repo half of the runner migration: move CI off the single serial bare-metal **gpu1** runner onto the ephemeral container-in-container **dhcp-ci** runners (image `ghcr.io/claymore666/dhcp-ci-runner`, Docker Engine 29.x; orchestrator pools 2–4, names `dhcp-ci-<n>`). Handshake met — `dhcp-ci-1` / `dhcp-ci-2` are Idle.

## This PR *is* the controlled test
A separate no-op PR couldn't test dhcp-ci (dev's current workflow still targets gpu1, so it'd run on gpu1). This PR carries the workflow change, so **its own `integration` check runs on a `dhcp-ci` runner** — green here = the runners validated *and* the cutover ready in one shot.

## Changes
- `runs-on: [self-hosted, gpu1]` → `[self-hosted, dhcp-ci]` in `integration.yml` + `coverage.yml` (targets the *label*; `dhcp-ci-<n>` names don't affect matching).
- **Dropped `concurrency: selfhosted-docker`** from both, with a "do not re-add" note. It existed only because jobs shared gpu1's one Docker daemon (`:integration`/`:golang-cover` refs, the dnsmasq fixture's fixed veth names + UDP/67). Each dhcp-ci job now has its own isolated nested daemon — parallel runs are collision-free, and serializing them would defeat the move.
- `actionlint.yaml`: declare `dhcp-ci`; keep `gpu1` declared so a revert stays lint-clean until gpu1 is retired.
- Comment/banner refresh; Go-toolchain guard now points at "rebuild the runner image" instead of gpu1's install script.

## Verification
- Local: actionlint clean; actionlint self-test still catches the known-bad fixture.
- **This PR's `integration` check on `dhcp-ci`** is the live validation — the gate for merging.
- Pre-validated out-of-band: the published runner image passed selftest on real hardware, and a JIT ephemeral runner from it built + installed + enabled plugin v1.0.0 on engine 29.

## Caveat (flagged, not blocking)
`coverage.yml` only triggers on PRs into `main`, so its dhcp-ci change isn't exercised by this dev PR — it first runs on dhcp-ci at the **next release PR**. Same one-line nature as integration.yml's change; watch it there.

## After merge
Retire gpu1's runner role (deregister the agent; drop `gpu1` from `actionlint.yaml` in a follow-up). gpu1 the machine is untouched.

---

## Runner-image fixes folded in (#158)

The first `integration` run on `dhcp-ci` surfaced two slim-image gaps the bare-metal runner masked. Both fixed here in `ci/runner-image/`, image republished (`ghcr.io/claymore666/dhcp-ci-runner@sha256:544e8539…`), and validated by this PR's green run.

1. **`cgroup.kill` EOPNOTSUPP** — running `dockerd` bare left every process in the cgroup-namespace root; cgroup v2's no-internal-processes rule then forced the nested daemon's plugin cgroups to be *threaded*, and runc (docker-ce ≥ 29) can't `cgroup.kill` a threaded cgroup → `docker plugin disable/enable` failed → cascaded the suite. Reproduced off-VM (even with `--cgroupns=private`, ruling that out). Fix: the entrypoint now evacuates the root cgroup into an `init` leaf + delegates controllers before dockerd starts (what systemd / docker:dind do). Verified: unprepped 0/5 disable-enable cycles, prepped 5/5.
2. **`ping` missing** — `TestFailure_LeaseExpiry`'s L2-reachability check shells out to `ping` on the runner host; the Debian-slim image lacked `iputils-ping`. Added it.

`selftest` now guards both (clean `domain` cgroup root with 0 procs; `ping` on PATH), so the image build fails if either regresses.

Closes #158 (batch-closed on the v1.1.0 release PR per the milestone workflow, not on this dev merge).
