### PR TITLE
ci: scope runner-image workflow token to least privilege

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -13,9 +13,10 @@ on:
       - .github/workflows/runner-image.yml
   workflow_dispatch:
 
+# Top-level is read-only; the write scope GHCR push needs is granted
+# only on the build job below (least privilege — Scorecard #160).
 permissions:
   contents: read
-  packages: write
 
 env:
   IMAGE: ghcr.io/claymore666/dhcp-ci-runner
@@ -24,6 +25,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
Closes #160.

## What
`runner-image.yml` carried `packages: write` at the **top level**, which Scorecard's Token-Permissions check flags as an excessive token (score 0). Moved the write to the `build` job (the only thing that pushes to GHCR); the top-level block is now `contents: read`.

## Why this is the whole fix
Audited all seven workflows: `runner-image.yml` was the **only** one with a top-level write. `release.yml` and `scorecard.yml` already declare writes per-job; the rest are top-level `contents: read` / `read-all`. So this single change takes Token-Permissions to 10.

## Verification
- YAML parses; top-level `{contents: read}`, build job `{contents: read, packages: write}`.
- The build job still has the `packages: write` it needs for `docker push` to GHCR — functionally unchanged, just least-privilege.
- Confirmed at next Scorecard run (scheduled) — expect Token-Permissions 0 → 10.