### PR TITLE
ci: pin all CI dependencies by hash

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,19 @@ updates:
       actions:
         patterns:
           - "*"
+
+  # Keep the SHA-pinned base-image digests fresh (#159). One entry per
+  # Dockerfile directory: the plugin build at the root and the CI
+  # runner image under ci/runner-image.
+  - package-ecosystem: docker
+    directories:
+      - /
+      - /ci/runner-image
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: sunday
+    groups:
+      docker:
+        patterns:
+          - "*"

--- a/.github/workflows/apk-pin-check.yml
+++ b/.github/workflows/apk-pin-check.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Check apk pins
         run: bash scripts/check-apk-pins.sh

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,7 @@ jobs:
       COVER_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:golang-cover
       COVER_DIR: /var/lib/dh-cover
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       # Coverage uses `-coverpkg=./...` for the unit-test step, which
       # forces go test to recompile stdlib's internal/coverage runtime
@@ -55,7 +55,7 @@ jobs:
       # "go1.25.0"' error. setup-go gives us a known-clean toolchain
       # at the cost of ~30s — fine for a 12-minute workflow that
       # runs only on manual dispatch.
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.25'
 
@@ -186,7 +186,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-${{ github.run_id }}
           path: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,7 +48,7 @@ jobs:
     env:
       INTEGRATION_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:integration
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       # The Go toolchain (go.mod's version) is baked into the dhcp-ci
       # runner image, so actions/setup-go is skipped. Fail loudly if

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,19 +98,19 @@ jobs:
             echo "Pre-release tag: $TAG — :latest will not be moved"
           fi
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ steps.tag.outputs.tag }}
           # Full history so RELEASE_NOTES.md credits / "since vX" greps
           # behave the same as on a developer checkout.
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -119,7 +119,7 @@ jobs:
       - name: Log in to Docker Hub
         id: hub-login
         if: env.HAS_HUB_CREDS == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -184,7 +184,7 @@ jobs:
       - name: Sync Docker Hub description from README
         if: env.HAS_HUB_CREDS == 'true'
         continue-on-error: true
-        uses: peter-evans/dockerhub-description@v5
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       # Pin-by-resolution: always build with the current runner agent
       # release. Outdated agents refuse jobs after GitHub's grace

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.25'
           cache: true
@@ -68,13 +68,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.25'
           cache: true
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
       - name: Run staticcheck
         run: staticcheck ./...
 
@@ -88,8 +88,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.25'
           cache: true
@@ -108,16 +108,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       # Keep this toolchain in sync with the Dockerfile's golang base
       # image — stdlib findings are evaluated against the scan
       # toolchain, which should represent what ships in the plugin.
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.25'
           cache: true
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
       - name: Scan
         run: |
           govulncheck ./... > vulns.txt || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.25-alpine@sha256:8d95af53d0d58e1759ddb4028285d9b1239067e4fbf4f544618cad0f60fbc354 AS builder
 
 # COVER_FLAGS is empty for the production build and `-cover -coverpkg=./...`
 # for the instrumented build used by the coverage workflow. Keeping the

--- a/ci/runner-image/Dockerfile
+++ b/ci/runner-image/Dockerfile
@@ -12,7 +12,7 @@
 # The plugin's digest-pinned base (alpine:3.20.3@sha256:...) is NOT
 # seeded: `docker load` can't satisfy digest references, and at 3.5 MB
 # the per-job pull is noise. The golang builder is the one that hurts.
-FROM debian:trixie-slim AS seeder
+FROM debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e AS seeder
 RUN apt-get update && apt-get install -y --no-install-recommends skopeo ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 RUN mkdir /seed \
@@ -22,7 +22,7 @@ RUN mkdir /seed \
          docker-archive:/seed/alpine-testimage.tar:alpine:3.20
 
 # ---- runner image
-FROM debian:trixie-slim
+FROM debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e
 
 ARG GO_VERSION=1.25.9
 # Resolved by the build workflow from actions/runner's latest release;


### PR DESCRIPTION
Closes #159.

## What
Pins every floating CI dependency Scorecard flagged (Pinned-Dependencies was **2/10**):

| Kind | Change |
|---|---|
| GitHub Actions | `checkout@v5`, `setup-go@v6`, `login-action@v4`, `dockerhub-description@v5`, `upload-artifact@v4` → full commit SHA, version kept as trailing `# vX` comment |
| Base images | `golang:1.25-alpine` and `debian:trixie-slim` (×2) → multi-arch **index** digest (multi-arch builds preserved); `alpine` was already pinned |
| go tools | `staticcheck@latest`→`@v0.7.0`, `govulncheck@latest`→`@v1.3.0` (`actionlint` already version-pinned) |
| Dependabot | new `docker` ecosystem for `/` and `/ci/runner-image` so the digest pins refresh weekly |

`scorecard.yml` was already SHA-pinned (OpenSSF template, Dependabot-managed) — intentionally untouched. Supersedes the "SHA-pin actions" bullet of #143.

## Verified
- All workflows + `dependabot.yml` parse.
- Main `Dockerfile` **builds** against the pinned `golang` digest; `debian` digest resolves via imagetools.
- No `@vX` action refs or `@latest` go installs remain (`scorecard.yml` pins aside).

## Note
SHAs/digests resolved live today. Once merged, the next Scorecard run should report Pinned-Dependencies 2 → 10; Dependabot owns keeping them current thereafter.