### PR TITLE
tests: native fuzz targets for DHCP-response parsers (#162)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,6 +51,20 @@ jobs:
       - name: Test (with race detector)
         run: go test -race -count=1 ./...
 
+      # Native fuzzing over the untrusted DHCP-response parsers (#162):
+      # BuildEvent's env-var path (DHCP-server-controlled) and the
+      # handler-pipe JSON decoder. Time-boxed so regressions surface
+      # per-PR without a long-running job; the committed seed corpora
+      # also run unconditionally in the race step above. Scorecard's
+      # Fuzzing check is satisfied by the presence of these targets.
+      - name: Fuzz (short)
+        run: |
+          for target in FuzzBuildEvent FuzzEventUnmarshal; do
+            echo "::group::${target}"
+            go test ./pkg/udhcpc/ -run '^$' -fuzz "^${target}$" -fuzztime 20s
+            echo "::endgroup::"
+          done
+
       # The CI gate scripts are code too — their table-driven tests run
       # here so a broken ratchet/vuln gate fails like any unit test.
       - name: Gate script self-tests

--- a/pkg/udhcpc/fuzz_test.go
+++ b/pkg/udhcpc/fuzz_test.go
@@ -1,0 +1,101 @@
+package udhcpc
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+)
+
+// FuzzBuildEvent exercises the env-var parsing path that turns a
+// busybox udhcpc(6) handler invocation into a downstream Event.
+//
+// This is the project's primary untrusted-input surface: every field
+// here is data the *DHCP server* put on the wire (busybox just relays
+// it into env vars), so a malformed-input crash or a bad-but-emitted
+// lease is an attacker-influenced fault. The fuzzer drives the highest
+// -value fields — the v4 ip/mask, the v6 address, MTU, and the
+// space-separated list options — across the bound/renew/lifecycle
+// event types.
+//
+// Invariant under test (stronger than "doesn't panic"): when
+// BuildEvent says "emit this", any IP it put on the Event MUST be
+// parseable as CIDR. Emitting an unparseable IP string is the exact
+// #128 bug class — it blows up later inside netlink.ParseAddr on the
+// renewal path, far from the input that caused it.
+func FuzzBuildEvent(f *testing.F) {
+	// Seeds mirror the shapes the integration fixtures produce
+	// (192.168.99.0/24 macvlan, 192.168.100.0/24 bridge) plus the
+	// degenerate inputs the unit tests already pin: missing fields,
+	// the v6 branch, the lifecycle types, and known-malformed values.
+	// args: eventType, ip, mask, ipv6, mtu, dns, router, search
+	f.Add("bound", "192.168.99.16", "24", "", "1500", "192.168.99.1", "192.168.99.1", "corp.example")
+	f.Add("renew", "192.168.100.5", "24", "", "", "", "192.168.100.1", "")
+	f.Add("bound", "", "", "fe80::1", "1280", "2001:db8::53", "", "")
+	f.Add("deconfig", "", "", "", "", "", "", "")
+	f.Add("nak", "", "", "", "", "", "", "")
+	f.Add("leasefail", "", "", "", "", "", "", "")
+	f.Add("bogus-type", "", "", "", "", "", "", "")
+	f.Add("bound", "not-an-ip", "abc", "", "not-an-int", "", "", "")
+	f.Add("bound", "192.168.0.1", "255.255.255.0", "", "0", "", "", "") // dotted mask: ParseCIDR rejects → skip
+
+	f.Fuzz(func(t *testing.T, eventType, ip, mask, ipv6, mtu, dns, router, search string) {
+		env := fakeEnv(map[string]string{
+			"ip":     ip,
+			"mask":   mask,
+			"ipv6":   ipv6,
+			"mtu":    mtu,
+			"dns":    dns,
+			"dns6":   dns,
+			"router": router,
+			"domain": search,
+			"search": search,
+			"ntpsrv": dns,
+		})
+
+		event, emit := BuildEvent(eventType, env)
+		if !emit {
+			// A suppressed event carries no contract beyond "don't crash",
+			// which we already got here by not panicking.
+			return
+		}
+
+		// Emitted bound/renew events must never carry an IP string that
+		// downstream netlink parsing would reject (#128).
+		if event.Data.IP != "" {
+			if _, _, err := net.ParseCIDR(event.Data.IP); err != nil {
+				t.Fatalf("BuildEvent emitted unparseable IP %q (eventType=%q ip=%q mask=%q ipv6=%q)",
+					event.Data.IP, eventType, ip, mask, ipv6)
+			}
+		}
+
+		// A positive MTU is the only value BuildEvent should ever store;
+		// 0/negative/garbage must be dropped, not propagated.
+		if event.Data.MTU < 0 {
+			t.Fatalf("BuildEvent emitted negative MTU %d from mtu=%q", event.Data.MTU, mtu)
+		}
+	})
+}
+
+// FuzzEventUnmarshal exercises the other untrusted boundary: the
+// newline-delimited JSON the udhcpc-handler binary writes into the
+// event pipe, which DHCPClient.Start decodes one line at a time
+// (client.go: json.Unmarshal(scanner.Bytes(), &event)). The bytes
+// cross a process boundary, so the decoder must tolerate any input
+// without panicking — a malformed line should fail the Unmarshal, not
+// take down the persistent-client goroutine.
+func FuzzEventUnmarshal(f *testing.F) {
+	f.Add([]byte(`{"Type":"bound","Data":{"IP":"192.168.99.16/24","Gateway":"192.168.99.1","MTU":1500}}`))
+	f.Add([]byte(`{"Type":"deconfig"}`))
+	f.Add([]byte(`{"Type":"bound","Data":{"DNSServers":["192.168.99.53"],"SearchList":["corp.example"]}}`))
+	f.Add([]byte(``))
+	f.Add([]byte(`{`))
+	f.Add([]byte(`{"Type":123}`))
+	f.Add([]byte(`not json at all`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var event Event
+		// Contract is "never panic"; an error return is the expected,
+		// safe outcome for garbage input.
+		_ = json.Unmarshal(data, &event)
+	})
+}


### PR DESCRIPTION
Raises OpenSSF Scorecard **Fuzzing** 0 → 10 by adding Go native fuzz targets over the two genuinely untrusted-input boundaries in `pkg/udhcpc`, and wiring a time-boxed fuzz run into the `test` job.

## Targets

- **`FuzzBuildEvent`** — the env-var path that turns a busybox `udhcpc(6)` handler invocation into an `Event`. Every field here is DHCP-server-controlled, so this is the project's primary attack surface. Beyond not-panicking, it asserts the **#128 invariant**: an emitted event never carries an IP string that downstream `netlink` CIDR parsing would reject (the bug class that used to blow up deep on the renewal path).
- **`FuzzEventUnmarshal`** — the handler→client pipe JSON decoder (`client.go`: `json.Unmarshal(scanner.Bytes(), &event)`). A malformed line must fail the unmarshal, not take down the persistent-client goroutine.

## Why these two (and not routes / vendor-class)

The issue listed routes and vendor-class as candidates, but neither is an untrusted-parsing path: busybox installs classless static routes itself (the plugin reads them off the link), and `VendorClass` is operator-supplied driver-opt, not wire data. The two parsers above are where attacker-influenced bytes actually get decoded.

## CI wiring

- Seed corpora mirror the integration fixtures (`192.168.99.0/24`, `192.168.100.0/24`) plus the degenerate inputs the unit tests already pin. Seeds run unconditionally in the existing race step.
- New **Fuzz (short)** step runs 20s of live fuzzing per target so regressions surface per-PR without a long-running job.

## Local validation

Both targets ran clean to ~2.4M / ~6.4M executions with zero crashers; the IP-parseability invariant held across the explored space.

Refs #162