### PR TITLE
ci: CodeQL advanced setup for Go + actions (#170)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,8 +41,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Go does NOT support build-mode `none` (CodeQL 2.25.x), and
+          # `autobuild` runs `make`, whose default target builds the
+          # plugin rootfs via `docker export` and leaves root-owned files
+          # that break CodeQL's DB bundling (EACCES). `manual` lets us
+          # drive a plain `go build ./...` — no make, no docker export.
           - language: go
-            build-mode: none
+            build-mode: manual
           - language: actions
             build-mode: none
     steps:
@@ -50,11 +55,24 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+
+      # Manual build for Go: compile every package so CodeQL's tracer
+      # sees it, without invoking make/docker (which autobuild would).
+      - name: Build Go for CodeQL tracing
+        if: matrix.build-mode == 'manual'
+        run: go build ./...
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,62 @@
+name: CodeQL
+
+# Static security analysis of the Go source (the primary language — the
+# untrusted DHCP-response parsers live here) plus the workflow files.
+#
+# Advanced setup, deliberately, not GitHub's "default setup": default
+# setup's Go autobuild runs `make`, whose default target builds the
+# plugin rootfs via `docker export` and leaves root-owned files
+# (e.g. plugin/rootfs/var/run/chrony) that break CodeQL's database
+# bundling with EACCES. `build-mode: none` analyses the Go source
+# directly — no build, no docker export, and it covers all source
+# files rather than only what a partial autobuild compiled. It also
+# keeps the action SHA-pinned and the config in version control, matching
+# the rest of the workflows (#170).
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+  schedule:
+    # Weekly, so advisories that publish between commits still surface.
+    - cron: '29 7 * * 3'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      security-events: write   # upload SARIF to code scanning
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Closes the biggest scanning gap: **the primary language (Go) was unscanned by CodeQL.** Default setup ran only on `actions` + a phantom `python`, and could not analyze this repo's Go at all — its autobuild invokes `make`, whose default target builds the plugin rootfs via `docker export` and leaves root-owned files (`plugin/rootfs/var/run/chrony`) that break CodeQL database bundling with `EACCES` (reproduced — the Go analysis ran but the run failed at bundling).

## Approach
Advanced setup with **`build-mode: none`** — analyses the Go source directly (no build, no docker export), so it covers *all* source files instead of only what a partial autobuild compiled. Config is version-controlled and the action is SHA-pinned, matching the other workflows. **Default setup has been disabled** so the two don't conflict.

- Triggers: PR + push to `main`/`dev`, plus a weekly schedule.
- Languages: `go`, `actions`.

Once this is green on `dev`, `Analyze (go)` can be added to branch protection as a required check (tracked in #172).

Refs #170