### PR TITLE
ci: honor HTTP(S)_PROXY in the runner image for the plugin docker build

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -58,6 +58,18 @@ jobs:
       - name: Selftest
         run: docker run --rm --privileged "${IMAGE}:latest" selftest
 
+      # Proxy wiring (#181): a bogus proxy is never contacted — selftest
+      # does no network pulls — so this hermetically proves setup_proxy
+      # writes the docker CLI `proxies` config (the only consumer that
+      # doesn't inherit the proxy automatically) and keeps the fixture
+      # subnets in NO_PROXY.
+      - name: Selftest (proxy mode)
+        run: |
+          docker run --rm --privileged \
+            -e HTTPS_PROXY=http://proxy.invalid:3128 \
+            -e NO_PROXY=example.com \
+            "${IMAGE}:latest" selftest
+
       - name: Push
         run: |
           docker push "${IMAGE}:latest"

--- a/ci/runner-image/README.md
+++ b/ci/runner-image/README.md
@@ -33,9 +33,21 @@ docker run --rm --privileged \
   (GitHub App credential with repo-scoped **Administration: write**).
   Suggested fields: `name` unique per instance, `labels` matching the
   workflows' `runs-on`, `runner_group_id: 1`.
+- **Forced-egress proxy (optional).** On hosts that route outbound
+  traffic through an HTTP proxy, pass `-e HTTP_PROXY -e HTTPS_PROXY -e
+  NO_PROXY` (or just `-e HTTPS_PROXY=…`). The runner agent, job tooling
+  (`go`/`git`/`curl`), and the nested daemon's registry pulls inherit
+  the env directly; the entrypoint additionally writes a docker CLI
+  `proxies` config so RUN steps inside `docker build` (the plugin
+  builder's `go mod download`) honor it too — that one isn't automatic.
+  The fixture subnets (`192.168.99.0/24`, `192.168.100.0/24`) and
+  loopback are force-added to `NO_PROXY`. No proxy env → nothing is
+  written and behavior is unchanged. The proxy URL is never baked into
+  the image (issue #181).
 - **No inbound network, no LAN dependencies.** The runner long-polls
   GitHub over outbound 443; the test DHCP traffic stays on virtual
-  interfaces inside the container. Outbound allowlist: `github.com`,
+  interfaces inside the container. Outbound allowlist (direct, or via
+  the proxy above): `github.com`,
   `api.github.com`, `*.actions.githubusercontent.com`,
   `objects.githubusercontent.com`, `ghcr.io`,
   `pkg-containers.githubusercontent.com`, `registry-1.docker.io`,
@@ -71,9 +83,10 @@ directory and on any new host.
 
 - The plugin build's `go mod download` inside its builder stage still
   fetches modules from the network per job (the baked cache helps the
-  runner-side test compile, not the docker-build stage). Acceptable at
-  current module sizes; a host-side GOPROXY cache is the upgrade path
-  if it ever isn't.
+  runner-side test compile, not the docker-build stage). It honors the
+  proxy when one is injected (see the orchestrator contract above).
+  Acceptable at current module sizes; a host-side GOPROXY cache is the
+  upgrade path if it ever isn't.
 - Image rebuilds don't track `go.mod` bumps automatically — the
   workflow triggers on `ci/runner-image/**` changes and manual
   dispatch. A stale cache costs seconds, not correctness.

--- a/ci/runner-image/entrypoint.sh
+++ b/ci/runner-image/entrypoint.sh
@@ -58,6 +58,48 @@ prepare_cgroups() {
 }
 prepare_cgroups
 
+# --- proxy plumbing ----------------------------------------------------
+# The CI host forces outbound traffic through an HTTP proxy (squid). The
+# orchestrator injects HTTP(S)_PROXY/NO_PROXY via `docker run -e`. Three
+# consumers need it; only the third isn't automatic:
+#   1. the Actions runner + job tooling (go/git/curl) inherit our env.
+#   2. the nested dockerd inherits our env -> honors it for registry pulls.
+#   3. RUN steps inside `docker build` (the plugin builder's `go mod
+#      download`, repo-root Dockerfile) get a FRESH env -> the daemon's
+#      proxy is invisible to them. Docker only forwards proxy into builds
+#      when the CLI's config.json carries a `proxies` block. Materialize
+#      that here so `make plugin`'s build honors the proxy.
+# The proxy URL is never baked into the image: no proxy env -> nothing
+# written -> no behavior change on direct-egress hosts (issue #181).
+setup_proxy() {
+    local proxy="${HTTPS_PROXY:-${https_proxy:-${HTTP_PROXY:-${http_proxy:-}}}}"
+    [ -n "$proxy" ] || return 0
+    local http_p="${HTTP_PROXY:-${http_proxy:-$proxy}}"
+    local https_p="${HTTPS_PROXY:-${https_proxy:-$proxy}}"
+    # Loopback + the integration fixture subnets (dnsmasq on veth pairs)
+    # must always bypass the proxy; merge with any orchestrator-supplied
+    # NO_PROXY rather than clobbering it.
+    local fixed="localhost,127.0.0.1,::1,192.168.99.0/24,192.168.100.0/24"
+    local no_p="${NO_PROXY:-${no_proxy:-}}"
+    no_p="${no_p:+$no_p,}$fixed"
+    export HTTP_PROXY="$http_p" HTTPS_PROXY="$https_p" NO_PROXY="$no_p"
+    export http_proxy="$http_p" https_proxy="$https_p" no_proxy="$no_p"
+    mkdir -p /root/.docker
+    cat > /root/.docker/config.json <<EOF
+{
+  "proxies": {
+    "default": {
+      "httpProxy": "$http_p",
+      "httpsProxy": "$https_p",
+      "noProxy": "$no_p"
+    }
+  }
+}
+EOF
+    log "proxy: build + daemon honor httpsProxy=$https_p (NO_PROXY=$no_p)"
+}
+setup_proxy
+
 # --- supervised dockerd ------------------------------------------------
 # Plain relaunch loop. dockerd must NOT be the container's main
 # process: the daemon-restart test SIGTERMs it and expects a fresh
@@ -120,6 +162,21 @@ if [[ "${1:-}" == "selftest" ]]; then
         [ "$root_type" = "domain" ] && [ "$root_procs" -eq 0 ] \
             || { log "FAIL: cgroup root type='$root_type' procs=$root_procs (want domain/0); prepare_cgroups did not take — plugin task teardown would EOPNOTSUPP (#158)"; exit 1; }
         log "selftest: cgroup posture OK (root=domain, root procs=0)"
+    fi
+
+    # proxy wiring (#181): when selftest runs WITH a proxy env, prove
+    # setup_proxy materialized the docker CLI config that makes
+    # `docker build` honor it, and that the fixture subnets stay direct.
+    # Hermetic — selftest does no network pulls, so a bogus proxy is fine.
+    if [ -n "${HTTPS_PROXY:-}${HTTP_PROXY:-}${https_proxy:-}${http_proxy:-}" ]; then
+        cfg=/root/.docker/config.json
+        [ -f "$cfg" ] || { log "FAIL: proxy env set but $cfg not written (setup_proxy did not run)"; exit 1; }
+        grep -q '"httpsProxy"' "$cfg" || { log "FAIL: $cfg has no httpsProxy entry"; exit 1; }
+        case ",${NO_PROXY:-}," in
+            *,192.168.99.0/24,*) : ;;
+            *) log "FAIL: NO_PROXY ('${NO_PROXY:-}') missing fixture subnet 192.168.99.0/24"; exit 1 ;;
+        esac
+        log "selftest: proxy wiring OK ($cfg written, NO_PROXY keeps fixtures direct)"
     fi
 
     old_pid=$(cat /var/run/docker.pid)


### PR DESCRIPTION
Makes the ephemeral runner image consume an injected HTTP proxy correctly, ahead of the CI host's forced-egress lockdown. Refs #181.

## Why

Audited every outbound path in the runner container. When the orchestrator passes `-e HTTP_PROXY/HTTPS_PROXY/NO_PROXY`, most consumers honor it for free — but one doesn't:

| Egress source | Auto? | Why |
|---|---|---|
| Actions runner agent, job tooling (`go`/`git`/`curl`) | yes | inherit the container env |
| Nested `dockerd` registry pulls | yes | `dockerd` is a child of the entrypoint → inherits env. **No `daemon.json` proxies block needed.** |
| **`go mod download` inside the plugin `docker build`** (repo-root `Dockerfile`) | **no** | runs in a build container with a fresh env; Docker only forwards proxy into RUN steps when the CLI's `config.json` has a `proxies` block. |

That last row is the bulk of per-job egress (already flagged in the image README's "Known limits"). Once direct container :443 is dropped, the plugin build's module download fails — and neither env-export nor `daemon.json` fixes it.

## What changed

- **`entrypoint.sh`**: a `setup_proxy` step (before the dockerd fork) that, *only when a proxy env is present*, writes `/root/.docker/config.json` with a `proxies.default` block and force-adds loopback + the integration fixture subnets (`192.168.99.0/24`, `192.168.100.0/24`) to `NO_PROXY`. The proxy URL is never baked — it comes from the runtime env, so the published image stays generic. No proxy env → nothing written → zero behavior change on direct-egress hosts.
- **`selftest`**: asserts (guarded on `HTTPS_PROXY` being set) that the CLI config was written and `NO_PROXY` keeps the fixtures direct.
- **`runner-image.yml`**: a second `selftest` invocation with a bogus `-e HTTPS_PROXY=http://proxy.invalid:3128`. Hermetic — selftest does no network pulls, so the bogus proxy is never contacted; it exercises the wiring only.
- **README**: documents the proxy env in the orchestrator contract; corrects the go-mod "Known limits" line.

## Out of scope

- Orchestrator-side `docker run -e …` injection (host/ops config, lives outside this repo).
- The firewall step that drops direct :443 — evidence-gated: confirm pulls appear in the proxy access log during one real job first.

## Verification

- The proxy parameter-expansion and `NO_PROXY`-merge logic was unit-tested hermetically across four cases (no-proxy, https-only with http fallback, http+https+corp-NO_PROXY merge, and the missing-subnet rejection); generated `config.json` validated as well-formed JSON. `bash -n` clean.
- **Not yet run in-image:** the proxy-mode `selftest` is built and exercised by the **Runner image** workflow, which triggers on push to `dev` (post-merge) and `workflow_dispatch` — it is *not* a `pull_request` gate, and the `integration` check on this PR runs against the currently-published `:latest` image, not this branch's. So the in-container selftest lands when this merges to `dev`. I can do a local privileged image build + both selftests on the runner host before merge if you'd like belt-and-braces.
