### PR TITLE
ci: fix actionlint SC1003 break in release.yml; pin shellcheck

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,22 +342,25 @@ jobs:
             echo "Pre-release / dry-run build for \`${TAG}\`." > notes.md
           fi
           # Append cosign verification instructions for the signed manifest.
-          {
-            echo
-            echo "## Verifying the signed artifacts"
-            echo
-            echo "The \`checksums.txt\` manifest is signed keylessly with cosign (Sigstore); one signature covers every attached artifact. Verify the manifest, then check the artifacts against it:"
-            echo
-            echo '```sh'
-            echo 'cosign verify-blob \'
-            echo '  --certificate checksums.txt.pem \'
-            echo '  --signature checksums.txt.sig \'
-            echo "  --certificate-identity-regexp '^https://github.com/claymore666/docker-net-dhcp/.github/workflows/release.yml@' \\"
-            echo '  --certificate-oidc-issuer https://token.actions.githubusercontent.com \'
-            echo '  checksums.txt'
-            echo 'sha256sum -c checksums.txt'
-            echo '```'
-          } >> notes.md
+          # Heredoc (not a wall of single-quoted echos) so the literal
+          # backslash line-continuations don't trip shellcheck SC1003 in
+          # the actionlint gate (#183). Quoted 'EOF' -> emitted verbatim.
+          cat >> notes.md <<'EOF'
+
+          ## Verifying the signed artifacts
+
+          The `checksums.txt` manifest is signed keylessly with cosign (Sigstore); one signature covers every attached artifact. Verify the manifest, then check the artifacts against it:
+
+          ```sh
+          cosign verify-blob \
+            --certificate checksums.txt.pem \
+            --signature checksums.txt.sig \
+            --certificate-identity-regexp '^https://github.com/claymore666/docker-net-dhcp/.github/workflows/release.yml@' \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            checksums.txt
+          sha256sum -c checksums.txt
+          ```
+          EOF
 
       - name: Create or update the GitHub Release with signed artifacts
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -107,6 +107,19 @@ jobs:
         with:
           go-version: '1.25'
           cache: true
+      # actionlint shells out to shellcheck for `run:` blocks. The agent
+      # itself is pinned (above), but the runner-supplied shellcheck is
+      # not — a hosted-image bump silently changes what the gate reports
+      # and can redden unrelated PRs (#183). Pin it so the gate is
+      # deterministic; bump deliberately alongside actionlint.
+      - name: Install shellcheck (pinned)
+        env:
+          SHELLCHECK_VERSION: v0.10.0
+        run: |
+          curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+            | tar -xJ
+          sudo install -m 0755 "shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+          shellcheck --version
       - name: Install actionlint
         run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
       - name: Lint workflows


### PR DESCRIPTION
Fixes the `actionlint` gate, which is **red on `dev`** as of the #168 merge and inherited by every open PR. Refs #183.

## What was red, and why it didn't block

The "Assemble release notes" step in `release.yml` (added by #168) emits the cosign instructions as a wall of single-quoted `echo`s ending in a literal backslash:

```sh
echo 'cosign verify-blob \'
echo '  --certificate checksums.txt.pem \'
```

shellcheck flags each trailing `\` inside single quotes as **SC1003** ("want to escape a single quote?") — a false positive, but actionlint exits non-zero on any shellcheck finding. These lines have been flaggable since they were written; #168 still merged because **`actionlint` is not a required status check** on `dev` (only `test`, `staticcheck`, `integration` are), so a red actionlint never blocks the merge button. The failure simply surfaced on the post-merge `dev` push.

## Fix

1. **Heredoc rewrite** of the cosign block (`cat >> notes.md <<'EOF'`). Removes the SC1003 trigger and is more readable. `notes.md` output is **byte-identical** (verified by extracting the step's script from both versions and diffing the generated file — 589 bytes, identical). `release.yml` is release-path, so this is also exercised by the rc dry-run before the next tag.
2. **Pin shellcheck (v0.10.0)** in the `actionlint` job. actionlint is pinned (v1.7.7) but the runner-supplied shellcheck was not — pin it so a hosted-image bump can't silently change what the gate reports. Same reasoning as the actionlint pin (#127).

## Verification (local, with the pinned tool versions)

- Old `release.yml` reproduces SC1003 under shellcheck 0.10.0 — diagnosis confirmed.
- Rewritten `release.yml` lints clean; whole-repo `actionlint -color` clean.
- Generated `notes.md` byte-identical (old vs. new).
- `scripts/test-actionlint.sh actionlint` still passes (the linter still catches its known-bad fixture).

## Follow-up (not in this PR)

`actionlint` (and `govulncheck`) aren't in `dev`'s required checks, so lint regressions can merge unnoticed — which is exactly how this one landed. Recommend adding `actionlint` to the required set; happy to do it as a separate step.
