### PR TITLE
ci: bump actionlint v1.7.7 → v1.7.12 (part of #177)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,7 +121,7 @@ jobs:
           sudo install -m 0755 "shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
           shellcheck --version
       - name: Install actionlint
-        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
       - name: Lint workflows
         run: actionlint -color
       - name: Verify actionlint catches known-bad patterns


### PR DESCRIPTION
The safe, self-contained half of #177. Bumps the pinned actionlint install in `test.yaml`.

Validated locally: v1.7.12 lints every workflow clean, and `scripts/test-actionlint.sh` still passes — it asserts the linter catches the known-bad fixture (incl. the v0.8.0 secrets-in-step-`if` trap), so the gate keeps its teeth.

The **Go 1.26 half of #177 is intentionally not here** — see the note on #177: it is coupled to the runner image (which bakes Go from `go.mod`) and needs sequencing. `staticcheck`/`govulncheck`/`scorecard-action`/`upload-artifact` are already at latest.

Refs #177