### PR TITLE
ci(runner-image): bump baked Go 1.25.9 → 1.26.4 (#177 step 1 of 2)

### DIFF
--- a/ci/runner-image/Dockerfile
+++ b/ci/runner-image/Dockerfile
@@ -16,15 +16,15 @@ FROM debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a
 RUN apt-get update && apt-get install -y --no-install-recommends skopeo ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 RUN mkdir /seed \
-    && skopeo copy docker://docker.io/library/golang:1.25-alpine \
-         docker-archive:/seed/golang-builder.tar:golang:1.25-alpine \
+    && skopeo copy docker://docker.io/library/golang:1.26-alpine \
+         docker-archive:/seed/golang-builder.tar:golang:1.26-alpine \
     && skopeo copy docker://docker.io/library/alpine:3.20 \
          docker-archive:/seed/alpine-testimage.tar:alpine:3.20
 
 # ---- runner image
 FROM debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e
 
-ARG GO_VERSION=1.25.9
+ARG GO_VERSION=1.26.4
 # Resolved by the build workflow from actions/runner's latest release;
 # no default on purpose so a stale pin can't hide in this file.
 ARG RUNNER_VERSION


### PR DESCRIPTION
**Step 1 of the Go 1.26 bump** (#177). Deliberately split: the `dhcp-ci` runner image bakes the Go toolchain (integration skips `setup-go`) and seeds the golang base for the nested plugin build, so the **pool must be on Go 1.26 before `go.mod` is bumped** — otherwise the `go.mod` PR runs its own integration on a 1.25 pool (per-job toolchain download or failure).

## This PR
- `ARG GO_VERSION` 1.25.9 → 1.26.4 (the runner's own Go for `go build`/`go test`)
- seeded `golang:1.25-alpine` → `golang:1.26-alpine` (nested plugin build)

It does **not** touch `go.mod`, so its own `integration` check still builds on the current 1.25 pool and should pass.

## Coordinated rollout (after merge)
1. Merge → `runner-image.yml` rebuilds + **selftests** + republishes `:latest` with Go 1.26 (off-pool, hosted).
2. **Orchestrator pulls** the new `:latest` (root-admin component) → pool runners come up on Go 1.26.
3. **Verify** a job runs green on the 1.26 pool.
4. **Then** open step 2 (the `go.mod` + workflow `go-version` + main `Dockerfile` golang:1.26 bump), whose integration now runs on the upgraded pool.

Do this on a **quiet pool** — it swaps the production CI substrate (rolling, selftest-gated, not a hard outage, but coordinate the orchestrator pull).

Refs #177