### PR TITLE
ci(runner-image): selftest checks golang:1.26 seed (#177 step 1 fix)

### DIFF
--- a/ci/runner-image/entrypoint.sh
+++ b/ci/runner-image/entrypoint.sh
@@ -143,7 +143,7 @@ if [[ "${1:-}" == "selftest" ]]; then
     driver=$(docker info --format '{{.Driver}}')
     [[ "$driver" == "overlay2" || "$driver" == "overlayfs" ]] \
         || { log "FAIL: storage driver is $driver, want overlay2/overlayfs (vfs = missing volume)"; exit 1; }
-    docker image inspect golang:1.25-alpine >/dev/null || { log "FAIL: golang seed missing"; exit 1; }
+    docker image inspect golang:1.26-alpine >/dev/null || { log "FAIL: golang seed missing"; exit 1; }
     docker image inspect alpine:3.20 >/dev/null || { log "FAIL: alpine seed missing"; exit 1; }
 
     # Host tooling the suites shell out to. The failure-injection suite's
@@ -191,7 +191,7 @@ if [[ "${1:-}" == "selftest" ]]; then
         ((SECONDS >= deadline)) && { log "FAIL: no relaunched daemon within 45s"; exit 1; }
         sleep 1
     done
-    docker image inspect golang:1.25-alpine >/dev/null || { log "FAIL: seed lost across restart"; exit 1; }
+    docker image inspect golang:1.26-alpine >/dev/null || { log "FAIL: seed lost across restart"; exit 1; }
     log "selftest OK: driver=overlay2, seeds present, supervised restart ${old_pid} -> ${new_pid}"
     exit 0
 fi


### PR DESCRIPTION
Follow-up to #187. The Go-1.26 runner image failed its **own selftest** and so did not publish:

```
Loaded image: golang:1.26-alpine
Error response from daemon: No such image: golang:1.25-alpine
[entrypoint] FAIL: golang seed missing
```

#187 bumped the seeded golang base to 1.26 in the Dockerfile, but `entrypoint.sh` still asserted `golang:1.25-alpine` in two selftest checks (post-load + post-restart). Pointed both at `golang:1.26-alpine`.

The selftest gate did its job — the mismatched image never reached `:latest`, so the pool was never at risk. After this merges, `runner-image.yml` re-runs and should publish the Go-1.26 image cleanly.

Refs #177