### PR TITLE
build: Go 1.25.9 → 1.26.4 (#177 step 2 of 2)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -57,7 +57,7 @@ jobs:
       # runs only on manual dispatch.
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Cleanup orphans from previous runs
         run: bash test/integration/cleanup-orphans.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       # Drifted go.mod/go.sum slips through silently until someone
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
       - name: Install staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
       # actionlint shells out to shellcheck for `run:` blocks. The agent
       # itself is pinned (above), but the runner-supplied shellcheck is
@@ -141,7 +141,7 @@ jobs:
       # toolchain, which should represent what ships in the plugin.
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine@sha256:8d95af53d0d58e1759ddb4028285d9b1239067e4fbf4f544618cad0f60fbc354 AS builder
+FROM golang:1.26-alpine@sha256:7a3e50096189ad57c9f9f865e7e4aa8585ed1585248513dc5cda498e2f41812c AS builder
 
 # COVER_FLAGS is empty for the production build and `-cover -coverpkg=./...`
 # for the instrumented build used by the coverage workflow. Keeping the

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devplayer0/docker-net-dhcp
 
-go 1.25.9
+go 1.26.4
 
 require (
 	github.com/docker/docker v28.5.2+incompatible


### PR DESCRIPTION
Step 2 — the source side of the Go 1.26 bump (#177). The runner pool is already on Go 1.26 (runner image from #187/#188, orchestrator pulled), so this PR's `integration` runs on the upgraded pool.

## Changes
- `go.mod`: `go 1.26.4`
- `test.yaml` + `coverage.yml`: `go-version` 1.25 → 1.26 (5 pins)
- main `Dockerfile` builder: `golang:1.26-alpine@sha256:7a3e50…` (digest)
- `release.yml` / `codeql.yml` use `go-version-file: go.mod` → follow automatically.

## Validation (local, on the real go1.26.4 toolchain)
`go mod tidy -diff` clean · `go build ./...` · `go vet` · `go test -race ./...` · **`staticcheck@v0.7.0` clean (supports 1.26 — no bump needed)**.

The `integration` run here doubles as the pool verification: its **Verify Go toolchain** step will print the baked `go version` — I will confirm it reports `go1.26.4` before merging (a `GOTOOLCHAIN` auto-download cannot mask this, since `go version` reports the binary in PATH).

Refs #177