### PR TITLE
ci: fix check-apk-pins.sh trailing-colon false positive + self-test (#169)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,6 +72,7 @@ jobs:
           bash scripts/test-coverage-ratchet.sh
           bash scripts/test-govulncheck-gate.sh
           bash scripts/test-check-option-docs.sh
+          bash scripts/test-check-apk-pins.sh
 
       # Every driver-option key the code parses must be documented in
       # docs/reference.md — an undocumented option turns CI red (#132).

--- a/scripts/check-apk-pins.sh
+++ b/scripts/check-apk-pins.sh
@@ -53,17 +53,30 @@ echo
 # Run apk inside the alpine image once and ask for each pinned pkg.
 # `apk policy` lists installed/available versions; we grep for the head
 # of the indexed candidate. Cleaner than parsing the apk index by hand.
-LATEST=$(docker run --rm "$ALPINE_REF" sh -c '
-    apk update -q >/dev/null
-    for p in "$@"; do
-        name="${p%%=*}"
-        printf "%s\t" "$name"
-        apk policy "$name" 2>/dev/null | awk "/^[[:space:]]+[0-9]/ {print \$1; exit}"
-    done
-' -- "${PINS[@]}")
+#
+# Test seam (#169): when APK_AVAIL_FILE is set, read pre-canned
+# `name<TAB>version` lines from it instead of querying the registry, so
+# the parse/compare logic is exercisable by scripts/test-check-apk-pins.sh
+# without docker or network.
+if [[ -n "${APK_AVAIL_FILE:-}" ]]; then
+    LATEST=$(cat "$APK_AVAIL_FILE")
+else
+    LATEST=$(docker run --rm "$ALPINE_REF" sh -c '
+        apk update -q >/dev/null
+        for p in "$@"; do
+            name="${p%%=*}"
+            printf "%s\t" "$name"
+            apk policy "$name" 2>/dev/null | awk "/^[[:space:]]+[0-9]/ {print \$1; exit}"
+        done
+    ' -- "${PINS[@]}")
+fi
 
 drift=0
 while IFS=$'\t' read -r name avail; do
+    # `apk policy` prints the candidate version with a trailing colon
+    # (e.g. `1.36.1-r31:`); strip it so a current pin compares equal
+    # instead of being falsely flagged as drifted (#169).
+    avail="${avail%:}"
     pinned=""
     for p in "${PINS[@]}"; do
         if [[ "${p%%=*}" == "$name" ]]; then pinned="${p#*=}"; fi

--- a/scripts/test-check-apk-pins.sh
+++ b/scripts/test-check-apk-pins.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Table-driven tests for check-apk-pins.sh (#169). Uses the APK_AVAIL_FILE
+# seam to feed synthetic `apk policy` output (no docker/network), against a
+# synthetic Dockerfile, and asserts the drift verdict. The first case is
+# the regression guard: `apk policy` emits versions with a trailing colon
+# (`1.36.1-r31:`), which the checker must strip so a current pin is NOT
+# falsely reported as an upgrade candidate.
+set -u
+
+CHECK="$(dirname "$0")/check-apk-pins.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Synthetic Dockerfile the checker parses pins + alpine ref from.
+DF="$TMP/Dockerfile"
+cat > "$DF" <<'EOF'
+FROM golang:1.26-alpine AS builder
+FROM alpine:3.20
+RUN apk add --no-cache \
+        busybox-extras=1.36.1-r31 \
+        iproute2=6.9.0-r0
+EOF
+
+failures=0
+# check NAME WANT_EXIT STRICT AVAIL_CONTENT GREP_PATTERN
+check() {
+    local name="$1" want_exit="$2" strict="$3" avail="$4" want_grep="$5"
+    printf '%s' "$avail" > "$TMP/avail.txt"
+    DOCKERFILE="$DF" APK_AVAIL_FILE="$TMP/avail.txt" \
+        bash "$CHECK" $strict > "$TMP/out" 2>&1
+    local got_exit=$?
+    local ok=1
+    [ "$got_exit" -eq "$want_exit" ] || ok=0
+    if [ -n "$want_grep" ] && ! grep -q "$want_grep" "$TMP/out"; then ok=0; fi
+    if [ "$ok" -eq 1 ]; then
+        echo "PASS: $name"
+    else
+        echo "FAIL: $name (want exit $want_exit/grep '$want_grep', got exit $got_exit)"
+        sed 's/^/    /' "$TMP/out"
+        failures=$((failures + 1))
+    fi
+}
+
+# Regression guard: trailing-colon versions equal to the pins => no drift.
+check "current pins (trailing colon) report OK, exit 0" 0 "--strict" \
+$'busybox-extras\t1.36.1-r31:\niproute2\t6.9.0-r0:\n' \
+"All apk pins current."
+
+# A genuinely newer available version => drift, --strict exits 1.
+check "behind pin flagged, --strict exits 1" 1 "--strict" \
+$'busybox-extras\t1.36.1-r32:\niproute2\t6.9.0-r0:\n' \
+"upgrade candidate"
+
+# Same drift without --strict is report-only (exit 0).
+check "behind pin is report-only without --strict" 0 "" \
+$'busybox-extras\t1.36.1-r32:\niproute2\t6.9.0-r0:\n' \
+"upgrade candidate"
+
+# Empty available (pkg not in index / bad pin) => drift.
+check "missing-from-index flagged, --strict exits 1" 1 "--strict" \
+$'busybox-extras\t\niproute2\t6.9.0-r0:\n' \
+"not found in index"
+
+# No FROM alpine: => usage error (exit 2).
+cat > "$TMP/Dockerfile.noalpine" <<'EOF'
+FROM golang:1.26-alpine AS builder
+RUN echo nope
+EOF
+DOCKERFILE="$TMP/Dockerfile.noalpine" APK_AVAIL_FILE="$TMP/avail.txt" \
+    bash "$CHECK" >/dev/null 2>&1
+if [ $? -eq 2 ]; then echo "PASS: missing FROM alpine: exits 2"; else
+    echo "FAIL: missing FROM alpine: should exit 2"; failures=$((failures + 1)); fi
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures apk-pin-check test(s) failed"
+    exit 1
+fi
+echo "All check-apk-pins tests passed"


### PR DESCRIPTION
Fixes the **APK pin drift** checker reporting current pins as drifted.

`apk policy` prints the candidate version with a trailing colon (`1.36.1-r31:`), which the checker compared verbatim against the pin (`1.36.1-r31`) — so every run with current pins falsely flagged an "upgrade candidate" (and a `--strict` consumer would always exit 1). Strip the trailing colon before comparing.

Adds **`scripts/test-check-apk-pins.sh`** (table-driven, via a new `APK_AVAIL_FILE` seam so the parse/compare logic runs without docker/network) and wires it into the gate self-tests. `check-apk-pins.sh` was the only gate script without a self-test — the gap that let this ship. The regression case **fails on the unfixed script and passes on the fix** (verified locally).

Refs #169