### PR TITLE
docs: v1.1.0 release prep (version bumps, verification docs, release notes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 > **This is a maintained fork** of [`devplayer0/docker-net-dhcp`][upstream].
 > The upstream repository has been quiet since 2021 and no longer builds on
-> current Docker. This fork modernises the toolchain (Go 1.25, docker SDK
+> current Docker. This fork modernises the toolchain (Go 1.26, docker SDK
 > v28, current Alpine), adds **macvlan** and **ipvlan** attachment modes,
 > fixes the daemon-restart deadlock, fixes a data race on the plugin's
 > internal state, and incorporates several open upstream PRs. As of v0.7.0
@@ -30,7 +30,7 @@
 >
 > Install:
 > ```bash
-> docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.0.0
+> docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.0
 > ```
 >
 > All upstream usage below still applies — bridge mode is unchanged and
@@ -55,17 +55,17 @@ handy for home deployment.
 The plugin can be installed with the `docker plugin install` command:
 
 ```
-$ docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.0.0
-Plugin "ghcr.io/claymore666/docker-net-dhcp:v1.0.0" is requesting the following privileges:
+$ docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.0
+Plugin "ghcr.io/claymore666/docker-net-dhcp:v1.1.0" is requesting the following privileges:
  - network: [host]
  - host pid namespace: [true]
  - mount: [/var/run/docker.sock]
  - capabilities: [CAP_NET_ADMIN CAP_SYS_ADMIN]
 Do you grant the above permissions? [y/N] y
-v1.0.0: Pulling from ghcr.io/claymore666/docker-net-dhcp
+v1.1.0: Pulling from ghcr.io/claymore666/docker-net-dhcp
 Digest: sha256:<some hash>
 <some id>: Complete
-Installed plugin ghcr.io/claymore666/docker-net-dhcp:v1.0.0
+Installed plugin ghcr.io/claymore666/docker-net-dhcp:v1.1.0
 $
 ```
 
@@ -76,6 +76,26 @@ Note: If you get an error like `invalid rootfs in image configuration`, try upgr
 This fork publishes semver-tagged plugin images on GitHub Container Registry: `ghcr.io/claymore666/docker-net-dhcp:vX.Y.Z`. See the [Releases page](https://github.com/claymore666/docker-net-dhcp/releases) for the changelog of each release.
 
 Currently published architectures: `linux/amd64` only. ARM builds (multi-arch via `scripts/push_multiarch_plugin.py`) are supported by the build pipeline but not currently published — open an issue if you need one.
+
+## Verifying releases
+
+Every release (v1.1.0 onward) is signed and attested via Sigstore. The
+published plugin image is signed with cosign (keyless), carries SLSA
+build provenance, and ships an SBOM; the release-artifact `checksums.txt`
+manifest is cosign-signed so one signature covers every attached file.
+The exact, copy-pasteable commands — pinned to that release's tag — are
+appended to each [GitHub Release](https://github.com/claymore666/docker-net-dhcp/releases)
+under **Verifying the signed artifacts**. In brief (replace `VERSION`):
+
+```bash
+# image signature
+cosign verify ghcr.io/claymore666/docker-net-dhcp:VERSION \
+  --certificate-identity-regexp '^https://github.com/claymore666/docker-net-dhcp/.github/workflows/release.yml@' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# SLSA build provenance (image + release artifacts)
+gh attestation verify oci://ghcr.io/claymore666/docker-net-dhcp:VERSION --repo claymore666/docker-net-dhcp
+```
 
 ## Attachment modes
 
@@ -120,13 +140,13 @@ $ sudo dhcpcd my-bridge
 Once the bridge is ready, you can create the network:
 
 ```
-$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.0.0 --ipam-driver null -o bridge=my-bridge my-dhcp-net
+$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 --ipam-driver null -o bridge=my-bridge my-dhcp-net
 <some network id>
 $
 
 # With IPv6 enabled
 # Although `docker network create` has a `--ipv6` flag, it doesn't work with the null IPAM driver
-$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.0.0 --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
+$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
 <some network id>
 $
 ```
@@ -187,7 +207,7 @@ services:
       - dhcp
 networks:
   dhcp:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.0.0
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.1.0
     driver_opts:
       bridge: my-bridge
       ipv6: 'true'
@@ -216,7 +236,7 @@ Note:
 ## Debugging
 
 To read the plugin's log, do `cat /var/lib/docker/plugins/*/rootfs/var/log/net-dhcp.log` (as `root`). You can also use
-`docker plugin set ghcr.io/claymore666/docker-net-dhcp:v1.0.0 LOG_LEVEL=trace` to increase log verbosity.
+`docker plugin set ghcr.io/claymore666/docker-net-dhcp:v1.1.0 LOG_LEVEL=trace` to increase log verbosity.
 
 `/Plugin.Health` exposes liveness and recovery counters as JSON on the plugin's UNIX socket — useful as a monitoring probe. See [`docs/parent-attached-modes.md`](docs/parent-attached-modes.md#health-endpoint) for the payload schema and a sample `curl` invocation.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,69 @@ vulnerable code path is reachable from the plugin process, so no
 action is required. Recorded here so future audits don't
 re-investigate. (Original report: third-pass code review, 2026-05-04.)
 
+## v1.1.0
+
+A security, supply-chain, and toolchain-maintenance release. **There are
+no functional plugin changes** — bridge / macvlan / ipvlan behaviour,
+every driver option, and the on-disk and `/Plugin.Health` surfaces are
+identical to v1.0.0. A network created against v1.0.0 behaves exactly the
+same on v1.1.0; what changed is how the artifacts are built, signed, and
+verified, and the security posture of the CI that produces them. This
+release takes the project's OpenSSF Scorecard to a clean sheet.
+
+### Supply chain & release integrity
+
+- **Signed images** — published plugin images are now signed with cosign
+  (keyless / Sigstore) by digest, on both GHCR and Docker Hub (#173).
+- **Build provenance** — SLSA build-provenance attestations for the image
+  and for every release artifact, verifiable with `gh attestation verify`
+  (#173).
+- **SBOM** — an SBOM in both SPDX and CycloneDX formats is generated over
+  the plugin rootfs and attached to each release (#174).
+- **Signed checksums & tags** — the release `checksums.txt` manifest is
+  cosign-signed so a single signature covers every attached artifact, and
+  release tags are now GPG/SSH-signed (#163, #175).
+- Each GitHub Release now carries copy-pasteable verification commands
+  under *Verifying the signed artifacts*; the README has a short-form
+  [Verifying releases](README.md#verifying-releases) section.
+
+### CI security hardening
+
+- **CodeQL** advanced setup analysing Go (the primary language, previously
+  unscanned) and the Actions workflows, wired in as a required check
+  (#170).
+- **Dependency Review** action blocks PRs that introduce high-severity
+  vulnerable dependencies at review time (#171).
+- **GitHub security toggles** — Dependabot security updates, secret-scanning
+  push protection, and private vulnerability reporting are enabled; the
+  Dependabot and CodeQL checks are required on `dev`/`main` (#172).
+- **Native fuzzing** — Go fuzz targets over the untrusted DHCP-response
+  parsers (the env-var event path and the handler-pipe JSON decoder) run
+  time-boxed on every PR and satisfy Scorecard's Fuzzing check (#162).
+- **Scorecard to 10** — all GitHub Actions and container images are
+  SHA-pinned, workflow tokens are scoped to least privilege, and the
+  remaining OSV advisories were triaged (unreachable client-library
+  findings dismissed with rationale; migration off the frozen
+  `github.com/docker/docker` module tracked separately) (#159, #160,
+  #161).
+
+### Toolchain & CI fixes
+
+- **Go 1.26.4** across the runner image, `go.mod`, the plugin Dockerfile,
+  and all workflow toolchains; actionlint bumped to v1.7.12 (#177).
+- **Runner image honors `HTTP(S)_PROXY`** for the nested plugin docker
+  build behind a forced-egress proxy (#181).
+- **`check-apk-pins.sh` false positive fixed** — `apk policy` emits
+  candidate versions with a trailing colon, which the drift check now
+  strips before comparing, so current pins are no longer flagged as
+  drifted; a table-driven self-test guards the regression (#169).
+- **actionlint determinism** — shellcheck is pinned in the actionlint job
+  so a hosted-image bump can't silently redden unrelated PRs; the SC1003
+  false-positive in the cosign block was resolved (#183).
+- Earlier in the cycle, the nested-dockerd `plugin disable/enable`
+  failure on the ephemeral CI runner (cgroup.kill `EOPNOTSUPP`) and the
+  Scorecard badge were addressed (#158, #176).
+
 ## v1.0.0
 
 The 1.0 milestone: the fork's quality infrastructure is now mechanical

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -309,7 +309,7 @@ exact create incantation (note: the Docker-level `--ipv6` flag does
 NOT work with the null IPAM driver and is not what you want):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.0.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 -o ipv6=true \
     lan-dhcp6
@@ -539,7 +539,7 @@ endpoint operation everything is back to disk-served.
 Override the location via the `STATE_DIR` env var on the plugin:
 
 ```bash
-docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.0.0 STATE_DIR=/some/other/path
+docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.1.0 STATE_DIR=/some/other/path
 ```
 
 ## Plugin env vars

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,7 +27,7 @@ The plugin publishes to two registries; GHCR is primary:
 for unattended):
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.0.0
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.0
 ```
 
 Privileges requested: `network: host`, host PID namespace, the Docker
@@ -35,9 +35,16 @@ socket mount, `CAP_NET_ADMIN` + `CAP_SYS_ADMIN`. All four are inherent
 to what the plugin does (creating links in arbitrary netns, driving
 DHCP on the host's L2 segments, querying the daemon).
 
+**Verify the signature (v1.1.0+).** The published image is cosign-signed
+(keyless) and carries SLSA build provenance; release artifacts ship a
+cosign-signed `checksums.txt` and an SBOM. Per-release, copy-pasteable
+verification commands live under **Verifying the signed artifacts** on
+each [GitHub Release](https://github.com/claymore666/docker-net-dhcp/releases);
+the [README](../README.md#verifying-releases) has the short form.
+
 **Pin a version.** `:latest` exists and tracks the newest release, but
 networks remember the exact driver string they were created with — a
-network created against `:v1.0.0` needs that tag present to operate.
+network created against `:v1.1.0` needs that tag present to operate.
 Pinning makes upgrades a deliberate step instead of a pull-side
 surprise.
 
@@ -87,7 +94,7 @@ You bring an existing Linux bridge that is L2-connected to the LAN
 bridge setup itself):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.0.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 \
     --ipam-driver null \
     -o bridge=my-bridge \
     my-dhcp-net
@@ -99,7 +106,7 @@ No host changes — containers get per-container kernel-generated MACs
 as macvlan children of a host NIC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.0.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 \
     lan-dhcp
@@ -113,7 +120,7 @@ security, hostile vSwitches, some Wi-Fi APs). The DHCP server must
 key reservations on DHCP option 61 (client identifier), not MAC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.0.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 \
     --ipam-driver null \
     -o mode=ipvlan -o parent=eth0 \
     lan-dhcp
@@ -192,7 +199,7 @@ Set with `docker plugin set <plugin> NAME=value`; take effect after
 JSON liveness + counters on the plugin's UNIX socket:
 
 ```bash
-PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.0.0)
+PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.1.0)
 curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
     http://localhost/Plugin.Health | jq .
 ```
@@ -262,7 +269,7 @@ Compose-managed alternative (network lifecycle tied to the project):
 ```yaml
 networks:
   lan:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.0.0
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.1.0
     driver_opts:
       mode: macvlan
       parent: eth0


### PR DESCRIPTION
Release-prep doc changes for v1.1.0, landing on `dev` ahead of the `dev`→`main` release PR.

- Bump image-tag references in install/create/set examples `:v1.0.0` → `:v1.1.0` (README, docs/reference.md, docs/parent-attached-modes.md). Provenance markers (`(v1.0.0+)`, "since v1.0.0") left intact — v1.1.0 has no functional plugin changes.
- README: toolchain line Go 1.25 → 1.26; new **Verifying releases** section (cosign image verify + `gh attestation verify`, pointing at each Release's per-tag instructions).
- docs/reference.md: signature-verification pointer in the install section.
- RELEASE_NOTES.md: `## v1.1.0` — supply-chain/release-integrity, CI security hardening, toolchain & CI fixes. Framed explicitly as **no functional plugin changes**.

No code changes; gates run clean (option-docs drift, apk-pin self-test, actionlint).