### PR TITLE
ci: allowlist unreachable docker/docker advisories in dependency-review (#193)

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,36 @@
+# Config for the Dependency Review gate (.github/workflows/dependency-review.yml).
+#
+# Posture mirrors the govulncheck gate: fail a PR that introduces a new
+# high-or-critical advisory. The allow-ghsas list below is the
+# advisory-level counterpart of .github/vuln-allowlist.txt and follows
+# the same rules:
+#   - Every entry needs a justification and a review date. No bare IDs.
+#   - Entries are only for findings with no fixed release available on
+#     the module path we depend on. The moment a fix ships, the bump
+#     lands and the entry is removed.
+#   - Reachability is the arbiter: an entry is only acceptable while
+#     govulncheck (scripts/govulncheck-gate.sh) reports the path
+#     unreachable. If govulncheck ever flags it, the acceptance is void.
+
+fail-on-severity: high
+comment-summary-in-pr: on-failure
+
+# All three are daemon-side / `docker cp`-side Moby vulnerabilities in
+# github.com/docker/docker. This plugin uses that module only as a
+# CLIENT library; its sole call-sites are NetworkList, NetworkInspect,
+# and ContainerInspect. It never invokes the AuthZ, archive-PUT, or
+# `docker cp` handlers where these live, so none are reachable from the
+# plugin process — govulncheck confirms (green on the same PRs). No fix
+# is available: the github.com/docker/docker module is frozen at
+# v28.5.2; the successor github.com/moby/moby/v2 migration is tracked in
+# #178, at which point these acceptances are re-evaluated. Reviewed
+# 2026-06-14 (#193).
+allow-ghsas:
+  # AuthZ plugin bypass on oversized request bodies (= GO-2026-4887,
+  # also in vuln-allowlist.txt for the govulncheck gate).
+  - GHSA-x744-4wpc-v9h2
+  # `PUT /containers/{id}/archive` executes container binary on the host.
+  - GHSA-x86f-5xw2-fm2r
+  # Race condition in `docker cp` allows bind-mount redirection to a
+  # host path.
+  - GHSA-rg2x-37c3-w2rh

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -27,9 +27,9 @@ jobs:
       - name: Dependency review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
-          # Match the govulncheck gate's posture: fail on a newly
-          # introduced high-or-critical advisory.
-          fail-on-severity: high
-          # Flag copyleft/unknown licenses for review without hard-failing
-          # the build on a license the tool can't classify.
-          comment-summary-in-pr: on-failure
+          # Posture (fail-on-severity: high) and the allow-ghsas list of
+          # known-unreachable daemon-side docker/docker advisories live in
+          # the config file — the advisory-level counterpart of
+          # .github/vuln-allowlist.txt (#193). Keep accepted findings
+          # there with justification + review date, not inline here.
+          config-file: ./.github/dependency-review-config.yml

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,24 @@ vulnerable code path is reachable from the plugin process, so no
 action is required. Recorded here so future audits don't
 re-investigate. (Original report: third-pass code review, 2026-05-04.)
 
+The v1.1.0 Dependency Review gate (#193) surfaced two further
+`github.com/docker/docker` advisories at v28.5.2:
+
+- **GHSA-x86f-5xw2-fm2r** — `PUT /containers/{id}/archive` executes a
+  container binary on the host.
+- **GHSA-rg2x-37c3-w2rh** — race condition in `docker cp` allows
+  bind-mount redirection to a host path.
+
+Both are `docker cp` / archive-extraction paths in the Moby daemon and
+CLI. The plugin invokes none of them — its only client calls remain the
+three inspect/list APIs above — so neither is reachable; `govulncheck`
+confirms (green). No fix is published on the frozen
+`github.com/docker/docker` module path (successor `moby/moby/v2`
+migration tracked in #178). They are accepted at the advisory level in
+`.github/dependency-review-config.yml` with a review date, alongside the
+older AuthZ finding (GHSA-x744-4wpc-v9h2 = GO-2026-4887), and will be
+re-evaluated when the module migration lands.
+
 ## v1.1.0
 
 A security, supply-chain, and toolchain-maintenance release. **There are


### PR DESCRIPTION
Unblocks the v1.1.0 release PR (#192). The `dev`→`main` diff bumps `github.com/docker/docker` v28.4.0 → v28.5.2 (go-deps, #140), and `dependency-review` flags three HIGH Moby advisories present at v28.5.2:

- `GHSA-x744-4wpc-v9h2` — AuthZ plugin bypass on oversized bodies (= `GO-2026-4887`, already in `vuln-allowlist.txt`)
- `GHSA-x86f-5xw2-fm2r` — `PUT /containers/{id}/archive` executes a container binary on the host (new)
- `GHSA-rg2x-37c3-w2rh` — `docker cp` race → bind-mount redirection to a host path (new)

All three are **daemon-side / `docker cp`-side** Moby paths. This plugin uses `docker/docker` only as a **client library** — call-sites are `NetworkList`, `NetworkInspect`, `ContainerInspect` — and never reaches them. **`govulncheck` (reachability arbiter) is green** on the same PRs. No fix is published on the frozen `docker/docker` module path; `moby/moby/v2` migration is tracked in #178, when these acceptances are re-evaluated.

## Changes
- New `.github/dependency-review-config.yml`: moves `fail-on-severity: high` + `comment-summary-in-pr` into the config and adds an `allow-ghsas` list for the three GHSAs — the advisory-level counterpart of `vuln-allowlist.txt`, same rules (justification + review date, no bare IDs, reachability as arbiter).
- `dependency-review.yml`: references the config via `config-file`.
- `RELEASE_NOTES.md`: documents the two newer advisories in "Acknowledged findings".

Refs #178. Closes via the v1.1.0 release PR.