### PR TITLE
ci: Scorecard read-only admin token for Branch-Protection

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          # Read-only, single-repo fine-grained PAT (Administration: read).
+          # The default GITHUB_TOKEN cannot read branch-protection settings,
+          # so the Branch-Protection check scores -1 (inconclusive) without
+          # it. Stored as a repo secret; renew before its expiry.
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
           # Publish to the Scorecard REST API — feeds the README badge
           # and https://scorecard.dev/viewer/?uri=github.com/claymore666/docker-net-dhcp
           publish_results: true


### PR DESCRIPTION
Wires a single-repo, read-only fine-grained PAT (`Administration: read`) into the Scorecard workflow as `repo_token` via the `SCORECARD_TOKEN` secret.

The default `GITHUB_TOKEN` cannot read branch-protection settings, so the `Branch-Protection` check scored `-1` (inconclusive) despite protection being configured. With the token, the scanner can evaluate it.

The token is read-only, scoped to this repo, and must be renewed before expiry (noted in a workflow comment).

Closes #197