### PR TITLE
ci: add issue forms and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Report a problem with the plugin
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Thanks for filing a bug. **Do not use this form for security
+        vulnerabilities** — follow the private process in
+        [SECURITY.md](https://github.com/claymore666/docker-net-dhcp/blob/main/SECURITY.md).
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      description: From `docker plugin ls` (e.g. v1.1.0).
+      placeholder: v1.1.0
+    validations:
+      required: true
+  - type: input
+    id: docker-version
+    attributes:
+      label: Docker version
+      description: "Output of `docker version --format '{{.Server.Version}}'`."
+      placeholder: "26.1.5"
+    validations:
+      required: true
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Network mode
+      description: The `mode` driver option of the affected network.
+      options:
+        - bridge
+        - macvlan
+        - ipvlan
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect to happen, and what happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: >-
+        Include the `docker network create` line and any `docker run` /
+        compose snippet needed to reproduce.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Plugin logs
+      description: >-
+        Relevant output from `docker plugin logs <plugin>`. Automatically
+        rendered as code, so no backticks needed.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability (private)
+    url: https://github.com/claymore666/docker-net-dhcp/security/advisories/new
+    about: >-
+      Do NOT open a public issue for anything you believe is exploitable.
+      Report it privately via GitHub Security Advisories. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest an enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        The guiding principle for this plugin is: one `docker network create`
+        line, then plain `networks: [...]` in any compose file — no static IPs,
+        sidecars, or per-container plumbing. Please frame requests against that.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do that the plugin doesn't support today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like the plugin to do?
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you've tried or other approaches you weighed.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!--
+PRs target the `dev` branch, never `main`. Releases are cut by the
+maintainer via a dev -> main release PR. See the Contributing section
+of the README.
+-->
+
+## What this changes
+
+<!-- Brief description of the change and why it's needed. -->
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Checklist
+
+- [ ] Branched off and targets `dev` (not `main`)
+- [ ] Tests added/updated for the change (the coverage ratchet is enforced at release)
+- [ ] Unit tests, `staticcheck`, and the integration suite pass
+- [ ] Docs (README / `docs/`) updated if behaviour or options changed
+- [ ] No secrets, credentials, or internal host details in the diff


### PR DESCRIPTION
Adds:
- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured bug form (plugin version, Docker version, mode, repro, logs)
- `.github/ISSUE_TEMPLATE/feature_request.yml` — enhancement form framed around the plugin's zero-config principle
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, links the private security-advisory flow
- `.github/PULL_REQUEST_TEMPLATE.md` — contributor checklist (targets `dev`, tests added, docs updated, no secrets)

Reinforces the OpenSSF Best Practices report_process / contribution criteria.

Closes #201