### PR TITLE
docs: v1.1.1 release prep (version pins, RELEASE_NOTES)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 >
 > Install:
 > ```bash
-> docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.0
+> docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.1
 > ```
 >
 > All upstream usage below still applies — bridge mode is unchanged and
@@ -56,17 +56,17 @@ handy for home deployment.
 The plugin can be installed with the `docker plugin install` command:
 
 ```
-$ docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.0
-Plugin "ghcr.io/claymore666/docker-net-dhcp:v1.1.0" is requesting the following privileges:
+$ docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.1
+Plugin "ghcr.io/claymore666/docker-net-dhcp:v1.1.1" is requesting the following privileges:
  - network: [host]
  - host pid namespace: [true]
  - mount: [/var/run/docker.sock]
  - capabilities: [CAP_NET_ADMIN CAP_SYS_ADMIN]
 Do you grant the above permissions? [y/N] y
-v1.1.0: Pulling from ghcr.io/claymore666/docker-net-dhcp
+v1.1.1: Pulling from ghcr.io/claymore666/docker-net-dhcp
 Digest: sha256:<some hash>
 <some id>: Complete
-Installed plugin ghcr.io/claymore666/docker-net-dhcp:v1.1.0
+Installed plugin ghcr.io/claymore666/docker-net-dhcp:v1.1.1
 $
 ```
 
@@ -141,13 +141,13 @@ $ sudo dhcpcd my-bridge
 Once the bridge is ready, you can create the network:
 
 ```
-$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 --ipam-driver null -o bridge=my-bridge my-dhcp-net
+$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 --ipam-driver null -o bridge=my-bridge my-dhcp-net
 <some network id>
 $
 
 # With IPv6 enabled
 # Although `docker network create` has a `--ipv6` flag, it doesn't work with the null IPAM driver
-$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
+$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
 <some network id>
 $
 ```
@@ -208,7 +208,7 @@ services:
       - dhcp
 networks:
   dhcp:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.1.0
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.1.1
     driver_opts:
       bridge: my-bridge
       ipv6: 'true'
@@ -237,7 +237,7 @@ Note:
 ## Debugging
 
 To read the plugin's log, do `cat /var/lib/docker/plugins/*/rootfs/var/log/net-dhcp.log` (as `root`). You can also use
-`docker plugin set ghcr.io/claymore666/docker-net-dhcp:v1.1.0 LOG_LEVEL=trace` to increase log verbosity.
+`docker plugin set ghcr.io/claymore666/docker-net-dhcp:v1.1.1 LOG_LEVEL=trace` to increase log verbosity.
 
 `/Plugin.Health` exposes liveness and recovery counters as JSON on the plugin's UNIX socket — useful as a monitoring probe. See [`docs/parent-attached-modes.md`](docs/parent-attached-modes.md#health-endpoint) for the payload schema and a sample `curl` invocation.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,6 +44,29 @@ migration tracked in #178). They are accepted at the advisory level in
 older AuthZ finding (GHSA-x744-4wpc-v9h2 = GO-2026-4887), and will be
 re-evaluated when the module migration lands.
 
+## v1.1.1
+
+A compliance and project-hygiene release. **There are no functional
+plugin changes** — bridge / macvlan / ipvlan behaviour, every driver
+option, and the on-disk and `/Plugin.Health` surfaces are identical to
+v1.1.0; the published image is functionally the same (a new digest, as
+expected for a new tag). What changed:
+
+- **OpenSSF Best Practices passing badge** earned and added to the
+  README ([project 13229](https://www.bestpractices.dev/projects/13229)).
+- **OpenSSF Scorecard Branch-Protection** is now evaluable: the Scorecard
+  workflow is given a read-only, single-repo token so the check can read
+  branch-protection settings (it previously scored as inconclusive). With
+  this and the badge, all three previously-open Scorecard checks resolve.
+- **Contributing documentation**: a `Contributing` section in the README
+  covering how to report issues, the pull-request flow and required CI
+  checks, the coding standard, and the tests-with-changes policy.
+- **Issue and pull-request templates**: structured bug-report and
+  feature-request forms (with a private security-advisory link) and a PR
+  checklist.
+- Maintainer-facing: the release runbook now documents post-release
+  branch cleanup, and the repository auto-deletes merged PR branches.
+
 ## v1.1.0
 
 A security, supply-chain, and toolchain-maintenance release. **There are

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -309,7 +309,7 @@ exact create incantation (note: the Docker-level `--ipv6` flag does
 NOT work with the null IPAM driver and is not what you want):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 -o ipv6=true \
     lan-dhcp6
@@ -539,7 +539,7 @@ endpoint operation everything is back to disk-served.
 Override the location via the `STATE_DIR` env var on the plugin:
 
 ```bash
-docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.1.0 STATE_DIR=/some/other/path
+docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.1.1 STATE_DIR=/some/other/path
 ```
 
 ## Plugin env vars

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,7 +27,7 @@ The plugin publishes to two registries; GHCR is primary:
 for unattended):
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.0
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.1
 ```
 
 Privileges requested: `network: host`, host PID namespace, the Docker
@@ -44,7 +44,7 @@ the [README](../README.md#verifying-releases) has the short form.
 
 **Pin a version.** `:latest` exists and tracks the newest release, but
 networks remember the exact driver string they were created with — a
-network created against `:v1.1.0` needs that tag present to operate.
+network created against `:v1.1.1` needs that tag present to operate.
 Pinning makes upgrades a deliberate step instead of a pull-side
 surprise.
 
@@ -94,7 +94,7 @@ You bring an existing Linux bridge that is L2-connected to the LAN
 bridge setup itself):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
     --ipam-driver null \
     -o bridge=my-bridge \
     my-dhcp-net
@@ -106,7 +106,7 @@ No host changes — containers get per-container kernel-generated MACs
 as macvlan children of a host NIC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 \
     lan-dhcp
@@ -120,7 +120,7 @@ security, hostile vSwitches, some Wi-Fi APs). The DHCP server must
 key reservations on DHCP option 61 (client identifier), not MAC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
     --ipam-driver null \
     -o mode=ipvlan -o parent=eth0 \
     lan-dhcp
@@ -199,7 +199,7 @@ Set with `docker plugin set <plugin> NAME=value`; take effect after
 JSON liveness + counters on the plugin's UNIX socket:
 
 ```bash
-PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.1.0)
+PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.1.1)
 curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
     http://localhost/Plugin.Health | jq .
 ```
@@ -269,7 +269,7 @@ Compose-managed alternative (network lifecycle tied to the project):
 ```yaml
 networks:
   lan:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.1.0
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.1.1
     driver_opts:
       mode: macvlan
       parent: eth0


### PR DESCRIPTION
Release prep for v1.1.1 per the runbook:
- Bump install/usage pins `v1.1.0` → `v1.1.1` in README, `docs/reference.md`, `docs/parent-attached-modes.md` (historical 'v1.1.0 onward' / 'v1.1.0+' signing references left intact).
- Add the `## v1.1.1` RELEASE_NOTES section — compliance/hygiene release, no functional plugin changes.

Merges to `dev`; the `dev` → `main` release PR follows.