### PR TITLE
Release v1.1.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Report a problem with the plugin
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Thanks for filing a bug. **Do not use this form for security
+        vulnerabilities** — follow the private process in
+        [SECURITY.md](https://github.com/claymore666/docker-net-dhcp/blob/main/SECURITY.md).
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      description: From `docker plugin ls` (e.g. v1.1.0).
+      placeholder: v1.1.0
+    validations:
+      required: true
+  - type: input
+    id: docker-version
+    attributes:
+      label: Docker version
+      description: "Output of `docker version --format '{{.Server.Version}}'`."
+      placeholder: "26.1.5"
+    validations:
+      required: true
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Network mode
+      description: The `mode` driver option of the affected network.
+      options:
+        - bridge
+        - macvlan
+        - ipvlan
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect to happen, and what happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: >-
+        Include the `docker network create` line and any `docker run` /
+        compose snippet needed to reproduce.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Plugin logs
+      description: >-
+        Relevant output from `docker plugin logs <plugin>`. Automatically
+        rendered as code, so no backticks needed.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability (private)
+    url: https://github.com/claymore666/docker-net-dhcp/security/advisories/new
+    about: >-
+      Do NOT open a public issue for anything you believe is exploitable.
+      Report it privately via GitHub Security Advisories. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest an enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        The guiding principle for this plugin is: one `docker network create`
+        line, then plain `networks: [...]` in any compose file — no static IPs,
+        sidecars, or per-container plumbing. Please frame requests against that.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do that the plugin doesn't support today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like the plugin to do?
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you've tried or other approaches you weighed.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!--
+PRs target the `dev` branch, never `main`. Releases are cut by the
+maintainer via a dev -> main release PR. See the Contributing section
+of the README.
+-->
+
+## What this changes
+
+<!-- Brief description of the change and why it's needed. -->
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Checklist
+
+- [ ] Branched off and targets `dev` (not `main`)
+- [ ] Tests added/updated for the change (the coverage ratchet is enforced at release)
+- [ ] Unit tests, `staticcheck`, and the integration suite pass
+- [ ] Docs (README / `docs/`) updated if behaviour or options changed
+- [ ] No secrets, credentials, or internal host details in the diff

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          # Read-only, single-repo fine-grained PAT (Administration: read).
+          # The default GITHUB_TOKEN cannot read branch-protection settings,
+          # so the Branch-Protection check scores -1 (inconclusive) without
+          # it. Stored as a repo secret; renew before its expiry.
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
           # Publish to the Scorecard REST API — feeds the README badge
           # and https://scorecard.dev/viewer/?uri=github.com/claymore666/docker-net-dhcp
           publish_results: true

--- a/README.md
+++ b/README.md
@@ -273,3 +273,27 @@ this point `udhcpc` must be stopped
 5. `net-dhcp` starts `udhcpc` on the container end of the `veth` pair in the container's **network namespace** (but
 still in the plugin **PID namespace** - this means that the container can't see the DHCP client)
 6. `udhcpc` continues to run, renewing the lease when required, until the container shuts down
+
+# Contributing
+
+Contributions are welcome.
+
+- **Questions, bugs, and feature requests:** open a [GitHub issue](https://github.com/claymore666/docker-net-dhcp/issues).
+  For bugs, please include the plugin version, your Docker version, the network
+  mode (`bridge`, `macvlan`, or `ipvlan`), and the relevant output from
+  `docker plugin logs <plugin>`.
+- **Code changes:** open a pull request against the `dev` branch (not `main`).
+  Requirements for an acceptable contribution:
+  - **Coding standard:** Go code must be formatted with `gofmt` and pass
+    `go vet` and [`staticcheck`](https://staticcheck.dev/); shell and workflow
+    files must pass `shellcheck`/`actionlint`. These are enforced in CI.
+  - **Tests:** new functionality is expected to ship with tests; a coverage
+    ratchet enforces this at release time.
+  - **Green CI:** every PR must pass the required checks — unit tests,
+    `staticcheck`, the live integration suite, `govulncheck`, and `actionlint` —
+    before it can be merged.
+- **Security vulnerabilities:** do **not** open a public issue — follow the
+  private process described in [SECURITY.md](SECURITY.md).
+
+This is an actively maintained fork. It is solo-maintained, so please allow a
+few days for a response.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Release](https://img.shields.io/github/v/release/claymore666/docker-net-dhcp?sort=semver)](https://github.com/claymore666/docker-net-dhcp/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/claymore666/docker-net-dhcp)](https://goreportcard.com/report/github.com/claymore666/docker-net-dhcp)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/claymore666/docker-net-dhcp/badge)](https://scorecard.dev/viewer/?uri=github.com/claymore666/docker-net-dhcp)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13229/badge)](https://www.bestpractices.dev/projects/13229)
 
 > **This is a maintained fork** of [`devplayer0/docker-net-dhcp`][upstream].
 > The upstream repository has been quiet since 2021 and no longer builds on

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 >
 > Install:
 > ```bash
-> docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.0
+> docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.1
 > ```
 >
 > All upstream usage below still applies — bridge mode is unchanged and
@@ -56,17 +56,17 @@ handy for home deployment.
 The plugin can be installed with the `docker plugin install` command:
 
 ```
-$ docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.0
-Plugin "ghcr.io/claymore666/docker-net-dhcp:v1.1.0" is requesting the following privileges:
+$ docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.1
+Plugin "ghcr.io/claymore666/docker-net-dhcp:v1.1.1" is requesting the following privileges:
  - network: [host]
  - host pid namespace: [true]
  - mount: [/var/run/docker.sock]
  - capabilities: [CAP_NET_ADMIN CAP_SYS_ADMIN]
 Do you grant the above permissions? [y/N] y
-v1.1.0: Pulling from ghcr.io/claymore666/docker-net-dhcp
+v1.1.1: Pulling from ghcr.io/claymore666/docker-net-dhcp
 Digest: sha256:<some hash>
 <some id>: Complete
-Installed plugin ghcr.io/claymore666/docker-net-dhcp:v1.1.0
+Installed plugin ghcr.io/claymore666/docker-net-dhcp:v1.1.1
 $
 ```
 
@@ -141,13 +141,13 @@ $ sudo dhcpcd my-bridge
 Once the bridge is ready, you can create the network:
 
 ```
-$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 --ipam-driver null -o bridge=my-bridge my-dhcp-net
+$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 --ipam-driver null -o bridge=my-bridge my-dhcp-net
 <some network id>
 $
 
 # With IPv6 enabled
 # Although `docker network create` has a `--ipv6` flag, it doesn't work with the null IPAM driver
-$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
+$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
 <some network id>
 $
 ```
@@ -208,7 +208,7 @@ services:
       - dhcp
 networks:
   dhcp:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.1.0
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.1.1
     driver_opts:
       bridge: my-bridge
       ipv6: 'true'
@@ -237,7 +237,7 @@ Note:
 ## Debugging
 
 To read the plugin's log, do `cat /var/lib/docker/plugins/*/rootfs/var/log/net-dhcp.log` (as `root`). You can also use
-`docker plugin set ghcr.io/claymore666/docker-net-dhcp:v1.1.0 LOG_LEVEL=trace` to increase log verbosity.
+`docker plugin set ghcr.io/claymore666/docker-net-dhcp:v1.1.1 LOG_LEVEL=trace` to increase log verbosity.
 
 `/Plugin.Health` exposes liveness and recovery counters as JSON on the plugin's UNIX socket — useful as a monitoring probe. See [`docs/parent-attached-modes.md`](docs/parent-attached-modes.md#health-endpoint) for the payload schema and a sample `curl` invocation.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,6 +44,29 @@ migration tracked in #178). They are accepted at the advisory level in
 older AuthZ finding (GHSA-x744-4wpc-v9h2 = GO-2026-4887), and will be
 re-evaluated when the module migration lands.
 
+## v1.1.1
+
+A compliance and project-hygiene release. **There are no functional
+plugin changes** — bridge / macvlan / ipvlan behaviour, every driver
+option, and the on-disk and `/Plugin.Health` surfaces are identical to
+v1.1.0; the published image is functionally the same (a new digest, as
+expected for a new tag). What changed:
+
+- **OpenSSF Best Practices passing badge** earned and added to the
+  README ([project 13229](https://www.bestpractices.dev/projects/13229)).
+- **OpenSSF Scorecard Branch-Protection** is now evaluable: the Scorecard
+  workflow is given a read-only, single-repo token so the check can read
+  branch-protection settings (it previously scored as inconclusive). With
+  this and the badge, all three previously-open Scorecard checks resolve.
+- **Contributing documentation**: a `Contributing` section in the README
+  covering how to report issues, the pull-request flow and required CI
+  checks, the coding standard, and the tests-with-changes policy.
+- **Issue and pull-request templates**: structured bug-report and
+  feature-request forms (with a private security-advisory link) and a PR
+  checklist.
+- Maintainer-facing: the release runbook now documents post-release
+  branch cleanup, and the repository auto-deletes merged PR branches.
+
 ## v1.1.0
 
 A security, supply-chain, and toolchain-maintenance release. **There are

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -309,7 +309,7 @@ exact create incantation (note: the Docker-level `--ipv6` flag does
 NOT work with the null IPAM driver and is not what you want):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 -o ipv6=true \
     lan-dhcp6
@@ -539,7 +539,7 @@ endpoint operation everything is back to disk-served.
 Override the location via the `STATE_DIR` env var on the plugin:
 
 ```bash
-docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.1.0 STATE_DIR=/some/other/path
+docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.1.1 STATE_DIR=/some/other/path
 ```
 
 ## Plugin env vars

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,7 +27,7 @@ The plugin publishes to two registries; GHCR is primary:
 for unattended):
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.0
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.1
 ```
 
 Privileges requested: `network: host`, host PID namespace, the Docker
@@ -44,7 +44,7 @@ the [README](../README.md#verifying-releases) has the short form.
 
 **Pin a version.** `:latest` exists and tracks the newest release, but
 networks remember the exact driver string they were created with — a
-network created against `:v1.1.0` needs that tag present to operate.
+network created against `:v1.1.1` needs that tag present to operate.
 Pinning makes upgrades a deliberate step instead of a pull-side
 surprise.
 
@@ -94,7 +94,7 @@ You bring an existing Linux bridge that is L2-connected to the LAN
 bridge setup itself):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
     --ipam-driver null \
     -o bridge=my-bridge \
     my-dhcp-net
@@ -106,7 +106,7 @@ No host changes — containers get per-container kernel-generated MACs
 as macvlan children of a host NIC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 \
     lan-dhcp
@@ -120,7 +120,7 @@ security, hostile vSwitches, some Wi-Fi APs). The DHCP server must
 key reservations on DHCP option 61 (client identifier), not MAC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
     --ipam-driver null \
     -o mode=ipvlan -o parent=eth0 \
     lan-dhcp
@@ -199,7 +199,7 @@ Set with `docker plugin set <plugin> NAME=value`; take effect after
 JSON liveness + counters on the plugin's UNIX socket:
 
 ```bash
-PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.1.0)
+PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.1.1)
 curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
     http://localhost/Plugin.Health | jq .
 ```
@@ -269,7 +269,7 @@ Compose-managed alternative (network lifecycle tied to the project):
 ```yaml
 networks:
   lan:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.1.0
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.1.1
     driver_opts:
       mode: macvlan
       parent: eth0

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -226,6 +226,20 @@ the `vX.Y.Z` milestone (the workflow leans on this for the
    previous version's README/docs, and the next release PR has to
    re-bump them. Forgotten once after v0.9.0 — that's why
    `release.yml`'s header comment carries the same checklist.
+11. **Prune merged branches.** The repo has *Automatically delete head
+   branches* enabled, so merged PR head branches are removed on merge.
+   Two things that setting doesn't cover, so clean them now:
+   ```sh
+   # the release branch is merged but was never a PR head:
+   git push origin --delete release/vX.Y.Z
+   # sweep for any other branch already merged into dev that lingered:
+   git fetch --prune origin
+   git branch -r --merged origin/dev | grep -vE 'origin/(dev|main|HEAD)$'
+   ```
+   Delete what that sweep lists. Leave alone: open-PR branches,
+   Dependabot branches (it recreates its own — close via the PR), and
+   the `upstream/*` refs (those are the original fork's remote, not
+   ours).
 
 ## Verifying
 


### PR DESCRIPTION
Release **v1.1.1** — a compliance and project-hygiene release. **No functional plugin changes**; bridge/macvlan/ipvlan behaviour, all driver options, and the on-disk / `/Plugin.Health` surfaces are identical to v1.1.0.

## What's in it
- OpenSSF Best Practices **passing** badge (project 13229), added to the README.
- OpenSSF Scorecard **Branch-Protection** now evaluable (read-only repo token wired into the Scorecard workflow) — resolves the last of the three open Scorecard checks alongside the badge.
- README **Contributing** section (issue reporting, PR-to-`dev` flow + required checks, coding standard, tests-with-changes policy).
- **Issue forms + PR template** (bug report / feature request with a private security-advisory link; PR checklist).
- Maintainer: runbook documents post-release branch cleanup; repo auto-deletes merged PR branches.
- Install/usage pins bumped `v1.1.0` → `v1.1.1` across README and docs.

## Closes
Closes #197
Closes #199
Closes #201
Closes #203
Closes #208