### PR TITLE
docs: governance, code of conduct, security assurance (OpenSSF silver)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,36 @@
+# Code of Conduct
+
+## Our pledge
+
+This project is committed to providing a welcoming, harassment-free
+experience for everyone who participates — in issues, pull requests,
+and any other project space — regardless of background or identity.
+
+## Our standard
+
+This project adopts the **Contributor Covenant, version 2.1** as its
+code of conduct. The full text is published at:
+
+- https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+In short: be respectful and constructive. Harassment, personal attacks,
+and other unwelcoming behaviour are not tolerated. Maintainers may
+remove, edit, or reject contributions and interactions that violate
+this code, and may ban participants for serious or repeated violations.
+
+## Scope
+
+This code applies within all project spaces (the repository, issues,
+pull requests, and discussions) and when an individual is representing
+the project in public spaces.
+
+## Reporting
+
+Report unacceptable behaviour to the maintainer at
+**christian.kamien@gmail.com**. Reports will be reviewed and handled
+confidentially. As a security-sensitive note: this address is for
+conduct reports — **software vulnerabilities** go through the private
+process in [`SECURITY.md`](SECURITY.md), not here.
+
+Enforcement follows the Contributor Covenant's enforcement guidelines
+(linked above).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,52 @@
+# Project governance
+
+This document describes how `docker-net-dhcp` is governed and who is
+responsible for what. It is intentionally lightweight: this is a small,
+actively maintained fork, not a foundation project.
+
+## Model
+
+`docker-net-dhcp` is currently a **single-maintainer** project. The
+maintainer ([@claymore666](https://github.com/claymore666)) holds final
+decision-making authority over the codebase, its releases, and its
+infrastructure (the GitHub repository and the GHCR / Docker Hub
+registries).
+
+This is an honest statement of the current bus factor, not an
+aspiration: there is one maintainer today. Growing that number is an
+explicit goal — see "Becoming a maintainer" below.
+
+## Roles and responsibilities
+
+- **Maintainer** — triages issues, reviews and merges pull requests,
+  cuts releases (per [`docs/release-runbook.md`](docs/release-runbook.md)),
+  responds to security reports (per [`SECURITY.md`](SECURITY.md)), and
+  owns the CI/CD and supply-chain configuration.
+- **Contributors** — anyone who opens an issue or pull request. There
+  is no membership barrier; see [the Contributing section of the
+  README](README.md#contributing).
+
+## How decisions are made
+
+- All code changes land through a pull request against the `dev`
+  branch and must pass the required CI checks (unit tests,
+  `staticcheck`, the integration suite, `govulncheck`, `actionlint`)
+  before merge.
+- The maintainer reviews and merges. Substantial or user-visible
+  changes are discussed in the relevant issue first.
+- Releases are deliberate, maintainer-initiated steps; merging a PR is
+  not a release. The procedure is documented in the release runbook.
+
+## Becoming a maintainer
+
+Sustained, high-quality contribution is the path to commit/maintainer
+access. If you have been contributing regularly and would like to help
+maintain the project — including sharing release and infrastructure
+responsibility so the project is resilient to any one person becoming
+unavailable — open an issue or reach out to the maintainer. Broadening
+the maintainer base is welcome.
+
+## Code of conduct
+
+Participation in this project is governed by the
+[Code of Conduct](CODE_OF_CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,11 @@ You can expect an initial response within a few days; this is a
 solo-maintained project, so please allow a reasonable window for a
 fix before any public disclosure (90 days is a fine default).
 
+**Response process.** On receipt the maintainer triages and confirms
+the report, fixes the issue in a released version, and publishes a
+GitHub Security Advisory. **Reporters are credited** in the advisory
+and the fix's release notes unless they ask to remain anonymous.
+
 ## Scope — what this plugin is
 
 `docker-net-dhcp` is a privileged Docker network plugin: it runs with
@@ -46,3 +51,44 @@ release** are documented with justification and a review date in
 re-evaluated by CI on every PR (govulncheck gate) plus a weekly
 scheduled scan. Entries there are deliberate, reviewed acceptances —
 not oversights.
+
+## Security assurance case
+
+A short argument for why the plugin's security posture is adequate for
+its purpose.
+
+**Security goals.** (1) The plugin must not let a container escape to
+the host or to another container via its netns/mount-ns handling. (2)
+Untrusted, attacker-influenced input — chiefly DHCP-server responses —
+must not cause memory-unsafe behaviour or injection. (3) Published
+artifacts must be tamper-evident so users install what was built.
+
+**Threats** (see *Scope* above). The plugin is privileged
+(`CAP_NET_ADMIN`/`CAP_SYS_ADMIN`, host PID ns, Docker socket), so the
+relevant adversaries are a malicious container, a hostile LAN DHCP
+server supplying crafted lease/option bytes, and a supply-chain
+attacker tampering with distributed images.
+
+**Mitigations and why they suffice.**
+- *Memory safety / injection:* the plugin is written in Go (memory-safe)
+  and the untrusted DHCP-response parsers (`pkg/udhcpc.BuildEvent`, the
+  handler-pipe JSON decoder) have native fuzz targets plus seed corpora
+  run on every PR, so malformed server input is exercised, not assumed
+  safe.
+- *Escape / cross-container confusion:* the live integration suite drives
+  real DHCP exchanges through bridge/macvlan/ipvlan against a real
+  kernel and daemon, including recovery, tombstone-stability, and
+  concurrency scenarios; the race detector runs in unit CI.
+- *No cryptography of its own:* the plugin performs no encryption,
+  authentication, or key handling, so whole classes of crypto-misuse
+  threats do not apply.
+- *Supply chain:* releases are cosign-signed (keyless), carry SLSA build
+  provenance and an SBOM, and ship a signed `checksums.txt`; CI gates
+  every change with `govulncheck`, CodeQL, `staticcheck`, and Dependency
+  Review (see the [README](README.md#verifying-releases)).
+
+**Residual risk.** The plugin necessarily trusts the DHCP server for
+*addressing* (that is its function); a hostile server can hand out bad
+addresses/routes, which is a network-design concern outside the
+plugin's control. This is accepted and documented in *Scope*.
+


### PR DESCRIPTION
Adds the addressable silver-level documentation:
- `GOVERNANCE.md` — maintainer model, roles, decision process, path to more maintainers (`governance`, `roles_responsibilities`)
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1 by reference + report contact (`code_of_conduct`)
- `SECURITY.md` — response process + reporter credit + explicit assurance case (`vulnerability_response_process`, `vulnerability_report_credit`, `assurance_case`)

Does not claim `access_continuity`/`bus_factor` — those need a second maintainer. `test_statement_coverage80` is tracked by #206.

Closes #216