### PR TITLE
tests: unit-level error-path coverage via docker + netlink seams (#206)

### DIFF
--- a/.github/coverage-baseline.txt
+++ b/.github/coverage-baseline.txt
@@ -25,8 +25,23 @@
 #   - pkg/util 87.7 -> 87.0: LOWERED for run-to-run integration
 #     variance only — no util code changed this cycle; measured 87.1,
 #     0.1 over the old epsilon. New floor leaves variance headroom.
-github.com/devplayer0/docker-net-dhcp/pkg/util 87.0
-github.com/devplayer0/docker-net-dhcp/pkg/plugin 77.5
+#
+# v1.2.0 recorded decision (PR #220, #206 — error-path coverage):
+#   - pkg/plugin 77.5 -> 82.0: RAISED. This is the follow-through on the
+#     v1.0.0 intent above. New docker-client interface + netlink
+#     function-var seams made the previously integration-only / wholly
+#     unreachable error arms unit-testable (netOptions fallback,
+#     recoverEndpoints, lookup/initialDHCP/reacquire docker arms,
+#     validateParentForChild, deleteParentAttachedEndpoint, addRoutes,
+#     findLinkByMAC). Measured merged 82.3; floor 82.0 for epsilon room.
+#     Restores the pre-v1.0.0 level (was 82.4).
+#   - pkg/util 87.0 -> 88.0: RAISED, earned by the JSONErrResponse
+#     log-severity branch tests. Measured 88.7; floor 88.0.
+#   - pkg/udhcpc / cmd/net-dhcp left at floor: their +0.3/+0.4 this run
+#     is integration run-to-run variance, not earned by this PR (no
+#     udhcpc/cmd code or tests changed) — not ratcheted.
+github.com/devplayer0/docker-net-dhcp/pkg/util 88.0
+github.com/devplayer0/docker-net-dhcp/pkg/plugin 82.0
 github.com/devplayer0/docker-net-dhcp/pkg/udhcpc 85.5
 github.com/devplayer0/docker-net-dhcp/cmd/net-dhcp 75.0
 github.com/devplayer0/docker-net-dhcp/cmd/udhcpc-handler 50.0

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	dNetwork "github.com/docker/docker/api/types/network"
-	docker "github.com/docker/docker/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
@@ -67,7 +66,7 @@ func closeNetHandle(h *netlink.Handle) {
 }
 
 type dhcpManager struct {
-	docker  *docker.Client
+	docker  dockerClient
 	joinReq JoinRequest
 	opts    DHCPNetworkOptions
 
@@ -116,7 +115,7 @@ type dhcpManager struct {
 	startErr  error
 }
 
-func newDHCPManager(docker *docker.Client, r JoinRequest, opts DHCPNetworkOptions) *dhcpManager {
+func newDHCPManager(docker dockerClient, r JoinRequest, opts DHCPNetworkOptions) *dhcpManager {
 	return &dhcpManager{
 		docker:  docker,
 		joinReq: r,

--- a/pkg/plugin/docker_client.go
+++ b/pkg/plugin/docker_client.go
@@ -1,0 +1,21 @@
+package plugin
+
+import (
+	"context"
+
+	dContainer "github.com/docker/docker/api/types/container"
+	dNetwork "github.com/docker/docker/api/types/network"
+)
+
+// dockerClient is the narrow slice of the Docker API client the plugin
+// actually uses. Depending on the interface (rather than the concrete
+// *client.Client) lets tests inject a fake and exercise the error arms
+// of the recovery / option-fallback paths, which integration cannot
+// reach without a real daemon misbehaving. The concrete client
+// satisfies this interface as-is.
+type dockerClient interface {
+	NetworkList(ctx context.Context, options dNetwork.ListOptions) ([]dNetwork.Summary, error)
+	NetworkInspect(ctx context.Context, networkID string, options dNetwork.InspectOptions) (dNetwork.Inspect, error)
+	ContainerInspect(ctx context.Context, containerID string) (dContainer.InspectResponse, error)
+	Close() error
+}

--- a/pkg/plugin/docker_client_test.go
+++ b/pkg/plugin/docker_client_test.go
@@ -234,6 +234,21 @@ func TestLookupEndpointMAC(t *testing.T) {
 	}
 }
 
+func TestReacquireEndpoint_MACLookupError(t *testing.T) {
+	// Non-ipvlan mode looks up the original MAC first; a docker failure
+	// there must abort before the CreateEndpoint replay (which needs a
+	// live netns and is integration-covered).
+	f := &fakeDocker{inspectErr: errors.New("inspect boom")}
+	p := &Plugin{docker: f}
+
+	err := p.reacquireEndpoint(context.Background(),
+		JoinRequest{NetworkID: "n1", EndpointID: "ep1"},
+		DHCPNetworkOptions{Bridge: "br0"})
+	if err == nil {
+		t.Fatal("expected error when endpoint MAC lookup fails")
+	}
+}
+
 func TestInitialDHCPHostname_Success(t *testing.T) {
 	const netID, epID = "n1", "ep1"
 	f := &fakeDocker{

--- a/pkg/plugin/docker_client_test.go
+++ b/pkg/plugin/docker_client_test.go
@@ -1,0 +1,296 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	dContainer "github.com/docker/docker/api/types/container"
+	dNetwork "github.com/docker/docker/api/types/network"
+)
+
+const testDHCPDriver = "claymore666/docker-net-dhcp:latest"
+
+// fakeDocker is a programmable dockerClient for exercising the error
+// arms of the recovery, option-fallback and hostname-lookup paths,
+// which integration cannot reach without a real daemon misbehaving.
+type fakeDocker struct {
+	listResult []dNetwork.Summary
+	listErr    error
+
+	inspectResult map[string]dNetwork.Inspect
+	inspectErr    error
+
+	containerResult map[string]dContainer.InspectResponse
+	containerErr    error
+
+	closeErr error
+
+	listCalls      int
+	inspectCalls   int
+	containerCalls int
+}
+
+func (f *fakeDocker) NetworkList(_ context.Context, _ dNetwork.ListOptions) ([]dNetwork.Summary, error) {
+	f.listCalls++
+	return f.listResult, f.listErr
+}
+
+func (f *fakeDocker) NetworkInspect(_ context.Context, id string, _ dNetwork.InspectOptions) (dNetwork.Inspect, error) {
+	f.inspectCalls++
+	if f.inspectErr != nil {
+		return dNetwork.Inspect{}, f.inspectErr
+	}
+	return f.inspectResult[id], nil
+}
+
+func (f *fakeDocker) ContainerInspect(_ context.Context, id string) (dContainer.InspectResponse, error) {
+	f.containerCalls++
+	if f.containerErr != nil {
+		return dContainer.InspectResponse{}, f.containerErr
+	}
+	return f.containerResult[id], nil
+}
+
+func (f *fakeDocker) Close() error { return f.closeErr }
+
+func TestRecoverEndpoints_NetworkListError(t *testing.T) {
+	f := &fakeDocker{listErr: errors.New("list boom")}
+	p := &Plugin{docker: f}
+
+	p.recoverEndpoints(context.Background())
+
+	if got := p.recoveryFailed.Load(); got != 1 {
+		t.Fatalf("recoveryFailed: got %d want 1", got)
+	}
+	if f.inspectCalls != 0 {
+		t.Fatalf("NetworkInspect should not be called after list failure (got %d)", f.inspectCalls)
+	}
+}
+
+func TestRecoverEndpoints_SkipsNonDHCPNetworks(t *testing.T) {
+	f := &fakeDocker{listResult: []dNetwork.Summary{{ID: "n1", Driver: "bridge"}}}
+	p := &Plugin{docker: f}
+
+	p.recoverEndpoints(context.Background())
+
+	if got := p.recoveryFailed.Load(); got != 0 {
+		t.Fatalf("recoveryFailed: got %d want 0", got)
+	}
+	if f.inspectCalls != 0 {
+		t.Fatalf("non-DHCP network should be skipped before NetworkInspect (got %d)", f.inspectCalls)
+	}
+}
+
+func TestRecoverEndpoints_NetworkInspectError(t *testing.T) {
+	f := &fakeDocker{
+		listResult: []dNetwork.Summary{{ID: "n1", Driver: testDHCPDriver}},
+		inspectErr: errors.New("inspect boom"),
+	}
+	p := &Plugin{docker: f}
+
+	p.recoverEndpoints(context.Background())
+
+	if got := p.recoveryFailed.Load(); got != 1 {
+		t.Fatalf("recoveryFailed: got %d want 1", got)
+	}
+}
+
+func TestRecoverEndpoints_NetOptionsDecodeError(t *testing.T) {
+	withStateDir(t, t.TempDir()) // force the on-disk miss -> docker fallback
+	f := &fakeDocker{
+		listResult: []dNetwork.Summary{{ID: "n1", Driver: testDHCPDriver}},
+		inspectResult: map[string]dNetwork.Inspect{
+			"n1": {ID: "n1", Driver: testDHCPDriver, Options: map[string]string{"bogus_unknown_key": "x"}},
+		},
+	}
+	p := &Plugin{docker: f}
+
+	p.recoverEndpoints(context.Background())
+
+	if got := p.recoveryFailed.Load(); got != 1 {
+		t.Fatalf("recoveryFailed: got %d want 1 (decode of unknown option should fail)", got)
+	}
+}
+
+func TestNetOptions_DiskHitSkipsDocker(t *testing.T) {
+	withStateDir(t, t.TempDir())
+	want := DHCPNetworkOptions{Bridge: "br0"}
+	if err := saveOptions("n1", want); err != nil {
+		t.Fatalf("saveOptions: %v", err)
+	}
+	// Docker errors on any call, proving the disk hit short-circuits it.
+	f := &fakeDocker{inspectErr: errors.New("docker must not be called")}
+	p := &Plugin{docker: f}
+
+	got, err := p.netOptions(context.Background(), "n1")
+	if err != nil {
+		t.Fatalf("netOptions: %v", err)
+	}
+	if got.Bridge != want.Bridge {
+		t.Fatalf("opts: got %+v want %+v", got, want)
+	}
+	if f.inspectCalls != 0 {
+		t.Fatalf("disk hit must not call NetworkInspect (got %d)", f.inspectCalls)
+	}
+}
+
+func TestNetOptions_DockerFallbackSuccessAndBackfill(t *testing.T) {
+	withStateDir(t, t.TempDir())
+	f := &fakeDocker{
+		inspectResult: map[string]dNetwork.Inspect{
+			"n1": {ID: "n1", Driver: testDHCPDriver, Options: map[string]string{"bridge": "br9"}},
+		},
+	}
+	p := &Plugin{docker: f}
+
+	got, err := p.netOptions(context.Background(), "n1")
+	if err != nil {
+		t.Fatalf("netOptions: %v", err)
+	}
+	if got.Bridge != "br9" {
+		t.Fatalf("opts: got %+v want bridge=br9", got)
+	}
+	// Backfill: the next load should now hit disk without touching docker.
+	if _, err := loadOptions("n1"); err != nil {
+		t.Fatalf("expected options backfilled to disk, loadOptions: %v", err)
+	}
+}
+
+func TestNetOptions_DockerInspectError(t *testing.T) {
+	withStateDir(t, t.TempDir())
+	f := &fakeDocker{inspectErr: errors.New("inspect boom")}
+	p := &Plugin{docker: f}
+
+	if _, err := p.netOptions(context.Background(), "n1"); err == nil {
+		t.Fatal("expected error when disk misses and NetworkInspect fails")
+	}
+}
+
+func TestNetOptions_DockerDecodeError(t *testing.T) {
+	withStateDir(t, t.TempDir())
+	f := &fakeDocker{
+		inspectResult: map[string]dNetwork.Inspect{
+			"n1": {ID: "n1", Driver: testDHCPDriver, Options: map[string]string{"bogus_unknown_key": "x"}},
+		},
+	}
+	p := &Plugin{docker: f}
+
+	if _, err := p.netOptions(context.Background(), "n1"); err == nil {
+		t.Fatal("expected parse error for unknown option key")
+	}
+}
+
+func TestLookupEndpointMAC(t *testing.T) {
+	const netID, epID = "n1", "ep1"
+	cases := []struct {
+		name    string
+		f       *fakeDocker
+		wantMAC string
+		wantErr bool
+	}{
+		{
+			name:    "inspect_error",
+			f:       &fakeDocker{inspectErr: errors.New("boom")},
+			wantErr: true,
+		},
+		{
+			name: "endpoint_not_found",
+			f: &fakeDocker{inspectResult: map[string]dNetwork.Inspect{
+				netID: {Containers: map[string]dNetwork.EndpointResource{
+					"c1": {EndpointID: "other", MacAddress: "aa:bb:cc:dd:ee:ff"},
+				}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "found",
+			f: &fakeDocker{inspectResult: map[string]dNetwork.Inspect{
+				netID: {Containers: map[string]dNetwork.EndpointResource{
+					"c1": {EndpointID: epID, MacAddress: "aa:bb:cc:dd:ee:ff"},
+				}},
+			}},
+			wantMAC: "aa:bb:cc:dd:ee:ff",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := &Plugin{docker: c.f}
+			mac, err := p.lookupEndpointMAC(context.Background(), netID, epID)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got mac=%q", mac)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if mac != c.wantMAC {
+				t.Fatalf("mac: got %q want %q", mac, c.wantMAC)
+			}
+		})
+	}
+}
+
+func TestInitialDHCPHostname_Success(t *testing.T) {
+	const netID, epID = "n1", "ep1"
+	f := &fakeDocker{
+		inspectResult: map[string]dNetwork.Inspect{
+			netID: {Containers: map[string]dNetwork.EndpointResource{
+				"realctr": {EndpointID: epID},
+			}},
+		},
+		containerResult: map[string]dContainer.InspectResponse{
+			"realctr": {Config: &dContainer.Config{Hostname: "myhost"}},
+		},
+	}
+	p := &Plugin{docker: f}
+
+	if got := p.initialDHCPHostname(context.Background(), netID, epID); got != "myhost" {
+		t.Fatalf("hostname: got %q want myhost", got)
+	}
+}
+
+func TestInitialDHCPHostname_EmptyOnFailure(t *testing.T) {
+	const netID, epID = "n1", "ep1"
+	cases := []struct {
+		name string
+		f    *fakeDocker
+	}{
+		{
+			name: "network_inspect_error",
+			f:    &fakeDocker{inspectErr: errors.New("boom")},
+		},
+		{
+			name: "container_inspect_error",
+			f: &fakeDocker{
+				inspectResult: map[string]dNetwork.Inspect{
+					netID: {Containers: map[string]dNetwork.EndpointResource{"realctr": {EndpointID: epID}}},
+				},
+				containerErr: errors.New("boom"),
+			},
+		},
+		{
+			name: "endpoint_placeholder_not_yet_bound",
+			f: &fakeDocker{
+				inspectResult: map[string]dNetwork.Inspect{
+					netID: {Containers: map[string]dNetwork.EndpointResource{"ep-" + epID: {EndpointID: epID}}},
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Short deadline so the poll loop gives up quickly instead of
+			// waiting the full initialDHCPHostnameLookupTimeout.
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+			defer cancel()
+			p := &Plugin{docker: c.f}
+			if got := p.initialDHCPHostname(ctx, netID, epID); got != "" {
+				t.Fatalf("hostname: got %q want empty", got)
+			}
+		})
+	}
+}

--- a/pkg/plugin/netlink_seam.go
+++ b/pkg/plugin/netlink_seam.go
@@ -13,3 +13,11 @@ var (
 	nlLinkDel           = netlink.LinkDel
 	nlRouteListFiltered = netlink.RouteListFiltered
 )
+
+// linkLister is the subset of *netlink.Handle that findLinkByMAC needs.
+// Taking the interface (not the concrete handle) lets the MAC-walk logic
+// be unit-tested without a live netns handle; *netlink.Handle satisfies
+// it as-is.
+type linkLister interface {
+	LinkList() ([]netlink.Link, error)
+}

--- a/pkg/plugin/netlink_seam.go
+++ b/pkg/plugin/netlink_seam.go
@@ -1,0 +1,15 @@
+package plugin
+
+import "github.com/vishvananda/netlink"
+
+// Indirection over the package-level netlink calls the plugin makes, so
+// unit tests can inject failures or synthetic results for error paths
+// that otherwise require CAP_NET_ADMIN and a live network namespace
+// (and so are only reachable via the integration suite). Production code
+// calls these vars; tests swap them out and restore in t.Cleanup. No
+// behavioural change — each var is just the netlink function it names.
+var (
+	nlLinkByName        = netlink.LinkByName
+	nlLinkDel           = netlink.LinkDel
+	nlRouteListFiltered = netlink.RouteListFiltered
+)

--- a/pkg/plugin/netlink_seam_test.go
+++ b/pkg/plugin/netlink_seam_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"github.com/devplayer0/docker-net-dhcp/pkg/util"
 )
@@ -169,6 +170,108 @@ func TestAddRoutes_DefaultGatewayV4(t *testing.T) {
 	if res.Gateway != "192.168.0.1" {
 		t.Fatalf("gateway: got %q want 192.168.0.1", res.Gateway)
 	}
+}
+
+func TestAddRoutes_DefaultGatewayV6(t *testing.T) {
+	stubRouteList(t, []netlink.Route{
+		{Dst: nil, Gw: net.ParseIP("fe80::1")},
+	}, nil)
+	p := &Plugin{}
+	res := &JoinResponse{}
+	if err := p.addRoutes(&DHCPNetworkOptions{}, true, &fakeLink{}, JoinRequest{}, joinHint{}, res); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.GatewayIPv6 != "fe80::1" {
+		t.Fatalf("v6 gateway: got %q want fe80::1", res.GatewayIPv6)
+	}
+}
+
+func TestAddRoutes_SkipRoutesDropsStatic(t *testing.T) {
+	_, dst, _ := net.ParseCIDR("10.0.0.0/8")
+	stubRouteList(t, []netlink.Route{
+		{Dst: dst, Gw: net.IPv4(192, 168, 0, 254)},
+	}, nil)
+	p := &Plugin{}
+	res := &JoinResponse{}
+	if err := p.addRoutes(&DHCPNetworkOptions{SkipRoutes: true}, false, &fakeLink{}, JoinRequest{}, joinHint{}, res); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.StaticRoutes) != 0 {
+		t.Fatalf("skip_routes should drop static routes, got %d", len(res.StaticRoutes))
+	}
+}
+
+func TestAddRoutes_KernelRouteSkipped(t *testing.T) {
+	_, dst, _ := net.ParseCIDR("10.0.0.0/8")
+	stubRouteList(t, []netlink.Route{
+		{Dst: dst, Protocol: unix.RTPROT_KERNEL},
+	}, nil)
+	p := &Plugin{}
+	res := &JoinResponse{}
+	// hint left empty: the kernel-protocol check short-circuits before
+	// the hint deref.
+	if err := p.addRoutes(&DHCPNetworkOptions{}, false, &fakeLink{}, JoinRequest{}, joinHint{}, res); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.StaticRoutes) != 0 {
+		t.Fatalf("kernel route should be skipped, got %d static routes", len(res.StaticRoutes))
+	}
+}
+
+func TestAddRoutes_OnLinkRoute(t *testing.T) {
+	_, dst, _ := net.ParseCIDR("10.0.0.0/8")
+	stubRouteList(t, []netlink.Route{
+		{Dst: dst}, // no Gw -> on-link
+	}, nil)
+	p := &Plugin{}
+	res := &JoinResponse{}
+	hint := joinHint{IPv4: &netlink.Addr{IPNet: &net.IPNet{IP: net.IPv4(192, 168, 0, 50), Mask: net.CIDRMask(24, 32)}}}
+	if err := p.addRoutes(&DHCPNetworkOptions{}, false, &fakeLink{}, JoinRequest{}, hint, res); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.StaticRoutes) != 1 || res.StaticRoutes[0].RouteType != RouteTypeOnLink {
+		t.Fatalf("expected one on-link route, got %+v", res.StaticRoutes)
+	}
+}
+
+type fakeLinkLister struct {
+	links []netlink.Link
+	err   error
+}
+
+func (f fakeLinkLister) LinkList() ([]netlink.Link, error) { return f.links, f.err }
+
+func TestFindLinkByMAC(t *testing.T) {
+	mac, _ := net.ParseMAC("aa:bb:cc:dd:ee:ff")
+	other, _ := net.ParseMAC("11:22:33:44:55:66")
+	match := &fakeLink{typ: "macvlan", attrs: netlink.LinkAttrs{HardwareAddr: mac}}
+
+	t.Run("list_error", func(t *testing.T) {
+		_, err := findLinkByMAC(fakeLinkLister{err: errors.New("boom")}, mac)
+		if err == nil {
+			t.Fatal("expected error when LinkList fails")
+		}
+	})
+	t.Run("no_match", func(t *testing.T) {
+		_, err := findLinkByMAC(fakeLinkLister{links: []netlink.Link{
+			&fakeLink{typ: "device", attrs: netlink.LinkAttrs{HardwareAddr: other}},
+		}}, mac)
+		if err == nil {
+			t.Fatal("expected error when no link matches the MAC")
+		}
+	})
+	t.Run("found", func(t *testing.T) {
+		got, err := findLinkByMAC(fakeLinkLister{links: []netlink.Link{
+			&fakeLink{typ: "device", attrs: netlink.LinkAttrs{HardwareAddr: other}},
+			match,
+		}}, mac)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != match {
+			t.Fatalf("got wrong link: %+v", got)
+		}
+	})
 }
 
 func TestAddRoutes_StaticNextHopV4(t *testing.T) {

--- a/pkg/plugin/netlink_seam_test.go
+++ b/pkg/plugin/netlink_seam_test.go
@@ -1,0 +1,192 @@
+package plugin
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/devplayer0/docker-net-dhcp/pkg/util"
+)
+
+// fakeLink is a minimal netlink.Link for driving the type/flags-dependent
+// branches of validateParentForChild and the route helpers without a real
+// interface.
+type fakeLink struct {
+	attrs netlink.LinkAttrs
+	typ   string
+}
+
+func (f *fakeLink) Attrs() *netlink.LinkAttrs { return &f.attrs }
+func (f *fakeLink) Type() string              { return f.typ }
+
+// stubLinkByName swaps nlLinkByName for the test's duration.
+func stubLinkByName(t *testing.T, fn func(string) (netlink.Link, error)) {
+	t.Helper()
+	prev := nlLinkByName
+	nlLinkByName = fn
+	t.Cleanup(func() { nlLinkByName = prev })
+}
+
+func TestValidateParentForChild(t *testing.T) {
+	cases := []struct {
+		name    string
+		link    netlink.Link
+		lookErr error
+		wantErr error
+		wantOK  bool
+	}{
+		{
+			name:    "lookup_failure",
+			lookErr: errors.New("no such device"),
+			wantErr: nil, // wrapped generic error, just expect non-nil
+		},
+		{
+			name:    "reject_bridge",
+			link:    &fakeLink{typ: "bridge"},
+			wantErr: util.ErrParentInvalid,
+		},
+		{
+			name:    "reject_macvlan",
+			link:    &fakeLink{typ: "macvlan"},
+			wantErr: util.ErrParentInvalid,
+		},
+		{
+			name:    "reject_ipvlan",
+			link:    &fakeLink{typ: "ipvlan"},
+			wantErr: util.ErrParentInvalid,
+		},
+		{
+			name:    "reject_macvtap",
+			link:    &fakeLink{typ: "macvtap"},
+			wantErr: util.ErrParentInvalid,
+		},
+		{
+			name:    "parent_down",
+			link:    &fakeLink{typ: "device", attrs: netlink.LinkAttrs{Flags: 0}},
+			wantErr: util.ErrParentDown,
+		},
+		{
+			name:   "ok_device_up",
+			link:   &fakeLink{typ: "device", attrs: netlink.LinkAttrs{Flags: net.FlagUp}},
+			wantOK: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			stubLinkByName(t, func(string) (netlink.Link, error) {
+				return c.link, c.lookErr
+			})
+			link, err := validateParentForChild("parent0")
+			if c.wantOK {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if link == nil {
+					t.Fatal("expected a link, got nil")
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if c.wantErr != nil && !errors.Is(err, c.wantErr) {
+				t.Fatalf("expected errors.Is(%v), got %v", c.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestDeleteParentAttachedEndpoint(t *testing.T) {
+	t.Run("link_already_gone", func(t *testing.T) {
+		stubLinkByName(t, func(string) (netlink.Link, error) {
+			return nil, errors.New("not found")
+		})
+		p := &Plugin{}
+		if err := p.deleteParentAttachedEndpoint(DeleteEndpointRequest{NetworkID: "n1", EndpointID: "ep1"}); err != nil {
+			t.Fatalf("expected nil (link gone is expected), got %v", err)
+		}
+	})
+
+	t.Run("link_del_error", func(t *testing.T) {
+		stubLinkByName(t, func(string) (netlink.Link, error) {
+			return &fakeLink{typ: "macvlan"}, nil
+		})
+		prev := nlLinkDel
+		nlLinkDel = func(netlink.Link) error { return errors.New("del boom") }
+		t.Cleanup(func() { nlLinkDel = prev })
+
+		p := &Plugin{}
+		if err := p.deleteParentAttachedEndpoint(DeleteEndpointRequest{NetworkID: "n1", EndpointID: "ep1"}); err == nil {
+			t.Fatal("expected error when LinkDel fails")
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		stubLinkByName(t, func(string) (netlink.Link, error) {
+			return &fakeLink{typ: "macvlan"}, nil
+		})
+		prev := nlLinkDel
+		nlLinkDel = func(netlink.Link) error { return nil }
+		t.Cleanup(func() { nlLinkDel = prev })
+
+		p := &Plugin{}
+		if err := p.deleteParentAttachedEndpoint(DeleteEndpointRequest{NetworkID: "n1", EndpointID: "ep1"}); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	})
+}
+
+func stubRouteList(t *testing.T, routes []netlink.Route, err error) {
+	t.Helper()
+	prev := nlRouteListFiltered
+	nlRouteListFiltered = func(int, *netlink.Route, uint64) ([]netlink.Route, error) {
+		return routes, err
+	}
+	t.Cleanup(func() { nlRouteListFiltered = prev })
+}
+
+func TestAddRoutes_ListError(t *testing.T) {
+	stubRouteList(t, nil, errors.New("list boom"))
+	p := &Plugin{}
+	res := &JoinResponse{}
+	err := p.addRoutes(&DHCPNetworkOptions{}, false, &fakeLink{}, JoinRequest{}, joinHint{}, res)
+	if err == nil {
+		t.Fatal("expected error when RouteListFiltered fails")
+	}
+}
+
+func TestAddRoutes_DefaultGatewayV4(t *testing.T) {
+	stubRouteList(t, []netlink.Route{
+		{Dst: nil, Gw: net.IPv4(192, 168, 0, 1)}, // default route
+	}, nil)
+	p := &Plugin{}
+	res := &JoinResponse{}
+	if err := p.addRoutes(&DHCPNetworkOptions{}, false, &fakeLink{}, JoinRequest{}, joinHint{}, res); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Gateway != "192.168.0.1" {
+		t.Fatalf("gateway: got %q want 192.168.0.1", res.Gateway)
+	}
+}
+
+func TestAddRoutes_StaticNextHopV4(t *testing.T) {
+	_, dst, _ := net.ParseCIDR("10.0.0.0/8")
+	stubRouteList(t, []netlink.Route{
+		{Dst: dst, Gw: net.IPv4(192, 168, 0, 254)},
+	}, nil)
+	p := &Plugin{}
+	res := &JoinResponse{}
+	// hint.IPv4 must be set: the route-skip check dereferences it for v4.
+	hint := joinHint{IPv4: &netlink.Addr{IPNet: &net.IPNet{IP: net.IPv4(192, 168, 0, 50), Mask: net.CIDRMask(24, 32)}}}
+	if err := p.addRoutes(&DHCPNetworkOptions{}, false, &fakeLink{}, JoinRequest{}, hint, res); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.StaticRoutes) != 1 {
+		t.Fatalf("static routes: got %d want 1", len(res.StaticRoutes))
+	}
+	if res.StaticRoutes[0].RouteType != RouteTypeNextHop || res.StaticRoutes[0].NextHop != "192.168.0.254" {
+		t.Fatalf("static route: got %+v", res.StaticRoutes[0])
+	}
+}

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -733,7 +733,7 @@ func (p *Plugin) addRoutes(opts *DHCPNetworkOptions, v6 bool, link netlink.Link,
 		family = unix.AF_INET6
 	}
 
-	routes, err := netlink.RouteListFiltered(family, &netlink.Route{
+	routes, err := nlRouteListFiltered(family, &netlink.Route{
 		LinkIndex: link.Attrs().Index,
 		Type:      unix.RTN_UNICAST,
 	}, netlink.RT_FILTER_OIF|netlink.RT_FILTER_TYPE)

--- a/pkg/plugin/network_test.go
+++ b/pkg/plugin/network_test.go
@@ -34,6 +34,11 @@ func TestValidateModeOptions(t *testing.T) {
 			wantErr: util.ErrModeMismatch,
 		},
 		{
+			name:    "bridge_mode_validate_dhcp_rejected",
+			opts:    DHCPNetworkOptions{Mode: ModeBridge, Bridge: "br0", ValidateDHCP: true},
+			wantErr: util.ErrModeMismatch,
+		},
+		{
 			name:    "default_mode_missing_bridge",
 			opts:    DHCPNetworkOptions{},
 			wantErr: util.ErrBridgeRequired,
@@ -237,6 +242,16 @@ func TestResolveExplicitV4(t *testing.T) {
 				Interface: &EndpointInterface{Address: "192.168.0.50/24"},
 				Options:   map[string]interface{}{"ip": "192.168.0.51"},
 			},
+			wantErr: true,
+		},
+		{
+			name:    "invalid_iface_address",
+			r:       CreateEndpointRequest{Interface: &EndpointInterface{Address: "not-an-ip"}},
+			wantErr: true,
+		},
+		{
+			name:    "invalid_driver_opt_ip",
+			r:       CreateEndpointRequest{Options: map[string]interface{}{"ip": "not-an-ip"}},
 			wantErr: true,
 		},
 	}

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -44,7 +44,7 @@ func subLinkName(endpointID string) string {
 // a bridge or another macvlan/ipvlan). We do not change the parent's
 // state — the host's NIC config is off-limits.
 func validateParentForChild(name string) (netlink.Link, error) {
-	link, err := netlink.LinkByName(name)
+	link, err := nlLinkByName(name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to lookup parent interface %v: %w", name, err)
 	}
@@ -315,7 +315,7 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 // and ipvlan since they live under the same name.
 func (p *Plugin) deleteParentAttachedEndpoint(r DeleteEndpointRequest) error {
 	name := subLinkName(r.EndpointID)
-	link, err := netlink.LinkByName(name)
+	link, err := nlLinkByName(name)
 	if err != nil {
 		// Expected: the link is gone with the container netns.
 		log.WithFields(log.Fields{
@@ -324,7 +324,7 @@ func (p *Plugin) deleteParentAttachedEndpoint(r DeleteEndpointRequest) error {
 		}).Debug("Child link already gone (expected)")
 		return nil
 	}
-	if err := netlink.LinkDel(link); err != nil {
+	if err := nlLinkDel(link); err != nil {
 		return fmt.Errorf("failed to delete leftover child link %v: %w", name, err)
 	}
 	log.WithFields(log.Fields{

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -338,7 +338,7 @@ func (p *Plugin) deleteParentAttachedEndpoint(r DeleteEndpointRequest) error {
 // container's netns handle) and returns the link with the given hardware
 // address. Used to re-discover a macvlan child after Docker has moved and
 // renamed it inside the container.
-func findLinkByMAC(handle *netlink.Handle, mac net.HardwareAddr) (netlink.Link, error) {
+func findLinkByMAC(handle linkLister, mac net.HardwareAddr) (netlink.Link, error) {
 	links, err := handle.LinkList()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list links: %w", err)

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -254,7 +254,7 @@ type Plugin struct {
 	awaitTimeout time.Duration
 	startTime    time.Time
 
-	docker *docker.Client
+	docker dockerClient
 	server http.Server
 
 	// mu guards joinHints, persistentDHCP, and endpointFingerprints.

--- a/pkg/util/docker.go
+++ b/pkg/util/docker.go
@@ -5,18 +5,24 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
 )
 
 const (
 	OptionsKeyGeneric = "com.docker.network.generic"
 )
 
+// ContainerInspector is the one Docker-client method AwaitContainerInspect
+// needs. Taking an interface (not the concrete *client.Client) lets callers
+// inject a fake in tests; the real client satisfies it as-is.
+type ContainerInspector interface {
+	ContainerInspect(ctx context.Context, id string) (container.InspectResponse, error)
+}
+
 // AwaitContainerInspect polls docker.ContainerInspect until it succeeds,
 // ctx is cancelled, or interval-paced retries exhaust. Synchronous for
 // the same reason as AwaitNetNS — the previous async form leaked a
 // poller goroutine on ctx-cancel that kept hitting the Docker API forever.
-func AwaitContainerInspect(ctx context.Context, docker *client.Client, id string, interval time.Duration) (container.InspectResponse, error) {
+func AwaitContainerInspect(ctx context.Context, docker ContainerInspector, id string, interval time.Duration) (container.InspectResponse, error) {
 	var dummy container.InspectResponse
 	for {
 		ctr, err := docker.ContainerInspect(ctx, id)

--- a/pkg/util/json_test.go
+++ b/pkg/util/json_test.go
@@ -80,6 +80,38 @@ func TestJSONErrResponse_ExplicitStatusOverrides(t *testing.T) {
 	}
 }
 
+// The log-severity switch picks Error/Warn/Info by status class; these
+// two cover the >=500 and <400 arms (the 4xx arm is covered above).
+func TestJSONErrResponse_ServerErrorClass(t *testing.T) {
+	rec := httptest.NewRecorder()
+	JSONErrResponse(rec, errors.New("boom"), http.StatusInternalServerError)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d want 500", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/problem+json" {
+		t.Fatalf("content-type: got %q", ct)
+	}
+	var out struct {
+		Err string `json:"Err"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Err != "boom" {
+		t.Fatalf("err body: got %q", out.Err)
+	}
+}
+
+func TestJSONErrResponse_NonErrorClass(t *testing.T) {
+	rec := httptest.NewRecorder()
+	JSONErrResponse(rec, errors.New("informational"), http.StatusOK)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", rec.Code)
+	}
+}
+
 func TestParseJSONOrErrorResponse_OK(t *testing.T) {
 	body := strings.NewReader(`{"name":"foo"}`)
 	req := httptest.NewRequest(http.MethodPost, "/", body)


### PR DESCRIPTION
## What this changes

Tightens unit-level test coverage of the plugin's **error paths** by introducing two narrow test seams, so failure arms that previously only ran under integration (or were unreachable without a misbehaving daemon / `CAP_NET_ADMIN`) are now exercised in fast unit tests.

- **Docker-client seam:** a minimal `dockerClient` interface (`Close`, `ContainerInspect`, `NetworkInspect`, `NetworkList`) replaces the concrete `*client.Client` on `Plugin`/`dhcpManager`; `util.AwaitContainerInspect` now takes a `ContainerInspector`. A fake client drives the error arms of `netOptions` (docker fallback + decode), `recoverEndpoints`, `lookupEndpointMAC`, and `initialDHCPHostname`.
- **Netlink seam:** the package-level netlink calls in `validateParentForChild`, `deleteParentAttachedEndpoint`, and `addRoutes` become overridable function vars; tests inject failures and synthetic links/routes (parent-type rejection, parent-down, link-del failure, route-list failure, default-gateway and static next-hop extraction).
- **Pure helpers:** remaining branches in `resolveExplicitV4`, `validateModeOptions`, and `JSONErrResponse`.

No behavioural change to production code — each seam var *is* the netlink function it replaces, and the real docker client satisfies the new interface as-is.

Local unit coverage: `pkg/plugin` 32.6% → 40.1%, `pkg/util` 62.9% → 66.1% (race suite green, gofmt/vet/staticcheck clean).

## Baseline raise (follow-up commit on this PR)

The committed floors in `.github/coverage-baseline.txt` are **merged unit+integration** numbers, which only the Coverage workflow can measure. I'll raise the floors to the CI-measured merged values (with epsilon headroom) in a follow-up commit on this PR once the Coverage job reports them — rather than guess from unit-only numbers. Per the v1.0.0 recorded decision, the intent is to ratchet `pkg/plugin` back up toward ~82.

Test design recorded on the issue before code: #206 (comment).

## Related issue

Refs #206

## Checklist

- [x] Branched off and targets `dev` (not `main`)
- [x] Tests added/updated for the change (the coverage ratchet is enforced at release)
- [x] Unit tests, `staticcheck` pass locally; integration runs in CI on this PR
- [x] Docs — n/a (no behaviour or option changes; test-only + internal seams)
- [x] No secrets, credentials, or internal host details in the diff
