### PR TITLE
docs: restructure README into a concise landing page + docs/ split (#205)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,75 +8,94 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/claymore666/docker-net-dhcp/badge)](https://scorecard.dev/viewer/?uri=github.com/claymore666/docker-net-dhcp)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13229/badge)](https://www.bestpractices.dev/projects/13229)
 
-> **This is a maintained fork** of [`devplayer0/docker-net-dhcp`][upstream].
-> The upstream repository has been quiet since 2021 and no longer builds on
-> current Docker. This fork modernises the toolchain (Go 1.26, docker SDK
-> v28, current Alpine), adds **macvlan** and **ipvlan** attachment modes,
-> fixes the daemon-restart deadlock, fixes a data race on the plugin's
-> internal state, and incorporates several open upstream PRs. As of v0.7.0
-> every PR is gated on a live integration suite that drives real DHCP
-> exchanges through all three modes plus recovery, tombstone-stability,
-> and concurrency scenarios; v1.0.0 adds dual-stack (DHCPv6) coverage
-> and a failure-injection suite (server loss, refused renewals, lease
-> expiry) asserting the degraded modes, plus a coverage ratchet and
-> supply-chain gates on every release.
->
-> See [`docs/reference.md`](docs/reference.md) for the complete driver
-> reference (all options, settings, observability, troubleshooting),
-> [`RELEASE_NOTES.md`](RELEASE_NOTES.md) for the full changelog and
-> credits, [`docs/parent-attached-modes.md`](docs/parent-attached-modes.md)
-> for the macvlan / ipvlan how-to, and
-> [`docs/release-runbook.md`](docs/release-runbook.md) for the
-> publish-a-new-version procedure (maintainer-facing).
->
-> Install:
-> ```bash
-> docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.1
-> ```
->
-> All upstream usage below still applies — bridge mode is unchanged and
-> remains the default. The maintained image lives at
-> `ghcr.io/claymore666/docker-net-dhcp` instead of `ghcr.io/devplayer0/...`.
+A Docker network plugin that allocates container IP addresses (IPv4 and
+optionally IPv6) from an **existing DHCP server** — your router, a
+Fritz!Box, dnsmasq, anything — instead of Docker's self-managed IPAM
+pools. Containers come up on your LAN as first-class hosts, addressable
+like any other machine. Bridge, macvlan, and ipvlan attachment modes.
+
+> **This is a maintained fork** of [`devplayer0/docker-net-dhcp`][upstream]
+> (quiet since 2021, no longer builds on current Docker). This fork
+> modernises the toolchain (Go 1.26, docker SDK v28, current Alpine),
+> adds **macvlan** and **ipvlan** modes, fixes the daemon-restart
+> deadlock and a state data-race, and gates every PR on a live
+> integration suite (all three modes + DHCPv6, recovery, failure
+> injection) with a coverage ratchet and supply-chain gates on release.
+> The maintained image lives at `ghcr.io/claymore666/docker-net-dhcp`.
 
 [upstream]: https://github.com/devplayer0/docker-net-dhcp
 
----
+## Quick start
 
-`docker-net-dhcp` is a Docker plugin providing a network driver which allocates IP addresses (IPv4 and optionally IPv6)
-via an existing DHCP server (e.g. your router).
+Install the plugin:
 
-When configured correctly, this allows you to spin up a container (e.g. `docker run ...` or `docker-compose up ...`) and
-access it on your network as if it was any other machine! _Probably_ not a great idea for production, but it's pretty
-handy for home deployment.
-
-# Usage
-
-## Installation
-
-The plugin can be installed with the `docker plugin install` command:
-
-```
-$ docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.1
-Plugin "ghcr.io/claymore666/docker-net-dhcp:v1.1.1" is requesting the following privileges:
- - network: [host]
- - host pid namespace: [true]
- - mount: [/var/run/docker.sock]
- - capabilities: [CAP_NET_ADMIN CAP_SYS_ADMIN]
-Do you grant the above permissions? [y/N] y
-v1.1.1: Pulling from ghcr.io/claymore666/docker-net-dhcp
-Digest: sha256:<some hash>
-<some id>: Complete
-Installed plugin ghcr.io/claymore666/docker-net-dhcp:v1.1.1
-$
+```bash
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.1
 ```
 
-Note: If you get an error like `invalid rootfs in image configuration`, try upgrading your Docker installation.
+It requests `host` networking, the host PID namespace, the Docker
+socket, and `CAP_NET_ADMIN`/`CAP_SYS_ADMIN` — grant them to proceed.
+(If you hit `invalid rootfs in image configuration`, upgrade Docker.)
 
-## Other tags
+Create a bridge-mode network and run a container on it (assumes you
+already have a host bridge `my-bridge` on your LAN — see
+[bridge mode](docs/bridge-mode.md) for that one-time setup):
 
-This fork publishes semver-tagged plugin images on GitHub Container Registry: `ghcr.io/claymore666/docker-net-dhcp:vX.Y.Z`. See the [Releases page](https://github.com/claymore666/docker-net-dhcp/releases) for the changelog of each release.
+```bash
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
+  --ipam-driver null -o bridge=my-bridge my-dhcp-net
 
-Currently published architectures: `linux/amd64` only. ARM builds (multi-arch via `scripts/push_multiarch_plugin.py`) are supported by the build pipeline but not currently published — open an issue if you need one.
+docker run --rm -ti --network my-dhcp-net alpine ip address show
+```
+
+The `null` IPAM driver is **mandatory** — it stops Docker handing out
+addresses that would collide with the real LAN.
+
+## Attachment modes
+
+Selected by the `mode` driver option:
+
+| mode | parent | host changes required |
+| ---- | ------ | --------------------- |
+| `bridge` (default) | a Linux bridge you maintain (`-o bridge=<name>`) | yes — you bring the bridge |
+| `macvlan` | a host NIC (`-o parent=<iface>`) | none |
+| `ipvlan` (L2) | a host NIC (`-o parent=<iface>`) | none |
+
+macvlan/ipvlan attach directly to a host NIC without a bridge — the
+right pick when you don't want to reconfigure the host's networking.
+
+## Documentation
+
+- **[Driver reference](docs/reference.md)** — every option, plugin
+  setting, the `/Plugin.Health` observability endpoint, and
+  troubleshooting.
+- **[Bridge mode](docs/bridge-mode.md)** — host bridge setup +
+  end-to-end walkthrough.
+- **[macvlan / ipvlan modes](docs/parent-attached-modes.md)** — NIC
+  attachment, DHCP identity (hostname / option 60 / 61), restart
+  stability, recovery.
+- **[How it works](docs/internals.md)** — the veth + DHCP-client
+  mechanism and lease flow.
+- **[Changelog](RELEASE_NOTES.md)** — per-release notes and credits.
+- **[Release runbook](docs/release-runbook.md)** — maintainer-facing
+  publish procedure.
+
+## Project & community
+
+- **Contributing:** see [below](#contributing).
+- **Security policy / vulnerability reporting:** [SECURITY.md](SECURITY.md)
+  (do not open public issues for vulnerabilities).
+- **Bug reports & feature requests:** the
+  [issue forms](https://github.com/claymore666/docker-net-dhcp/issues/new/choose).
+- **Pull requests:** the
+  [PR template](.github/PULL_REQUEST_TEMPLATE.md) — target the `dev` branch.
+- **Governance & code of conduct:** [GOVERNANCE.md](GOVERNANCE.md),
+  [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+This fork publishes semver-tagged images on GHCR
+(`ghcr.io/claymore666/docker-net-dhcp:vX.Y.Z`, `linux/amd64`; ARM via
+the build pipeline on request). See the
+[Releases page](https://github.com/claymore666/docker-net-dhcp/releases).
 
 ## Verifying releases
 
@@ -98,184 +117,7 @@ cosign verify ghcr.io/claymore666/docker-net-dhcp:VERSION \
 gh attestation verify oci://ghcr.io/claymore666/docker-net-dhcp:VERSION --repo claymore666/docker-net-dhcp
 ```
 
-## Attachment modes
-
-The plugin supports three attachment modes, selected by the `mode` driver option:
-
-| mode | parent | host changes required |
-| ---- | ------ | --------------------- |
-| `bridge` (default) | a Linux bridge you maintain (`-o bridge=<name>`) | yes — you bring the bridge |
-| `macvlan` | a host NIC (`-o parent=<iface>`) | none |
-| `ipvlan` (L2) | a host NIC (`-o parent=<iface>`) | none |
-
-The bridge-mode walkthrough below is the original upstream flow. For
-macvlan/ipvlan see [`docs/parent-attached-modes.md`](docs/parent-attached-modes.md) — those modes
-attach directly to a host NIC without a bridge and are the right pick
-when you don't want to reconfigure the host's networking. The doc also
-covers DHCP identity (hostname / option 60 / option 61), the
-`/Plugin.Health` endpoint, restart stability, and recovery.
-
-## Network creation (bridge mode)
-
-In order to create a Docker network in bridge mode, you'll need a pre-configured bridge interface on the host. How you
-set this up will depend on your system, but the following (manual) instructions should work on most Linux distros:
-
-```
-# Create the bridge
-$ sudo ip link add my-bridge type bridge
-$ sudo ip link set my-bridge up
-
-# Assuming 'eth0' is connected to your LAN (where the DHCP server is)
-$ sudo ip link set eth0 up
-# Attach your network card to the bridge
-$ sudo ip link set eth0 master my-bridge
-
-# If your firewall's policy for forwarding is to drop packets, you'll need to add an ACCEPT rule
-$ sudo iptables -A FORWARD -i my-bridge -j ACCEPT
-
-# Get an IP for the host (will go out to the DHCP server since eth0 is attached to the bridge)
-# Replace this step with whatever network configuration you were using for eth0
-$ sudo dhcpcd my-bridge
-```
-
-Once the bridge is ready, you can create the network:
-
-```
-$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 --ipam-driver null -o bridge=my-bridge my-dhcp-net
-<some network id>
-$
-
-# With IPv6 enabled
-# Although `docker network create` has a `--ipv6` flag, it doesn't work with the null IPAM driver
-$ docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
-<some network id>
-$
-```
-
-_Note: The `null` IPAM driver **must** be used, or else Docker will try to allocate IP addresses from its choice of
-subnet - this can cause IP conflicts since the bridge is connected to your local network!_
-
-## Container creation
-
-Once you've set up a network, you can create some containers:
-
-```
-$ docker run --rm -ti --network my-dhcp-net alpine
-/ # ip address show
-1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1000
-    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
-    inet 127.0.0.1/8 scope host lo
-       valid_lft forever preferred_lft forever
-159: my-bridge0@if160: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc noqueue state UP qlen 1000
-    link/ether 86:41:68:f8:85:b9 brd ff:ff:ff:ff:ff:ff
-    inet 10.255.0.246/24 brd 10.255.0.255 scope global test0
-       valid_lft forever preferred_lft forever
-/ # ip route show
-default via 10.255.0.123 dev my-bridge0
-10.255.0.0/24 dev my-bridge0 scope link  src 10.255.0.246
-/ #
-```
-
-Or, in a Docker Compose file:
-
-```yaml
-version: '3'
-services:
-  app:
-    hostname: my-http
-    image: nginx
-    mac_address: 86:41:68:f8:85:b9
-    networks:
-      - dhcp
-networks:
-  dhcp:
-    external:
-      name: my-dhcp-net
-```
-
-The above Compose file assumes your network has already been created with `docker network create`. **This is the
-recommended way to use `docker-net-dhcp`**, since it allows the network to be shared among multiple compose projects and
-other containers. However, you can also create the network as part of the Compose definition. In this case Docker
-Compose will manage the network itself (for example deleting it when `docker-compose down` is run).
-
-```yaml
-version: '3'
-services:
-  app:
-    image: nginx
-    hostname: my-server
-    networks:
-      - dhcp
-networks:
-  dhcp:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.1.1
-    driver_opts:
-      bridge: my-bridge
-      ipv6: 'true'
-      ignore_conflicts: 'false'
-      skip_routes: 'false'
-    ipam:
-      driver: 'null'
-```
-
-Note:
- - It will take a bit longer than usual for the container to start, as a DHCP lease needs to be obtained before creating it
- - Once created, a persistent DHCP client will renew the DHCP lease (and then update the default gateway in the
-   container) when necessary - **this client runs separately from the container**
- - Use `--mac-address` to specify a MAC address if you've configured reserved IP addresses on your DHCP server, or if
-   you want a container to re-use an old lease
- - Add `--hostname my-host` to have the DHCP transmit this name as the host for the container. This is useful if your
-   DHCP server is configured to update DNS records from DHCP leases.
- - If the `docker run` command times out waiting for a lease, you can try increasing the initial timeout value by
-   passing `-o lease_timeout=60s` when creating the network (e.g. to increase to 60 seconds)
- - By default, a bridge can only be used for a single DHCP network. There is additionally a check to see if a bridge is
-	 is used by any other Docker networks. To disable this check (it's also possible this check might mistakenly detect a
-   conflict), pass `-o ignore_conflicts=true` when creating the network.
- - `docker-net-dhcp` will try to copy static routes from the host bridge to the container. To disable this behaviour,
-   pass `-o skip_routes=true` when creating the network.
-
-## Debugging
-
-To read the plugin's log, do `cat /var/lib/docker/plugins/*/rootfs/var/log/net-dhcp.log` (as `root`). You can also use
-`docker plugin set ghcr.io/claymore666/docker-net-dhcp:v1.1.1 LOG_LEVEL=trace` to increase log verbosity.
-
-`/Plugin.Health` exposes liveness and recovery counters as JSON on the plugin's UNIX socket — useful as a monitoring probe. See [`docs/parent-attached-modes.md`](docs/parent-attached-modes.md#health-endpoint) for the payload schema and a sample `curl` invocation.
-
-### Plugin env vars
-
-All three are `docker plugin set`-able and take effect after a `disable && enable` cycle:
-
-| name            | default              | meaning |
-| --------------- | -------------------- | ------- |
-| `LOG_LEVEL`     | `info`               | logrus level. `trace` is the most verbose. |
-| `AWAIT_TIMEOUT` | `10s`                | Cap on the per-endpoint polling helpers (sandbox / link rename / netns appearance). |
-| `STATE_DIR`     | `/var/lib/net-dhcp`  | Where per-network options and the tombstone file are persisted. |
-
-# Implementation
-
-Fundamentally, the same mechanism is used by `net-dhcp` as Docker's `bridge` driver to wire up networking to containers.
-That is, a bridge on the host is used as a switch so that containers can communicate with each other - `veth` pairs
-connect each container's network namespace to the bridge.
-
-- While Docker creates and manages its own bridges (and routes and filters traffic), `net-dhcp` uses an existing bridge
-  on the host, bridged with the desired local network.
-- Instead of allocating IP addresses from a static pool stored on the Docker host, `net-dhcp` relies on an external DHCP
-  server to provide IP addresses
-
-## Flow
-
-1. Container creation request is made
-2. A `veth` pair is created and the host end is connected to the bridge (at this point both interfaces are still in the
-host namespace)
-3. A DHCP client (BusyBox `udhcpc`) is started on the container end (still in the host namespace) - initial IP address
-is provided to Docker by the plugin
-4. Docker moves the container end of the `veth` pair into the container's network namespace and sets the IP address - at
-this point `udhcpc` must be stopped
-5. `net-dhcp` starts `udhcpc` on the container end of the `veth` pair in the container's **network namespace** (but
-still in the plugin **PID namespace** - this means that the container can't see the DHCP client)
-6. `udhcpc` continues to run, renewing the lease when required, until the container shuts down
-
-# Contributing
+## Contributing
 
 Contributions are welcome.
 
@@ -298,3 +140,7 @@ Contributions are welcome.
 
 This is an actively maintained fork. It is solo-maintained, so please allow a
 few days for a response.
+
+## License
+
+MIT — see [LICENSE.md](LICENSE.md).

--- a/docs/bridge-mode.md
+++ b/docs/bridge-mode.md
@@ -1,0 +1,127 @@
+# Bridge mode
+
+Bridge mode is `docker-net-dhcp`'s default. Unlike the parent-attached
+modes ([macvlan / ipvlan](parent-attached-modes.md)), bridge mode plugs
+container `veth`s into **a Linux bridge you maintain** — so it needs a
+small amount of one-time host setup, but works anywhere a bridge can be
+bridged onto the LAN where the DHCP server lives.
+
+For the full option/observability/troubleshooting matrix see the
+[driver reference](reference.md). This page is the end-to-end
+walkthrough.
+
+## 1. Prepare a host bridge
+
+You need a pre-configured bridge interface on the host. How you set this
+up depends on your distro; the following manual steps work on most Linux
+systems:
+
+```bash
+# Create the bridge
+sudo ip link add my-bridge type bridge
+sudo ip link set my-bridge up
+
+# Assuming 'eth0' is connected to your LAN (where the DHCP server is)
+sudo ip link set eth0 up
+# Attach your network card to the bridge
+sudo ip link set eth0 master my-bridge
+
+# If your firewall's forwarding policy is DROP, add an ACCEPT rule
+sudo iptables -A FORWARD -i my-bridge -j ACCEPT
+
+# Get an IP for the host (goes out to the DHCP server, since eth0 is
+# attached to the bridge). Replace with whatever config you used for eth0.
+sudo dhcpcd my-bridge
+```
+
+## 2. Create the network
+
+```bash
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
+  --ipam-driver null -o bridge=my-bridge my-dhcp-net
+```
+
+With IPv6 as well (the `docker network create --ipv6` flag does **not**
+work with the null IPAM driver; use the `ipv6` driver option instead):
+
+```bash
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
+  --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
+```
+
+> **The `null` IPAM driver is mandatory.** Without it Docker allocates
+> addresses from its own pool, which collides with the real LAN the
+> bridge is attached to.
+
+See the [driver reference](reference.md#driver-options-network-level)
+for every network-level option (`lease_timeout`, `ignore_conflicts`,
+`skip_routes`, `gateway`, `propagate_dns`, …).
+
+## 3. Run containers
+
+```console
+$ docker run --rm -ti --network my-dhcp-net alpine
+/ # ip address show
+159: my-bridge0@if160: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 ...
+    link/ether 86:41:68:f8:85:b9 brd ff:ff:ff:ff:ff:ff
+    inet 10.255.0.246/24 brd 10.255.0.255 scope global my-bridge0
+/ # ip route show
+default via 10.255.0.123 dev my-bridge0
+10.255.0.0/24 dev my-bridge0 scope link src 10.255.0.246
+```
+
+Or in Docker Compose, against a network created out-of-band (the
+**recommended** approach — the network is shared across compose projects
+and survives `compose down`):
+
+```yaml
+services:
+  app:
+    hostname: my-http
+    image: nginx
+    mac_address: 86:41:68:f8:85:b9
+    networks:
+      - dhcp
+networks:
+  dhcp:
+    external:
+      name: my-dhcp-net
+```
+
+You can also have Compose manage the network itself (it is then deleted
+on `compose down`):
+
+```yaml
+services:
+  app:
+    image: nginx
+    hostname: my-server
+    networks:
+      - dhcp
+networks:
+  dhcp:
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.1.1
+    driver_opts:
+      bridge: my-bridge
+      ipv6: 'true'
+    ipam:
+      driver: 'null'
+```
+
+Notes:
+
+- The container takes a little longer than usual to start — a DHCP lease
+  is obtained before it is created.
+- A persistent DHCP client renews the lease (and updates the container's
+  default gateway) for the life of the endpoint. **It runs separately
+  from the container.**
+- Use `--mac-address` / `mac_address` for MAC-keyed reservations or to
+  reuse an old lease; `--hostname` / `hostname` is sent as DHCP option 12
+  for DHCP-DNS integration. Per-endpoint and per-container knobs are
+  documented in the [driver reference](reference.md#driver-options-per-endpoint).
+
+## See also
+
+- [Driver reference](reference.md) — all options, observability, troubleshooting
+- [macvlan / ipvlan modes](parent-attached-modes.md) — attach to a host NIC, no bridge
+- [How it works](internals.md) — the veth + DHCP-client mechanism

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1,0 +1,37 @@
+# How it works
+
+Fundamentally, `net-dhcp` uses the same mechanism as Docker's built-in
+`bridge` driver to wire networking to containers: a bridge on the host
+acts as a switch, and `veth` pairs connect each container's network
+namespace to it. Two things differ:
+
+- **Existing bridge, not a managed one.** Where Docker creates and
+  manages its own bridges (and routes/filters traffic), `net-dhcp` uses
+  an existing bridge on the host, bridged onto the desired local
+  network. (In macvlan/ipvlan mode the parent is a host NIC instead —
+  see [parent-attached modes](parent-attached-modes.md).)
+- **External addressing.** Instead of allocating addresses from a static
+  pool on the Docker host, `net-dhcp` relies on an external DHCP server
+  to provide them.
+
+## Flow (bridge mode)
+
+1. A container-creation request is made.
+2. A `veth` pair is created and the host end is connected to the bridge
+   (both interfaces are still in the host namespace at this point).
+3. A DHCP client (BusyBox `udhcpc`) is started on the container end
+   (still in the host namespace) — the initial IP address is provided to
+   Docker by the plugin.
+4. Docker moves the container end of the `veth` pair into the
+   container's network namespace and sets the IP address — at this point
+   `udhcpc` must be stopped.
+5. `net-dhcp` restarts `udhcpc` on the container end of the `veth` pair
+   in the container's **network namespace** (but still in the plugin's
+   **PID namespace**, so the container can't see the DHCP client).
+6. `udhcpc` keeps running, renewing the lease when required, until the
+   container shuts down.
+
+## See also
+
+- [Driver reference](reference.md) — options, `/Plugin.Health`, troubleshooting
+- [Bridge mode](bridge-mode.md) and [macvlan / ipvlan](parent-attached-modes.md) setup

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -10,9 +10,9 @@ the code parses appears in this document
 stale silently.
 
 Deeper-dive companions: [`parent-attached-modes.md`](parent-attached-modes.md)
-(macvlan/ipvlan concepts, DHCP identity, recovery semantics) and the
-top-level [`README.md`](../README.md) (bridge-mode walkthrough,
-implementation notes).
+(macvlan/ipvlan concepts, DHCP identity, recovery semantics),
+[`bridge-mode.md`](bridge-mode.md) (the bridge-mode walkthrough), and
+[`internals.md`](internals.md) (implementation notes).
 
 ---
 
@@ -90,8 +90,7 @@ All modes share two invariants:
 ### bridge (default)
 
 You bring an existing Linux bridge that is L2-connected to the LAN
-(see the [README](../README.md#network-creation-bridge-mode) for the
-bridge setup itself):
+(see [`bridge-mode.md`](bridge-mode.md) for the bridge setup itself):
 
 ```bash
 docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \


### PR DESCRIPTION
## What this changes

Restructures the README (was ~300 lines doing marketing + quick start + deep how-to + internals all at once) into a concise landing page that routes to `docs/`, per #205.

**Moved out of the README:**
- Manual host-bridge setup + the `docker network create` / container walkthrough → **new `docs/bridge-mode.md`**
- Implementation + Flow → **new `docs/internals.md`**
- Deep option notes, the plugin env-var table, and Debugging → **dropped** (not re-copied): `docs/reference.md` already documents all of these comprehensively (network/per-endpoint options, plugin settings, `/Plugin.Health`, troubleshooting), so this removes duplication rather than relocating it.

**Kept in the README:**
- Trimmed fork notice + install one-liner, what-it-does, Quick start, the attachment-modes table
- A **Documentation** hub and a **Project & community** hub (links to reference/bridge/parent-attached/internals, SECURITY, GOVERNANCE, CoC, issue forms, PR template)
- **Verifying releases** and **Contributing** — kept verbatim, anchors preserved
- A short License section

## Constraints honored

- `#verifying-releases` and `#contributing` anchors **preserved** — they're linked from `SECURITY.md`, `GOVERNANCE.md`, `RELEASE_NOTES.md`, `docs/reference.md`, and the OpenSSF Best Practices form / Scorecard evidence.
- Cross-references updated: `reference.md`'s two links to the old README bridge-walkthrough / implementation sections now point at `bridge-mode.md` / `internals.md`.
- No broken internal links or anchors (verified across README + all docs).
- Lands after #200 (Contributing) and #204 (badge), which shipped in v1.1.1 — no conflicts.

## Related issue

Refs #205 — precursor to #133 (GitHub Pages docs site).

## Checklist

- [x] Branched off and targets `dev` (not `main`)
- [x] Tests added/updated — n/a (docs only)
- [x] Unit tests, `staticcheck`, integration — n/a for docs; CI runs anyway
- [x] Docs updated (this PR is the docs change; all cross-refs fixed)
- [x] No secrets, credentials, or internal host details in the diff
