### PR TITLE
docs: versioned documentation site via GitHub Pages (#133)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,147 @@
+name: Docs site
+
+# Build and publish the versioned documentation site (#133).
+#
+# Single source of truth is the in-repo docs/ tree; mkdocs-material renders
+# it and mike publishes per-version snapshots to the `gh-pages` branch, which
+# GitHub Pages serves. Versioning mirrors the registry tagging scheme:
+#
+#   - real release tag vX.Y.Z   → publish that version AND move the `latest`
+#                                 alias + site default (the docs users land on)
+#   - pre-release tag vX.Y.Z-rcN → publish a preview version only; `latest` and
+#                                 the default are NOT moved (same zero-impact
+#                                 dry-run guarantee release.yml gives images)
+#   - push to dev               → publish/refresh the moving `dev` version
+#                                 (and, until the first release exists, point
+#                                 the site default at it so the root isn't a 404)
+#   - workflow_dispatch         → re-publish docs for an existing tag, or, with
+#                                 no input, the current dev
+#
+# Pull requests touching the docs only get a `mkdocs build --strict` check —
+# they never publish. actionlint gates this file like every other workflow.
+#
+# One-time setup (maintainer, after the first run creates gh-pages):
+#   Settings → Pages → Build and deployment → Source = "Deploy from a branch",
+#   Branch = gh-pages / (root). See docs/release-runbook.md.
+on:
+  push:
+    branches: [dev]
+    tags: ["v*"]
+  pull_request:
+    paths:
+      - docs/**
+      - mkdocs.yml
+      - .github/workflows/pages.yml
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to (re)publish docs for (e.g. v1.2.0). Blank = publish current dev."
+        required: false
+
+# Read-only by default; the deploy job grants itself contents: write to push
+# the built site to gh-pages.
+permissions:
+  contents: read
+
+# Serialise deploys so concurrent runs don't race on the gh-pages branch.
+# Don't cancel an in-flight deploy mid-push — let it finish cleanly.
+concurrency:
+  group: docs-site
+  cancel-in-progress: false
+
+jobs:
+  # Always-on validation: the site must build cleanly (no broken internal
+  # links, no bad config) before anything is published. This is the only
+  # job that runs on pull requests.
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+
+      - name: Install doc toolchain
+        run: pip install -r docs/requirements.txt
+
+      - name: Build site (strict)
+        run: mkdocs build --strict
+
+  # Publish a versioned snapshot to gh-pages. Skipped on pull requests.
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write # mike commits + pushes the built site to gh-pages
+    steps:
+      - name: Resolve docs ref
+        id: ref
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_TAG}" ]; then
+            REF="${INPUT_TAG}"
+          elif [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            REF="${GITHUB_REF_NAME}"
+          else
+            REF="dev"
+          fi
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+          echo "Publishing docs for: ${REF}"
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
+          # Full history so mike can read and rewrite the gh-pages branch.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+
+      - name: Install doc toolchain
+        run: pip install -r docs/requirements.txt
+
+      - name: Configure git identity for mike
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Make gh-pages available to mike
+        run: git fetch origin gh-pages --depth=1 || echo "no gh-pages branch yet — mike will create it"
+
+      # Map the resolved ref to a mike version + alias, mirroring the
+      # release.yml prerelease guard. Only a bare vX.Y.Z moves `latest`
+      # and the site default; rc tags publish a preview; dev publishes the
+      # moving dev version (and bootstraps the default until a release exists).
+      - name: Publish with mike
+        env:
+          REF: ${{ steps.ref.outputs.ref }}
+        run: |
+          set -euo pipefail
+          if [ "${REF}" = "dev" ]; then
+            mike deploy --push --update-aliases dev
+            # Bootstrap: before the first release there is no `latest`, so
+            # point the site root at dev. Once a release sets latest, this
+            # guard stops firing and dev pushes leave the default alone.
+            if ! mike list 2>/dev/null | grep -q '\[latest\]'; then
+              mike set-default --push dev
+            fi
+          elif [[ "${REF}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            # Real release: publish this version and move latest + default.
+            mike deploy --push --update-aliases "${REF}" latest
+            mike set-default --push latest
+          elif [[ "${REF}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            # Pre-release (vX.Y.Z-rcN): preview only — no alias, no default move.
+            mike deploy --push "${REF}"
+          else
+            echo "Ref '${REF}' is neither dev nor a vX.Y.Z[-rcN] tag; refusing." >&2
+            exit 1
+          fi
+          echo "## Docs published for ${REF}" >> "$GITHUB_STEP_SUMMARY"
+          mike list >> "$GITHUB_STEP_SUMMARY" || true

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 /plugin-cover/
 /multiarch/
 
+# mkdocs-material build output (docs site, #133) — published to gh-pages
+# by .github/workflows/pages.yml, never committed to a source branch.
+/site/
+
 .vscode/
 .claude/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/claymore666/docker-net-dhcp)](https://goreportcard.com/report/github.com/claymore666/docker-net-dhcp)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/claymore666/docker-net-dhcp/badge)](https://scorecard.dev/viewer/?uri=github.com/claymore666/docker-net-dhcp)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13229/badge)](https://www.bestpractices.dev/projects/13229)
+[![Docs](https://img.shields.io/badge/docs-claymore666.github.io-blue?logo=materialformkdocs&logoColor=white)](https://claymore666.github.io/docker-net-dhcp/)
 
 A Docker network plugin that allocates container IP addresses (IPv4 and
 optionally IPv6) from an **existing DHCP server** — your router, a
@@ -65,6 +66,10 @@ macvlan/ipvlan attach directly to a host NIC without a bridge — the
 right pick when you don't want to reconfigure the host's networking.
 
 ## Documentation
+
+A versioned documentation site is published at
+**<https://claymore666.github.io/docker-net-dhcp/>** (pick your plugin
+version from the selector). The same content lives in `docs/` in the repo:
 
 - **[Driver reference](docs/reference.md)** — every option, plugin
   setting, the `/Plugin.Health` observability endpoint, and

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,121 @@
+# docker-net-dhcp
+
+A Docker network plugin that allocates container IP addresses (IPv4 and
+optionally IPv6) from an **existing DHCP server** — your router, a
+Fritz!Box, dnsmasq, anything — instead of Docker's self-managed IPAM
+pools. Containers come up on your LAN as first-class hosts, addressable
+like any other machine. Bridge, macvlan, and ipvlan attachment modes.
+
+!!! info "This is a maintained fork"
+    A maintained fork of
+    [`devplayer0/docker-net-dhcp`](https://github.com/devplayer0/docker-net-dhcp)
+    (quiet since 2021, no longer builds on current Docker). This fork
+    modernises the toolchain (Go 1.26, docker SDK v28, current Alpine),
+    adds **macvlan** and **ipvlan** modes, fixes the daemon-restart
+    deadlock and a state data-race, and gates every PR on a live
+    integration suite (all three modes + DHCPv6, recovery, failure
+    injection) with a coverage ratchet and supply-chain gates on release.
+    The maintained image lives at `ghcr.io/claymore666/docker-net-dhcp`.
+
+## Quick start
+
+Install the plugin:
+
+```bash
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.1
+```
+
+It requests `host` networking, the host PID namespace, the Docker
+socket, and `CAP_NET_ADMIN`/`CAP_SYS_ADMIN` — grant them to proceed.
+(If you hit `invalid rootfs in image configuration`, upgrade Docker.)
+
+Create a bridge-mode network and run a container on it (assumes you
+already have a host bridge `my-bridge` on your LAN — see
+[Bridge mode](bridge-mode.md) for that one-time setup):
+
+```bash
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
+  --ipam-driver null -o bridge=my-bridge my-dhcp-net
+
+docker run --rm -ti --network my-dhcp-net alpine ip address show
+```
+
+The `null` IPAM driver is **mandatory** — it stops Docker handing out
+addresses that would collide with the real LAN.
+
+## Attachment modes
+
+Selected by the `mode` driver option:
+
+| mode | parent | host changes required |
+| ---- | ------ | --------------------- |
+| `bridge` (default) | a Linux bridge you maintain (`-o bridge=<name>`) | yes — you bring the bridge |
+| `macvlan` | a host NIC (`-o parent=<iface>`) | none |
+| `ipvlan` (L2) | a host NIC (`-o parent=<iface>`) | none |
+
+macvlan/ipvlan attach directly to a host NIC without a bridge — the
+right pick when you don't want to reconfigure the host's networking.
+
+## Documentation
+
+- **[Driver reference](reference.md)** — every option, plugin setting,
+  the `/Plugin.Health` observability endpoint, and troubleshooting.
+- **[Bridge mode](bridge-mode.md)** — host bridge setup + end-to-end
+  walkthrough.
+- **[macvlan / ipvlan modes](parent-attached-modes.md)** — NIC
+  attachment, DHCP identity (hostname / option 60 / 61), restart
+  stability, recovery.
+- **[How it works](internals.md)** — the veth + DHCP-client mechanism
+  and lease flow.
+- **[Release runbook](release-runbook.md)** — maintainer-facing publish
+  procedure.
+
+## Images & releases
+
+This fork publishes semver-tagged plugin images on GHCR
+(`ghcr.io/claymore666/docker-net-dhcp:vX.Y.Z`, `linux/amd64`; ARM via
+the build pipeline on request) and mirrors them to Docker Hub
+(`claymore666/net-dhcp`). Pin a version (`:vX.Y.Z`) for reproducibility,
+or track `:latest`.
+
+- [GHCR package](https://github.com/claymore666/docker-net-dhcp/pkgs/container/docker-net-dhcp)
+- [GitHub Releases](https://github.com/claymore666/docker-net-dhcp/releases)
+  — per-release notes, credits, and signed artifacts.
+
+This documentation is **versioned**: use the selector in the header to
+read the docs matching the plugin version you have installed.
+
+## Verifying releases
+
+Every release (v1.1.0 onward) is signed and attested via Sigstore. The
+published plugin image is signed with cosign (keyless), carries SLSA
+build provenance, and ships an SBOM; the release-artifact `checksums.txt`
+manifest is cosign-signed so one signature covers every attached file.
+The exact, copy-pasteable commands — pinned to that release's tag — are
+appended to each [GitHub Release](https://github.com/claymore666/docker-net-dhcp/releases)
+under **Verifying the signed artifacts**. In brief (replace `VERSION`):
+
+```bash
+# image signature
+cosign verify ghcr.io/claymore666/docker-net-dhcp:VERSION \
+  --certificate-identity-regexp '^https://github.com/claymore666/docker-net-dhcp/.github/workflows/release.yml@' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# SLSA build provenance (image + release artifacts)
+gh attestation verify oci://ghcr.io/claymore666/docker-net-dhcp:VERSION --repo claymore666/docker-net-dhcp
+```
+
+## Project & community
+
+- **Contributing:** open a pull request against the `dev` branch — see
+  the [Contributing section in the README](https://github.com/claymore666/docker-net-dhcp#contributing).
+- **Security policy / vulnerability reporting:**
+  [SECURITY.md](https://github.com/claymore666/docker-net-dhcp/blob/dev/SECURITY.md)
+  (do not open public issues for vulnerabilities).
+- **Bug reports & feature requests:** the
+  [issue forms](https://github.com/claymore666/docker-net-dhcp/issues/new/choose).
+
+## License
+
+MIT — see
+[LICENSE.md](https://github.com/claymore666/docker-net-dhcp/blob/dev/LICENSE.md).

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -40,7 +40,7 @@ DHCP on the host's L2 segments, querying the daemon).
 cosign-signed `checksums.txt` and an SBOM. Per-release, copy-pasteable
 verification commands live under **Verifying the signed artifacts** on
 each [GitHub Release](https://github.com/claymore666/docker-net-dhcp/releases);
-the [README](../README.md#verifying-releases) has the short form.
+the [home page](index.md#verifying-releases) has the short form.
 
 **Pin a version.** `:latest` exists and tracks the newest release, but
 networks remember the exact driver string they were created with — a

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -36,6 +36,26 @@ https://ghcr.io/v2/.../blobs/uploads/: 403 Forbidden` at the **Push
 to GHCR** step. The fix takes effect for the next workflow run; no
 re-tag needed.
 
+### GitHub Pages — enable the docs site
+
+The versioned documentation site (mkdocs-material + mike, `#133`) is
+built and published by `.github/workflows/pages.yml`. That workflow
+pushes the rendered site to the `gh-pages` branch; GitHub Pages has to
+be told to serve from it — once, after the branch first exists.
+
+The first run on `dev` (or the first tag) creates `gh-pages`. Then, at
+<https://github.com/claymore666/docker-net-dhcp/settings/pages>:
+
+1. **Build and deployment → Source** = **Deploy from a branch**.
+2. **Branch** = `gh-pages` / `(root)`. Save.
+
+The site then resolves at <https://claymore666.github.io/docker-net-dhcp/>.
+No per-release action: each `vX.Y.Z` tag publishes its own docs version
+and moves the `latest` alias automatically (rc tags publish a preview
+without moving `latest` — same guard as the image `:latest`). Until the
+first release, the workflow points the site root at the moving `dev`
+version so it isn't a 404.
+
 ### Docker Hub — secrets and scopes
 
 The workflow's Hub steps are gated on a job-level
@@ -145,10 +165,13 @@ the `vX.Y.Z` milestone (the workflow leans on this for the
    (including this runbook — process changes during the cycle land
    here too), and the coverage table if republished. Anything
    describing the previous version's behaviour, options, or
-   numbers gets updated on the release branch now. When the
-   project gains a GitHub wiki, it joins this review. The rc
-   dry-run (step 8) is the *last checkpoint* for catching stale
-   docs — by the real tag, text and code must agree.
+   numbers gets updated on the release branch now. Everything under
+   `docs/` (plus `docs/index.md`, the site home) is what the
+   versioned documentation site publishes for this tag, so the
+   review *is* the site review — there's no separate wiki to
+   reconcile. The rc dry-run (step 8) is the *last checkpoint* for
+   catching stale docs — by the real tag, text and code (and the
+   published site) must agree.
 4. **Add a `## vX.Y.Z` section** to `RELEASE_NOTES.md`, **above
    the previous version's section**. Summarise what's changing in
    user-visible terms; the workflow doesn't auto-build this from

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+# Documentation site toolchain (#133). Installed by .github/workflows/pages.yml
+# to build and version-deploy the mkdocs-material site. Compatible-release
+# pins (~=) track patch/minor fixes while holding the major; Dependabot's
+# pip ecosystem bumps them like any other dependency.
+mkdocs-material~=9.5
+mike~=2.1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,98 @@
+site_name: docker-net-dhcp
+site_description: >-
+  Docker network plugin that leases container IPs from an existing DHCP
+  server — bridge, macvlan, and ipvlan modes.
+site_url: https://claymore666.github.io/docker-net-dhcp/
+site_author: claymore666
+
+repo_url: https://github.com/claymore666/docker-net-dhcp
+repo_name: claymore666/docker-net-dhcp
+edit_uri: edit/dev/docs/
+
+# Single source of truth stays in-repo: the site is built from the same
+# docs/ tree that ships in the repository. Maintained per #133.
+docs_dir: docs
+
+# Treat every kind of broken reference as a warning so `mkdocs build
+# --strict` (run on every docs PR) fails on dead internal links AND dead
+# heading anchors — the cross-page #fragment links between these docs are
+# load-bearing.
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  links:
+    anchors: warn
+
+theme:
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.instant
+    - navigation.tracking
+    - content.code.copy
+    - content.action.edit
+    - search.suggest
+    - search.highlight
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+plugins:
+  - search
+  # Per-release versioned docs, driven by the deploy workflow (.github/
+  # workflows/pages.yml): each release publishes its vX.Y.Z docs and moves
+  # the `latest` alias, mirroring the registry `:vX.Y.Z` / `:latest` scheme.
+  - mike:
+      alias_type: symlink
+      canonical_version: latest
+
+extra:
+  version:
+    provider: mike
+    default: latest
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/claymore666/docker-net-dhcp
+    - icon: fontawesome/brands/docker
+      link: https://github.com/claymore666/docker-net-dhcp/pkgs/container/docker-net-dhcp
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+
+nav:
+  - Home: index.md
+  - Bridge mode: bridge-mode.md
+  - macvlan / ipvlan: parent-attached-modes.md
+  - Driver reference: reference.md
+  - How it works: internals.md
+  - Maintainer:
+      - Release runbook: release-runbook.md


### PR DESCRIPTION
Implements #133 — a versioned project documentation site.

## What

A documentation site built from the in-repo `docs/` tree (single source of truth) with **mkdocs-material**, versioned with **mike**. Versioning mirrors the registry tagging scheme:

| trigger | version published | `latest` alias / site default |
| --- | --- | --- |
| release tag `vX.Y.Z` | that version | moved to it |
| pre-release tag `vX.Y.Z-rcN` | preview only | **not** moved (same guard as image `:latest`) |
| push to `dev` | moving `dev` version | only bootstrapped until the first release exists |

## Files

- **`mkdocs.yml`** — material theme, mike versioning, and strict link **+ anchor** validation so dead internal references fail the build.
- **`docs/index.md`** — site landing page (pitch, quick start, attachment modes, docs hub, verifying releases). No content is duplicated from the existing docs — the reference/bridge/modes/internals pages are reused as-is.
- **`.github/workflows/pages.yml`** — two jobs: `build` runs `mkdocs build --strict` on every docs PR (this is the only job that runs on PRs); `deploy` publishes via mike to `gh-pages` on tags/`dev`/dispatch. Actions are SHA-pinned; the rc-tag guard mirrors `release.yml`.
- **`docs/requirements.txt`** — pinned doc toolchain (Dependabot-tracked).
- **runbook** — one-time Pages enablement (set source = `gh-pages`) + the per-release behavior; the existing documentation-review step now doubles as the site review.
- **README** — docs-site badge + link; one `reference.md` cross-link repointed from `../README.md` to the site home.

## Verification

- `mkdocs build --strict` passes locally (with anchor validation enabled — every cross-page `#fragment` between the docs resolves).
- `actionlint` clean on `pages.yml` (verified locally against the same linter the CI gate uses).
- The `build` job runs on this PR and validates the strict build in CI.

## Follow-up (post-merge, maintainer)

After the first `dev` push creates `gh-pages`, enable Pages once: **Settings → Pages → Source = Deploy from a branch → `gh-pages` / (root)**. Documented in the runbook. The site then resolves at https://claymore666.github.io/docker-net-dhcp/.

Per project norm, this PR does not `Close #133` — the v1.2.0 release PR batch-closes it on main.