### PR TITLE
ci: bump pages.yml setup-python to v6.2.0 (Node 24) (#225)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
@@ -100,7 +100,7 @@ jobs:
           # Full history so mike can read and rewrite the gh-pages branch.
           fetch-depth: 0
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 


### PR DESCRIPTION
Fixes the one Node 20 straggler from #133 (#225).

`actions/setup-python@v5` (pinned in `pages.yml`) is `using: node20`; GitHub forces JS actions to Node 24 from 2026-06-16. Bumped both the `build` and `deploy` jobs to `v6.2.0` (`using: node24`), keeping the SHA-pin convention.

The rest of the repo was already on node24-capable action majors (checkout v6, setup-go v6, artifacts v7, codeql v4, docker/login-action v4, …) — this was a slip in the just-merged pages workflow, not a repo-wide gap.

Verified: actionlint clean. Per milestone norm, the v1.2.0 release PR closes #225.