### PR TITLE
ci: bump cosign-installer to v4.1.2, hold download-artifact at v7 (#196)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,14 @@ updates:
       actions:
         patterns:
           - "*"
+    ignore:
+      # Hold actions/download-artifact at v7 until actions/upload-artifact
+      # ships a v8. download-artifact v8 defaults a download digest
+      # mismatch to a hard failure, and pairing upload v7 (its current
+      # latest) with download v8 mixes majors on the release artifacts.
+      # Remove this once upload-artifact v8 exists so both bump together.
+      - dependency-name: "actions/download-artifact"
+        versions: [">= 8"]
 
   # Keep the SHA-pinned base-image digests fresh (#159). One entry per
   # Dockerfile directory: the plugin build at the root and the CI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
       # (rootfs + config.json), the exact tree `docker plugin create`
       # consumed, so packaging that reconstructs the published plugin.
       - name: Install cosign
-        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       # Sign the published plugin images by digest (#173). docker plugins
       # are OCI artifacts, so cosign signs them like any image once we


### PR DESCRIPTION
Splits Dependabots grouped actions PR #196 so the two bumps land on their own risk profiles.

## cosign-installer 3.9.2 → 4.1.2
Bumps the default cosign from 2.x to 3.x. This action runs **only on the release path** (`release.yml` signing step), so PR CI does not exercise it. Per the runbook it must ride a **`vX.Y.Z-rc1` dry-run** before the next real release tag — the rc run signs + verify-installs with the new cosign, confirming signatures still verify before `v1.2.0` ships.

## download-artifact held at v7
Not bumped to v8. v8 defaults a download **digest mismatch to a hard failure**, and `actions/upload-artifact` has no v8 yet (latest v7.0.1) — pairing upload v7 with download v8 would mix majors on the release artifacts. Added a Dependabot `ignore` (`>= 8`) so it stops being re-proposed until upload-artifact v8 exists, at which point both bump together.

## Supersedes #196
Closing the grouped Dependabot PR in favour of this split. The cosign half lands here; the download-artifact half is deliberately deferred via the ignore.

Verified: `actionlint` clean on `release.yml`; `dependabot.yml` parses. Per milestone norm the v1.2.0 release PR closes #196.