### PR TITLE
ci: bump alpine to 3.24.0 + re-pin apk packages (#195)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,15 +16,15 @@ COPY pkg/ ./pkg/
 RUN mkdir bin/ && go build $COVER_FLAGS -o bin/ ./cmd/...
 
 
-FROM alpine:3.20.3@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
+FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 
 # Pin both the Alpine minor and the apk package versions: busybox supplies
 # udhcpc (the entire DHCP exchange), so a silent regression in busybox-extras
 # would land in plugin builds without warning. Bump together when refreshing.
 RUN mkdir -p /run/docker/plugins /var/lib/net-dhcp && \
     apk add --no-cache \
-        busybox-extras=1.36.1-r31 \
-        iproute2=6.9.0-r0
+        busybox-extras=1.37.0-r31 \
+        iproute2=7.0.0-r0
 
 COPY --from=builder /usr/local/src/docker-net-dhcp/bin/net-dhcp /usr/sbin/
 COPY --from=builder /usr/local/src/docker-net-dhcp/bin/udhcpc-handler /usr/lib/net-dhcp/udhcpc-handler


### PR DESCRIPTION
Supersedes Dependabot #195, which bumped only the `FROM` digest and would break the build: the apk pins reference 3.20 package versions absent from 3.24s repos.

## Changes
- `FROM alpine:3.20.3 → 3.24.0` (same digest Dependabot computed).
- `busybox-extras 1.36.1-r31 → 1.37.0-r31` (supplies `udhcpc`/`udhcpc6`).
- `iproute2 6.9.0-r0 → 7.0.0-r0`.

## Verification (local)
- Image **builds** on `alpine:3.24.0`.
- `udhcpc`, `udhcpc6`, and `ip` all present in the runtime image.
- `scripts/check-apk-pins.sh --strict` reports **all pins current** against the new base.

## Coordination note (#152 / #223)
PR #223 rewrites this same apk block, replacing `busybox-extras` with `dhcpcd=10.0.6-r1` (a 3.20 version) while keeping the base at 3.20.3. Whichever lands second must reconcile. For #223, the matching 3.24.0 version is **`dhcpcd=10.3.2-r0`** (still 10.x, so its dhcpcd-11 constraint holds) and `iproute2=7.0.0-r0`. Ill flag this on #223.

Per milestone norm, the v1.2.0 release PR closes #195.