### PR TITLE
ci: Trivy rootfs CVE scan (#143)

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,87 @@
+name: Trivy rootfs scan
+
+# CVE scan of the plugin's runtime rootfs (#143). Division of labour:
+#
+#   - govulncheck (test workflow)  → Go module/stdlib vulns, reachable
+#                                     from our code; the blocking gate.
+#   - APK pin drift (apk-pin-check) → signals when a newer busybox-extras
+#                                     / iproute2 is available; not CVEs.
+#   - THIS workflow                → CVEs in the OS packages actually
+#                                     installed in the shipped rootfs
+#                                     (the pinned apk versions + the
+#                                     Alpine base), which pin-drift can't
+#                                     see. `--pkg-types os` keeps it off
+#                                     Go packages so it doesn't double up
+#                                     with (or contradict) govulncheck's
+#                                     reachability-based verdicts.
+#
+# Informational, like apk-pin-check: it doesn't fail the run (exit-code
+# 0). The actionable artefact is the SARIF uploaded to Security → Code
+# scanning. Accepted-but-unfixed findings get a reviewed entry in
+# .trivyignore.yaml (justification + review date, never a bare ID) — the
+# same discipline as .github/vuln-allowlist.txt.
+#
+# Actions are SHA-pinned (tag in the trailing comment); Dependabot's
+# github-actions group maintains them.
+
+on:
+  schedule:
+    - cron: '23 6 * * 1'
+  # Also scan whenever the rootfs recipe or this scan's own config
+  # changes — catches a base-image / apk bump pulling in fresh CVEs at
+  # PR time (informational, not a required check).
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - '.trivyignore.yaml'
+      - '.github/workflows/trivy.yml'
+  push:
+    branches:
+      - dev
+    paths:
+      - 'Dockerfile'
+      - '.trivyignore.yaml'
+      - '.github/workflows/trivy.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      # Upload the SARIF to code scanning (Security tab).
+      security-events: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      # Build the exact runtime rootfs the plugin ships (same Dockerfile
+      # the release builds), so the scan sees the real installed apk set.
+      - name: Build plugin rootfs image
+        run: docker build -t docker-net-dhcp:scan .
+
+      - name: Trivy scan (OS packages)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: docker-net-dhcp:scan
+          scanners: vuln
+          pkg-types: os
+          format: sarif
+          output: trivy-results.sarif
+          trivyignores: .trivyignore.yaml
+          # Report everything (including unfixed); reviewed acceptances
+          # live in .trivyignore.yaml. Never fail the run — see header.
+          ignore-unfixed: false
+          exit-code: '0'
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,23 @@
+# Trivy ignore list (#143) — OS-package CVEs that are KNOWN, REVIEWED,
+# and accepted for the plugin rootfs scan (.github/workflows/trivy.yml).
+#
+# Same discipline as .github/vuln-allowlist.txt (the govulncheck gate):
+#   - Every entry needs a `statement` (justification) and the PR that
+#     added it. No bare IDs — an unexplained suppression is a bug.
+#   - Entries are for findings with no fixed apk available, or where the
+#     fix is pending an Alpine base bump. When a fix ships, bump the pin
+#     (apk-pin-check / Dependabot surface it) and remove the entry.
+#   - `expired_at` is the review date: Trivy re-surfaces the finding past
+#     that date so stale acceptances don't accumulate silently. Re-review
+#     and either re-justify with a new date or drop it.
+#
+# Template (copy, fill in, keep the comment block above your entry):
+#
+#   vulnerabilities:
+#     - id: CVE-YYYY-NNNNN
+#       # <why this is accepted; which apk package; added in PR #NNN>
+#       statement: "no fixed apk in Alpine 3.24; daemon-side only, not reachable"
+#       expired_at: 2026-09-01
+#
+# No accepted findings at present.
+vulnerabilities: []


### PR DESCRIPTION
Part of #143 (CI hardening follow-ups) — the **Trivy rootfs scan** item.

## What
A scheduled/informational Trivy scan of the plugin's runtime rootfs,
scoped to **OS packages** (`--pkg-types os`).

`apk-pin-check` already signals when a newer `busybox-extras` / `iproute2`
is available, but it can't tell whether the *pinned* versions (or the
Alpine base) carry CVEs. Trivy fills exactly that gap. Scoping it to OS
packages keeps it from overlapping — or contradicting — govulncheck,
which owns Go vulns with reachability gating.

## Behaviour
- **Informational, never fails the run** (`exit-code: 0`), same posture as
  `apk-pin-check`. The actionable artefact is the SARIF uploaded to
  **Security → Code scanning**.
- Triggers: weekly cron, `workflow_dispatch`, push to `dev`, and PRs that
  touch `Dockerfile` / the scan config (so a future base-image bump gets
  scanned at PR time — this PR exercises that path).
- Runs on the hosted runners (no load on the integration runner).
- Actions SHA-pinned with tag comments; Dependabot's github-actions group
  maintains them.

## Allowlist
`.trivyignore.yaml` carries reviewed-but-unfixed acceptances under the
same discipline as `.github/vuln-allowlist.txt`: every entry needs a
`statement` (justification) + the PR, and an `expired_at` review date so
stale acceptances re-surface. It starts empty.

## Scope notes (rest of #143)
- *SHA-pin all actions* — already done (#159/#166); box ticked on the issue.
- *Hosted-runner spike* — feasibility note to follow as an issue comment;
  not a migration.

## Verification
`actionlint` (the required gate, v1.7.12) passes on the new workflow and
across the full workflow set locally. The scan itself runs on this PR via
the `pull_request` paths trigger.