### PR TITLE
fix(state): validate networkID before state-file paths (go/path-injection #232)

### DIFF
--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"time"
 )
 
@@ -23,9 +25,24 @@ var stateDir = func() string {
 	return "/var/lib/net-dhcp"
 }()
 
+// validNetworkID accepts only a flat token — the shape of a libnetwork
+// network ID (hex). It rejects path separators and traversal elements
+// before networkID is ever interpolated into a filesystem path.
+var validNetworkID = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`).MatchString
+
 // stateFilePath returns the on-disk path for a given network's options.
-func stateFilePath(networkID string) string {
-	return filepath.Join(stateDir, networkID+".json")
+// networkID originates from the driver request, so it is validated and
+// the resolved path is confirmed to stay within stateDir before it
+// reaches any os.* call — closing the go/path-injection vector (CWE-22).
+func stateFilePath(networkID string) (string, error) {
+	if !validNetworkID(networkID) {
+		return "", fmt.Errorf("invalid network id %q", networkID)
+	}
+	p := filepath.Clean(filepath.Join(stateDir, networkID+".json"))
+	if !strings.HasPrefix(p, filepath.Clean(stateDir)+string(os.PathSeparator)) {
+		return "", fmt.Errorf("state path for network %q escapes %s", networkID, stateDir)
+	}
+	return p, nil
 }
 
 // tombstoneTTL bounds how long a recently-deleted endpoint's MAC is
@@ -172,12 +189,18 @@ func saveOptions(networkID string, opts DHCPNetworkOptions) error {
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create state dir %v: %w", stateDir, err)
 	}
+	final, err := stateFilePath(networkID)
+	if err != nil {
+		return err
+	}
 	data, err := json.Marshal(opts)
 	if err != nil {
 		return fmt.Errorf("failed to encode options: %w", err)
 	}
-	final := stateFilePath(networkID)
-	tmp, err := os.CreateTemp(stateDir, "."+networkID+".*.tmp")
+	// The temp name carries no networkID — CreateTemp's "*" already
+	// guarantees uniqueness, and keeping caller-supplied input out of the
+	// pattern removes it as a path-injection sink.
+	tmp, err := os.CreateTemp(stateDir, ".state-*.tmp")
 	if err != nil {
 		return fmt.Errorf("failed to create temp options file: %w", err)
 	}
@@ -207,7 +230,11 @@ func saveOptions(networkID string, opts DHCPNetworkOptions) error {
 // fall back to other sources (e.g. the docker API).
 func loadOptions(networkID string) (DHCPNetworkOptions, error) {
 	var opts DHCPNetworkOptions
-	data, err := os.ReadFile(stateFilePath(networkID))
+	path, err := stateFilePath(networkID)
+	if err != nil {
+		return opts, err
+	}
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return opts, err
 	}
@@ -222,7 +249,11 @@ func loadOptions(networkID string) (DHCPNetworkOptions, error) {
 // just means we never persisted state for this network in the first
 // place (e.g. created before we shipped persistence).
 func deleteOptions(networkID string) error {
-	if err := os.Remove(stateFilePath(networkID)); err != nil && !os.IsNotExist(err) {
+	path, err := stateFilePath(networkID)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove options file: %w", err)
 	}
 	return nil

--- a/pkg/plugin/state_test.go
+++ b/pkg/plugin/state_test.go
@@ -345,3 +345,53 @@ func TestUpdateEndpointIPs_PreservesUnsetField(t *testing.T) {
 		t.Errorf("v6-only update lost v4: %+v", fp)
 	}
 }
+
+// TestStateFilePath_RejectsPathInjection pins the go/path-injection
+// (CWE-22) guard: a networkID with separators / traversal must be
+// rejected before it reaches the filesystem, and the resolved path for a
+// valid ID must stay within stateDir.
+func TestStateFilePath_RejectsPathInjection(t *testing.T) {
+	withStateDir(t, t.TempDir())
+
+	for _, bad := range []string{
+		"", "..", "../../etc/passwd", "a/b", `a\b`, "foo.bar",
+		"net id", "with/slash", "./rel",
+	} {
+		if _, err := stateFilePath(bad); err == nil {
+			t.Errorf("stateFilePath(%q) = nil error, want rejection", bad)
+		}
+	}
+
+	for _, ok := range []string{"net123", "never-saved", "net_many", "abcDEF0123"} {
+		p, err := stateFilePath(ok)
+		if err != nil {
+			t.Errorf("stateFilePath(%q) unexpectedly rejected: %v", ok, err)
+			continue
+		}
+		if filepath.Dir(p) != filepath.Clean(stateDir) {
+			t.Errorf("stateFilePath(%q) = %q, not directly under stateDir %q", ok, p, stateDir)
+		}
+	}
+}
+
+// TestOptionsOps_RejectInvalidNetworkID: the public save/load/delete entry
+// points refuse a malicious ID rather than touching an out-of-bounds path.
+func TestOptionsOps_RejectInvalidNetworkID(t *testing.T) {
+	withStateDir(t, t.TempDir())
+
+	bad := "../../escape"
+	if err := saveOptions(bad, DHCPNetworkOptions{Bridge: "br0"}); err == nil {
+		t.Error("saveOptions accepted a traversal network id")
+	}
+	if _, err := loadOptions(bad); err == nil {
+		t.Error("loadOptions accepted a traversal network id")
+	}
+	if err := deleteOptions(bad); err == nil {
+		t.Error("deleteOptions accepted a traversal network id")
+	}
+	// Nothing should have been written anywhere under the temp stateDir.
+	entries, _ := os.ReadDir(stateDir)
+	if len(entries) != 0 {
+		t.Errorf("expected empty stateDir after rejected ops, found %d entries", len(entries))
+	}
+}


### PR DESCRIPTION
## What this changes

Closes the three CodeQL `go/path-injection` (CWE-22, high) alerts in
`pkg/plugin/state.go`. The per-network `networkID` — which originates from
the libnetwork driver request — was interpolated into state-file paths
without validation:

- `stateFilePath()` → `filepath.Join(stateDir, networkID+".json")`
  (used by `loadOptions`/`deleteOptions`/`saveOptions`)
- `saveOptions()` → `os.CreateTemp(stateDir, "."+networkID+".*.tmp")`

A network ID containing path separators or `..` could read/write/delete
outside `stateDir`. Real Docker network IDs are hex, so this is
defence-in-depth, but it's a clean hardening and clears the CodeQL gate.

## Fix

- `stateFilePath` validates `networkID` (flat token) **and** confirms the
  resolved path stays within `stateDir` (the recognised containment
  barrier), returning an error otherwise; the three callers propagate it.
- Dropped `networkID` from the `CreateTemp` pattern — the `*` already
  guarantees uniqueness, so caller input no longer reaches that sink.
- Unit tests cover the rejection paths and assert nothing is written
  out of bounds.

## Notes

Pre-existing (predates #152); surfaced as the only red, **non-required**
check on PR #223. Filed/fixed separately to keep that migration PR
focused. Once this lands on `dev`, #223 picks it up on its next `dev`
sync and goes fully green.

Closes #232.
