### PR TITLE
feat(health): split DHCP wire counters by family (#212)

### DIFF
--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -458,7 +458,12 @@ user-visible outcome.
   "leases_renewed": 42,
   "dhcp_timeouts": 0,
   "lease_release_failures": 0,
-  "naks_received": 0
+  "naks_received": 0,
+  "lease_changed_v6": 0,
+  "leases_obtained_v6": 4,
+  "leases_renewed_v6": 11,
+  "dhcp_timeouts_v6": 0,
+  "naks_received_v6": 0
 }
 ```
 
@@ -507,6 +512,16 @@ DHCP-wire counters (v0.9.0+):
   means containers are being re-addressed mid-life: `docker
   inspect` goes stale (see `lease_changed` above) and anything
   keyed on the old IPs needs attention.
+
+Per-family breakdown (v1.2.0+):
+
+- `lease_changed_v6`, `leases_obtained_v6`, `leases_renewed_v6`,
+  `dhcp_timeouts_v6`, `naks_received_v6` — the IPv6 share of the
+  matching aggregate above. The un-suffixed counters remain v4+v6
+  totals, so the IPv4 share is `<counter> − <counter>_v6`. On a
+  dual-stack host these isolate the v6-specific failure signal (a
+  v6 NAK or timeout) that the aggregate alone would mask — the
+  view you want while watching the DHCPv6 client.
 
 Sample call from a host shell:
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -219,6 +219,7 @@ curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
 | `lease_release_failures` | no | Teardown DHCPRELEASE didn't complete cleanly — the server may hold a phantom lease until natural expiry. A pattern points at upstream reachability problems mid-teardown. |
 | `naks_received` | no | (v1.0.0+) The server NAKed a renewal/rebind. udhcpc recovers by re-acquiring, so each NAK is typically followed by `leases_obtained` — and, if the address moved, `lease_changed` — bumps. Climbing alongside `lease_changed` means containers are being re-addressed mid-life. |
 | `ledger_write_failures` | no | Failed `audit_log` ledger appends — degrades forensics, not networking. Operators using `audit_log` alert on this. |
+| `lease_changed_v6`, `leases_obtained_v6`, `leases_renewed_v6`, `dhcp_timeouts_v6`, `naks_received_v6` | no | (v1.2.0+) Per-family breakdown: the IPv6 share of the matching aggregate above. The un-suffixed counters stay v4+v6 totals, so the IPv4 share is `<counter> − <counter>_v6`. On a dual-stack host this isolates a v6-specific NAK or timeout that the aggregate alone would hide. |
 
 ### Plugin log
 

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	dNetwork "github.com/docker/docker/api/types/network"
@@ -311,7 +312,7 @@ func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
 		// Bump the counter so operators can alert on the truthfulness
 		// gap; design discussion for a deeper fix is deferred (issue #104).
 		if m.plugin != nil {
-			m.plugin.leaseChanged.Add(1)
+			bumpFamily(&m.plugin.leaseChanged, &m.plugin.leaseChangedV6, v6)
 		}
 		log.
 			WithFields(m.logFields(v6)).
@@ -492,6 +493,16 @@ func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
 // ignores refused renewals in several shapes instead of NAKing), so
 // the naks_received contract is pinned here rather than in an
 // integration test (#128).
+// bumpFamily increments the aggregate counter (always) and its IPv6
+// sibling (only for v6 events), so /Plugin.Health exposes a per-family
+// breakdown while the aggregate stays a true v4+v6 total (#212).
+func bumpFamily(total, v6Counter *atomic.Int32, v6 bool) {
+	total.Add(1)
+	if v6 {
+		v6Counter.Add(1)
+	}
+}
+
 func (m *dhcpManager) handleEvent(event udhcpc.Event, v6 bool) {
 	switch event.Type {
 	// "deconfig" is intentionally not handled. Deleting the
@@ -509,7 +520,7 @@ func (m *dhcpManager) handleEvent(event udhcpc.Event, v6 bool) {
 		// the same MAC). Reuse the renew path so LastIP
 		// reflects what's actually in the kernel.
 		if m.plugin != nil {
-			m.plugin.leasesObtained.Add(1)
+			bumpFamily(&m.plugin.leasesObtained, &m.plugin.leasesObtainedV6, v6)
 		}
 		m.audit("bound", bareIP(event.Data.IP))
 		if err := m.renew(v6, event.Data); err != nil {
@@ -525,7 +536,7 @@ func (m *dhcpManager) handleEvent(event udhcpc.Event, v6 bool) {
 			Debug("udhcpc renew")
 
 		if m.plugin != nil {
-			m.plugin.leasesRenewed.Add(1)
+			bumpFamily(&m.plugin.leasesRenewed, &m.plugin.leasesRenewedV6, v6)
 		}
 		m.audit("renew", bareIP(event.Data.IP))
 		if err := m.renew(v6, event.Data); err != nil {
@@ -538,12 +549,12 @@ func (m *dhcpManager) handleEvent(event udhcpc.Event, v6 bool) {
 		}
 	case "leasefail":
 		if m.plugin != nil {
-			m.plugin.dhcpTimeouts.Add(1)
+			bumpFamily(&m.plugin.dhcpTimeouts, &m.plugin.dhcpTimeoutsV6, v6)
 		}
 		log.WithFields(m.logFields(v6)).Warn("udhcpc failed to get a lease")
 	case "nak":
 		if m.plugin != nil {
-			m.plugin.naksReceived.Add(1)
+			bumpFamily(&m.plugin.naksReceived, &m.plugin.naksReceivedV6, v6)
 		}
 		log.WithFields(m.logFields(v6)).Warn("udhcpc client received NAK")
 	}
@@ -622,7 +633,7 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 			case <-ticker.C:
 				if acquiring && time.Since(acquiringSince) >= dhcpOutageGrace {
 					if m.plugin != nil {
-						m.plugin.dhcpTimeouts.Add(1)
+						bumpFamily(&m.plugin.dhcpTimeouts, &m.plugin.dhcpTimeoutsV6, v6)
 					}
 					log.
 						WithFields(m.logFields(v6)).

--- a/pkg/plugin/dhcp_manager_test.go
+++ b/pkg/plugin/dhcp_manager_test.go
@@ -74,6 +74,40 @@ func TestRenew_LeaseChangedCounter(t *testing.T) {
 		}
 	})
 
+	t.Run("v6 changed IP bumps aggregate and v6 sibling", func(t *testing.T) {
+		p := &Plugin{}
+		m := &dhcpManager{plugin: p}
+		m.setLastIP(true, addr1)
+
+		if err := m.renew(true, udhcpc.Info{IP: addr2.String()}); err != nil {
+			t.Fatalf("renew: %v", err)
+		}
+
+		if got := p.leaseChanged.Load(); got != 1 {
+			t.Errorf("leaseChanged aggregate = %d, want 1", got)
+		}
+		if got := p.leaseChangedV6.Load(); got != 1 {
+			t.Errorf("leaseChangedV6 = %d, want 1", got)
+		}
+	})
+
+	t.Run("v4 changed IP leaves v6 sibling at zero", func(t *testing.T) {
+		p := &Plugin{}
+		m := &dhcpManager{plugin: p}
+		m.setLastIP(false, addr1)
+
+		if err := m.renew(false, udhcpc.Info{IP: addr2.String()}); err != nil {
+			t.Fatalf("renew: %v", err)
+		}
+
+		if got := p.leaseChanged.Load(); got != 1 {
+			t.Errorf("leaseChanged aggregate = %d, want 1", got)
+		}
+		if got := p.leaseChangedV6.Load(); got != 0 {
+			t.Errorf("leaseChangedV6 = %d, want 0 (v4 change must not touch the v6 sibling)", got)
+		}
+	})
+
 	t.Run("nil plugin is safe", func(t *testing.T) {
 		// Tests that drive renew without wiring a Plugin (pre-v0.9.0
 		// shape) must keep working — production callers always set
@@ -100,26 +134,42 @@ func TestHandleEvent_Counters(t *testing.T) {
 	}
 
 	cases := []struct {
-		event string
-		read  func(p *Plugin) int32
+		event     string
+		aggregate func(p *Plugin) int32
+		v6        func(p *Plugin) int32
 	}{
-		{"bound", func(p *Plugin) int32 { return p.leasesObtained.Load() }},
-		{"renew", func(p *Plugin) int32 { return p.leasesRenewed.Load() }},
-		{"leasefail", func(p *Plugin) int32 { return p.dhcpTimeouts.Load() }},
-		{"nak", func(p *Plugin) int32 { return p.naksReceived.Load() }},
+		{"bound", func(p *Plugin) int32 { return p.leasesObtained.Load() }, func(p *Plugin) int32 { return p.leasesObtainedV6.Load() }},
+		{"renew", func(p *Plugin) int32 { return p.leasesRenewed.Load() }, func(p *Plugin) int32 { return p.leasesRenewedV6.Load() }},
+		{"leasefail", func(p *Plugin) int32 { return p.dhcpTimeouts.Load() }, func(p *Plugin) int32 { return p.dhcpTimeoutsV6.Load() }},
+		{"nak", func(p *Plugin) int32 { return p.naksReceived.Load() }, func(p *Plugin) int32 { return p.naksReceivedV6.Load() }},
 	}
+	// Each event under both families: the aggregate always moves; the v6
+	// sibling moves only for v6 events and stays put for v4 ones (#212).
 	for _, c := range cases {
-		t.Run(c.event, func(t *testing.T) {
-			p := &Plugin{}
-			m := &dhcpManager{plugin: p}
-			m.setLastIP(false, addr)
-
-			m.handleEvent(udhcpc.Event{Type: c.event, Data: udhcpc.Info{IP: addr.String()}}, false)
-
-			if got := c.read(p); got != 1 {
-				t.Errorf("%s counter = %d, want 1", c.event, got)
+		for _, v6 := range []bool{false, true} {
+			family := "v4"
+			if v6 {
+				family = "v6"
 			}
-		})
+			t.Run(c.event+"/"+family, func(t *testing.T) {
+				p := &Plugin{}
+				m := &dhcpManager{plugin: p}
+				m.setLastIP(v6, addr)
+
+				m.handleEvent(udhcpc.Event{Type: c.event, Data: udhcpc.Info{IP: addr.String()}}, v6)
+
+				if got := c.aggregate(p); got != 1 {
+					t.Errorf("%s aggregate = %d, want 1", c.event, got)
+				}
+				wantV6 := int32(0)
+				if v6 {
+					wantV6 = 1
+				}
+				if got := c.v6(p); got != wantV6 {
+					t.Errorf("%s v6 sibling = %d, want %d", c.event, got, wantV6)
+				}
+			})
+		}
 	}
 
 	t.Run("deconfig and unknown bump nothing", func(t *testing.T) {

--- a/pkg/plugin/endpoints.go
+++ b/pkg/plugin/endpoints.go
@@ -289,6 +289,17 @@ type HealthResponse struct {
 	// degrades forensics, not networking; operators using audit_log
 	// alert on this directly.
 	LedgerWriteFailures int32 `json:"ledger_write_failures"`
+
+	// Per-family (IPv6) breakdown of the wire counters (#212). Each
+	// counts only the v6 client's events; the un-suffixed fields above
+	// remain v4+v6 aggregates, so the v4 share is the aggregate minus
+	// the matching *_v6 value. On a dual-stack host this isolates the
+	// v6-specific failure signal (NAK/timeout) the aggregate hides.
+	LeaseChangedV6   int32 `json:"lease_changed_v6"`
+	LeasesObtainedV6 int32 `json:"leases_obtained_v6"`
+	LeasesRenewedV6  int32 `json:"leases_renewed_v6"`
+	DHCPTimeoutsV6   int32 `json:"dhcp_timeouts_v6"`
+	NAKsReceivedV6   int32 `json:"naks_received_v6"`
 }
 
 func (p *Plugin) apiHealth(w http.ResponseWriter, r *http.Request) {
@@ -318,5 +329,10 @@ func (p *Plugin) apiHealth(w http.ResponseWriter, r *http.Request) {
 		LeaseReleaseFailures:   p.leaseReleaseFailures.Load(),
 		NAKsReceived:           p.naksReceived.Load(),
 		LedgerWriteFailures:    p.ledgerWriteFailures.Load(),
+		LeaseChangedV6:         p.leaseChangedV6.Load(),
+		LeasesObtainedV6:       p.leasesObtainedV6.Load(),
+		LeasesRenewedV6:        p.leasesRenewedV6.Load(),
+		DHCPTimeoutsV6:         p.dhcpTimeoutsV6.Load(),
+		NAKsReceivedV6:         p.naksReceivedV6.Load(),
 	}, http.StatusOK)
 }

--- a/pkg/plugin/endpoints_test.go
+++ b/pkg/plugin/endpoints_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -78,5 +79,48 @@ func TestApiHealth_TombstoneWriteFailureUnhealthy(t *testing.T) {
 	}
 	if got.TombstoneWriteFailures != 2 {
 		t.Errorf("expected 2 tombstone failures reported, got %d", got.TombstoneWriteFailures)
+	}
+}
+
+// TestApiHealth_PerFamilyCounters pins the #212 contract on the wire:
+// the un-suffixed counters stay v4+v6 aggregates while the *_v6 siblings
+// carry the v6 subset, and both surface under their snake_case keys.
+func TestApiHealth_PerFamilyCounters(t *testing.T) {
+	p := &Plugin{
+		startTime:      time.Now(),
+		joinHints:      make(map[string]joinHint),
+		persistentDHCP: make(map[string]*dhcpManager),
+	}
+	// Aggregates are totals; the v6 siblings are a subset of them.
+	p.naksReceived.Add(5)
+	p.naksReceivedV6.Add(2)
+	p.dhcpTimeouts.Add(3)
+	p.dhcpTimeoutsV6.Add(1)
+	p.leaseChanged.Add(4)
+	p.leaseChangedV6.Add(4)
+
+	req := httptest.NewRequest(http.MethodGet, "/Plugin.Health", nil)
+	rec := httptest.NewRecorder()
+	p.apiHealth(rec, req)
+
+	var got HealthResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.NAKsReceived != 5 || got.NAKsReceivedV6 != 2 {
+		t.Errorf("naks: aggregate=%d v6=%d, want 5 and 2", got.NAKsReceived, got.NAKsReceivedV6)
+	}
+	if got.DHCPTimeouts != 3 || got.DHCPTimeoutsV6 != 1 {
+		t.Errorf("timeouts: aggregate=%d v6=%d, want 3 and 1", got.DHCPTimeouts, got.DHCPTimeoutsV6)
+	}
+	if got.LeaseChanged != 4 || got.LeaseChangedV6 != 4 {
+		t.Errorf("lease_changed: aggregate=%d v6=%d, want 4 and 4", got.LeaseChanged, got.LeaseChangedV6)
+	}
+
+	// Pin the wire keys so the field names don't silently drift.
+	for _, key := range []string{"naks_received_v6", "dhcp_timeouts_v6", "leases_obtained_v6", "leases_renewed_v6", "lease_changed_v6"} {
+		if !strings.Contains(rec.Body.String(), key) {
+			t.Errorf("Health JSON missing %q field", key)
+		}
 	}
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -333,6 +333,20 @@ type Plugin struct {
 	// attention.
 	naksReceived atomic.Int32
 
+	// Per-family (IPv6) breakdown of the wire counters above (#212).
+	// handleEvent/renew already receive a `v6 bool`; these atoms count
+	// only the v6 client's events. The fields above stay aggregates
+	// (v4+v6) so existing operator alerts keep their meaning — the v4
+	// share is the aggregate minus the matching *V6 atom. On a dual-
+	// stack host this is the only way to tell a v6-specific NAK or
+	// timeout (the signal #152 is landing against) from a v4 one on
+	// /Plugin.Health without scraping logs.
+	leaseChangedV6   atomic.Int32
+	leasesObtainedV6 atomic.Int32
+	leasesRenewedV6  atomic.Int32
+	dhcpTimeoutsV6   atomic.Int32
+	naksReceivedV6   atomic.Int32
+
 	// ledger is the append-only lease audit log (#109), written by
 	// dhcpManager.audit for networks created with audit_log=true.
 	// ledgerWriteFailures counts failed appends, surfaced on


### PR DESCRIPTION
Closes nothing — references #212 (the v1.2.0 release PR batch-closes it).

> **Stacked on #223.** This is based on `feature/152-dhcpv6-ia-unification`, not `dev`, so the diff shows only the #212 change against #223's final dhcpcd event model (the v6 event shape #212 needs). It's a **draft** until #223 merges; GitHub will retarget it to `dev` automatically when #223's branch is deleted, after which I'll undraft. The CodeQL check inherits #223's pending path-injection alert (cleared by #233) — same as #223 itself.

## What
`/Plugin.Health`'s wire counters were family-agnostic — `handleEvent`/`renew` already receive a `v6 bool` but incremented the *same* atom for v4 and v6. On a dual-stack host you couldn't tell a v6 NAK/timeout from a v4 one, which is exactly the signal we want while landing the DHCPv6 work (#152).

## How
- Add `*_v6` sibling counters for the five family-relevant metrics: `leases_obtained`, `leases_renewed`, `dhcp_timeouts`, `naks_received`, `lease_changed`.
- **Backward compatible:** the un-suffixed fields stay **v4+v6 aggregates**, so existing operator alerts keep their meaning; the v4 share is `<counter> − <counter>_v6`. (Chose aggregate-plus-v6-sibling over making the existing fields v4-only, which would silently break v6-inclusive alerts.)
- A one-line `bumpFamily(total, v6Counter, v6)` helper keeps each of the six increment sites tidy.

## Acceptance (from #212)
- [x] Health output distinguishes v4 vs v6 for the wire counters + `lease_changed`.
- [x] Tests assert a v6 event moves the aggregate **and** the v6 sibling, while a v4 event leaves the v6 sibling at zero (and vice versa).
- [x] Health-RPC test pins the new snake_case wire keys.
- [x] Docs Health sections updated (`docs/reference.md`, `docs/parent-attached-modes.md`).

## Verification
`go test ./...`, `go vet`, `staticcheck`, `gofmt` all clean locally. New subtests run both families. Combined coverage (the ratchet floor) is validated by the coverage job; the added code is fully unit-covered.