### PR TITLE
feat(dhcpv6): honor a requested IPv6 address (--ip6 + tombstone hint) (#213)

### DIFF
--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -260,8 +260,9 @@ do; Fritz.Box does **not** unless you also configure a UI-side static
 reservation for the container's MAC. With a stable MAC (which the
 plugin gives you across restarts), that reservation persists.
 
-`ip` must be a bare IPv4 address. IPv6 driver-opt is not yet wired
-through to `udhcpc6`.
+`ip` must be a bare IPv4 address. There is no `ip6` driver-opt; request
+a specific v6 address with `--ip6` / `Interface.AddressIPv6` instead
+(honored since v1.2.0 — see the v6 hint note below).
 
 ## Restart stability (MAC and IP)
 
@@ -334,10 +335,13 @@ What you get, and the boundaries (v1.0.0 audit, #103):
   parent's MAC, so they share one DUID too — v6 servers tell them
   apart only by IAID, and per-container v6 reservations are not
   practical in ipvlan mode (same shape as the v4 MAC limitation).
-- **No static-v6 hint:** udhcpc6 has no v4-style `-r` request flag,
-  so `--ip6` / static v6 requests are accepted-but-ignored (logged);
-  the lease always arrives server-chosen. Use a DUID-keyed
-  reservation upstream when you need a fixed v6 address.
+- **Static-v6 hint (v1.2.0+):** a requested v6 address — `--ip6` /
+  `Interface.AddressIPv6`, or the address inherited from a tombstone on
+  restart — is sent to dhcpcd as the IA_NA preferred address
+  (`ia_na <iaid> / ADDR`), the v6 counterpart of `--ip`. The server
+  still has final say, but a dual-stack container now keeps its v6
+  address across `docker restart` like it keeps v4. (DUID-keyed
+  upstream reservations still work and stack with this.)
 - `propagate_dns=true` also covers v6: the DHCPv6 option-23 server
   list is written to `resolv.conf` on v6 bind/renew. The two
   families are last-writer-wins on that file.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -164,9 +164,13 @@ Passed per container via `docker network connect --driver-opt`, or as
 | `ip` | Request a specific IPv4 address (bare IP, no CIDR — the netmask comes from DHCP). Equivalent to `docker run --ip`; setting both to different values is an error. The address is *requested* from the DHCP server (DHCPREQUEST for it); the server still has final say. |
 | `com.docker.network.endpoint.ifname` | (v1.0.0+) Request a specific interface name inside the container (Compose `interface_name`, engine 28+; or this key under `driver_opts`, any engine). The plugin validates the name (≤15 bytes, kernel charset — invalid names fail the attach with a clear error) and returns it in its Join response. **Current engine limitation:** moby's remote-driver layer discards the returned name (`drivers/remote/driver.go` passes an empty `DstName`), so engines do not yet apply it for *plugin* drivers — built-in drivers only. The plugin side is ready; the rename activates as soon as the upstream pass-through ships. Until then interfaces stay `ethN` in attach order. |
 
-A static IPv6 request (`--ip6` / Interface.AddressIPv6) is currently
-accepted but logged-and-skipped — busybox udhcpc6 has no
-request-this-address flag. The v6 lease comes unhinted.
+A static IPv6 request (`--ip6` / Interface.AddressIPv6) is honored
+(v1.2.0+): it is sent to the DHCPv6 client as the IA_NA preferred
+address, mirroring `--ip` for v4. The same applies to the v6 address a
+container held before a restart — it is inherited from the tombstone
+and re-requested — so a dual-stack container keeps both addresses
+across `docker restart`. As with v4, the server has final say. (There
+is no `ip6` *driver-opt* channel — use `--ip6` / `AddressIPv6`.)
 
 Container-level knobs that interact with the plugin:
 

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -567,9 +567,19 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 	// no-op (server still ACKs the same address). On recovery it's
 	// what makes the lease "sticky".
 	requestedIP := ""
+	preferredV6 := ""
 	if !v6 {
 		if v4Addr, _ := m.lastIPs(); v4Addr != nil && v4Addr.IP != nil {
 			requestedIP = v4Addr.IP.String()
+		}
+	} else {
+		// Same stickiness for v6: on recovery ask for the IA_NA address
+		// the container already holds (lastIPv6 is seeded from the
+		// recovered state) rather than risk a fresh one. In the normal
+		// create->Join path it's a no-op — dhcpcd's pinned IA already
+		// returns the same address (#213).
+		if _, v6Addr := m.lastIPs(); v6Addr != nil && v6Addr.IP != nil {
+			preferredV6 = v6Addr.IP.String()
 		}
 	}
 	client, err := udhcpc.NewDHCPClient(m.ctrLink.Attrs().Name, &udhcpc.DHCPClientOptions{
@@ -582,6 +592,7 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 		// Docker was told about (#152).
 		MAC:         m.ctrLink.Attrs().HardwareAddr,
 		RequestedIP: requestedIP,
+		PreferredV6: preferredV6,
 		// ipvlan slaves share the parent's MAC; without -B the server
 		// may unicast renewals to the parent and the kernel has no
 		// way to demux to the right slave. Setting Broadcast for

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -308,6 +308,30 @@ func resolveExplicitV4(r CreateEndpointRequest) (string, error) {
 	return fromOpt, nil
 }
 
+// resolveExplicitV6 returns the bare IPv6 address the user requested via
+// `docker run --ip6` (libnetwork Interface.AddressIPv6), or "" when none
+// was supplied. The v6 counterpart of resolveExplicitV4, minus the
+// driver-opt channel (there is no `ip6` driver-opt — #213 scope is
+// `--ip6` and the tombstone v6 hint). libnetwork passes AddressIPv6 in
+// CIDR form; we hand the bare address to dhcpcd's `ia_na / ADDR`
+// preferred-address request (#213).
+func resolveExplicitV6(r CreateEndpointRequest) (string, error) {
+	if r.Interface == nil || r.Interface.AddressIPv6 == "" {
+		return "", nil
+	}
+	addr, err := netlink.ParseAddr(r.Interface.AddressIPv6)
+	if err != nil {
+		return "", fmt.Errorf("invalid Interface.AddressIPv6 %q (want CIDR): %w", r.Interface.AddressIPv6, util.ErrIPAM)
+	}
+	if addr.IP.To4() != nil {
+		return "", fmt.Errorf("Interface.AddressIPv6 must be IPv6: got %q: %w", r.Interface.AddressIPv6, util.ErrIPAM)
+	}
+	if addr.IP.IsUnspecified() {
+		return "", fmt.Errorf("Interface.AddressIPv6 must be a unicast IPv6: got %q: %w", r.Interface.AddressIPv6, util.ErrIPAM)
+	}
+	return addr.IP.String(), nil
+}
+
 // parseDriverOptIP extracts the bare IPv4 address from an optional
 // `ip` driver-option. libnetwork places per-endpoint driver-opts
 // (from `docker network connect --driver-opt KEY=VAL`) as flat keys
@@ -385,19 +409,15 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 		Interface: &EndpointInterface{},
 	}
 
-	// libnetwork passes Interface.AddressIPv6 when the user supplied
-	// `--ip6` on `docker run`. We don't yet wire that through to
-	// udhcpc6 (RequestedIP is v4-only in busybox), so honor it on a
-	// best-effort basis: warn loudly but don't fail the endpoint.
-	if r.Interface != nil && r.Interface.AddressIPv6 != "" {
-		log.WithFields(log.Fields{
-			"network":  shortID(r.NetworkID),
-			"endpoint": shortID(r.EndpointID),
-			"ipv6":     r.Interface.AddressIPv6,
-		}).Warn("Static IPv6 address requested but not yet wired through to udhcpc6; lease will come unhinted")
-	}
-
 	explicitV4, err := resolveExplicitV4(r)
+	if err != nil {
+		return res, err
+	}
+	// `docker run --ip6` arrives as Interface.AddressIPv6. Since #152
+	// pins the dhcpcd IA_NA we can now request it as the DHCPv6
+	// preferred address, so validate it here and ride it into the
+	// one-shot below (mirrors explicitV4 / RequestedIP for v4) (#213).
+	explicitV6, err := resolveExplicitV6(r)
 	if err != nil {
 		return res, err
 	}
@@ -449,17 +469,21 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 	// identity, and we don't want to surprise-mix in a stale neighbor.
 	effectiveMAC := r.Interface.MacAddress
 	requestedIP := explicitV4
+	requestedV6 := explicitV6
 	if effectiveMAC == "" {
 		if mac, ip, ipv6, ok := p.consumeTombstone(r.NetworkID, hostname); ok {
 			effectiveMAC = mac
 			if requestedIP == "" {
 				requestedIP = ip
 			}
-			// IPv6 from the tombstone is logged but not yet wired to
-			// udhcpc6 (busybox has no `-r` equivalent for v6). The
-			// data is preserved through the full lifecycle so a
-			// future change can request preferred-address from a
-			// DHCPv6 client without a wire-format change.
+			// Inherit the prior endpoint's IPv6 as the DHCPv6
+			// preferred address too, unless `--ip6` already named one,
+			// so a restarting container keeps its v6 lease the same
+			// way it keeps its v4 lease (#213). The tombstone preserves
+			// the bare address end-to-end for exactly this.
+			if requestedV6 == "" {
+				requestedV6 = ipv6
+			}
 			log.WithFields(log.Fields{
 				"network":      shortID(r.NetworkID),
 				"endpoint":     shortID(r.EndpointID),
@@ -550,9 +574,12 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 				// server returns a single binding (#152).
 				MAC: ctrLink.Attrs().HardwareAddr,
 			}
-			// RequestedIP is v4-only in udhcpc; passing it for v6
-			// would be silently ignored anyway, but keep it explicit.
-			if !v6 {
+			// Hint the preferred address per family: `request ADDR`
+			// for v4, `ia_na / ADDR` for v6 (#213). Empty values omit
+			// the directive, so an unhinted endpoint behaves as before.
+			if v6 {
+				clientOpts.PreferredV6 = requestedV6
+			} else {
 				clientOpts.RequestedIP = requestedIP
 			}
 			info, err := udhcpc.GetIP(timeoutCtx, ctrName, clientOpts)

--- a/pkg/plugin/network_test.go
+++ b/pkg/plugin/network_test.go
@@ -274,6 +274,63 @@ func TestResolveExplicitV4(t *testing.T) {
 	}
 }
 
+func TestResolveExplicitV6(t *testing.T) {
+	cases := []struct {
+		name    string
+		r       CreateEndpointRequest
+		wantIP  string
+		wantErr bool
+	}{
+		{name: "nil_interface", wantIP: ""},
+		{name: "empty_address", r: CreateEndpointRequest{Interface: &EndpointInterface{}}, wantIP: ""},
+		{
+			name:   "valid_v6_cidr",
+			r:      CreateEndpointRequest{Interface: &EndpointInterface{AddressIPv6: "fd00:dead:beef::5/64"}},
+			wantIP: "fd00:dead:beef::5",
+		},
+		{
+			name:    "v4_rejected",
+			r:       CreateEndpointRequest{Interface: &EndpointInterface{AddressIPv6: "192.168.0.50/24"}},
+			wantErr: true,
+		},
+		{
+			name:    "bare_addr_no_mask_rejected",
+			r:       CreateEndpointRequest{Interface: &EndpointInterface{AddressIPv6: "fd00::5"}},
+			wantErr: true,
+		},
+		{
+			name:    "garbage",
+			r:       CreateEndpointRequest{Interface: &EndpointInterface{AddressIPv6: "not-an-ip"}},
+			wantErr: true,
+		},
+		{
+			name:    "unspecified_v6_rejected",
+			r:       CreateEndpointRequest{Interface: &EndpointInterface{AddressIPv6: "::/0"}},
+			wantErr: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ip, err := resolveExplicitV6(c.r)
+			if c.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil (ip=%q)", ip)
+				}
+				if err != nil && !errors.Is(err, util.ErrIPAM) {
+					t.Errorf("expected ErrIPAM, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if ip != c.wantIP {
+				t.Errorf("ip mismatch: got %q want %q", ip, c.wantIP)
+			}
+		})
+	}
+}
+
 func TestValidateIPAMData(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -97,6 +97,10 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 	if err != nil {
 		return res, err
 	}
+	explicitV6, err := resolveExplicitV6(r)
+	if err != nil {
+		return res, err
+	}
 	// Look up the hostname up front so we can scope tombstone matching
 	// to the same container (prevents identity swap during sequential
 	// `compose restart`). Best-effort: if the lookup misses or returns
@@ -104,11 +108,18 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 	hostname := p.initialDHCPHostname(ctx, r.NetworkID, r.EndpointID)
 
 	requestedIP := explicitV4
+	requestedV6 := explicitV6
 	if mode == ModeMacvlan && effectiveMAC == "" {
 		if tombMAC, tombIP, tombIPv6, ok := p.consumeTombstone(r.NetworkID, hostname); ok {
 			effectiveMAC = tombMAC
 			if requestedIP == "" {
 				requestedIP = tombIP
+			}
+			// Inherit the prior v6 as the DHCPv6 preferred address too,
+			// so a restarting macvlan container keeps its v6 lease the
+			// same way it keeps v4 (#213).
+			if requestedV6 == "" {
+				requestedV6 = tombIPv6
 			}
 			log.WithFields(log.Fields{
 				"network":  shortID(r.NetworkID),
@@ -230,7 +241,9 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 				// tombstone-preserved MACs).
 				MAC: mac,
 			}
-			if !v6 {
+			if v6 {
+				clientOpts.PreferredV6 = requestedV6
+			} else {
 				clientOpts.RequestedIP = requestedIP
 			}
 			info, err := udhcpc.GetIP(tCtx, la.Name, clientOpts)

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -90,11 +90,10 @@ type tombstone struct {
 	// "do an unhinted DISCOVER".
 	IPAddress string `json:"ip_address,omitempty"`
 	// IPv6Address, when non-empty, is the bare IPv6 address from the
-	// previous lease. busybox udhcpc6 has no `-r` equivalent so this
-	// isn't surfaced as a request hint today, but it's persisted so
-	// (a) operators can correlate disk-state with leases and (b) a
-	// future change to a DHCPv6 client that supports preferred-
-	// address requests can read it without a wire-format change.
+	// previous lease. Since #152 (dhcpcd) and #213 it is requested as
+	// the DHCPv6 preferred address (IA_NA) on the next CreateEndpoint,
+	// so a restarting container keeps its v6 lease the same way the
+	// IPAddress hint keeps its v4 lease.
 	IPv6Address string    `json:"ipv6_address,omitempty"`
 	DeletedAt   time.Time `json:"deleted_at"`
 }

--- a/test/integration/ipv6_test.go
+++ b/test/integration/ipv6_test.go
@@ -15,9 +15,12 @@
 //     PluginRestart asserts this end-to-end.
 //   - option 23 (DNS servers) is requested by default — the `dns6`
 //     env arrives without any -O flag.
-//   - there is no "request this address" flag for v6 (`-r` is v4
-//     only), so v6 leases always come unhinted; continuity relies on
-//     the server recognising the stable DUID.
+//
+// Since #152 the v6 client is dhcpcd (not busybox udhcpc6), and #213
+// wires a preferred-address request: a requested v6 (`--ip6` or
+// tombstone-inherited) is sent as the IA_NA preferred address
+// (`ia_na <iaid> / ADDR`), so v6 stickiness no longer relies on the
+// server's DUID memory alone.
 package integration
 
 import (
@@ -217,6 +220,75 @@ func TestLifecycleMacvlan_IPv6_GoldenPath(t *testing.T) {
 	if after.LeaseReleaseFailures != before.LeaseReleaseFailures {
 		t.Errorf("lease_release_failures moved %d -> %d over a dual-stack lifecycle; the v6 Stop path is failing",
 			before.LeaseReleaseFailures, after.LeaseReleaseFailures)
+	}
+}
+
+// TestTombstoneRestart_PreservesIPv6 is the #213 acceptance test — the
+// v6 sibling of TestTombstoneRestart_PreservesMACAndIP. On Leave the
+// plugin tombstones the endpoint's v6 address; on the restart's
+// CreateEndpoint that address is requested back as the DHCPv6 preferred
+// address (dhcpcd `ia_na <iaid> / ADDR`), so a dual-stack container
+// keeps its v6 lease across `docker restart` exactly as it keeps v4.
+func TestTombstoneRestart_PreservesIPv6(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	netName := "dh-itest-v6tomb"
+	ctrName := "dh-itest-v6tomb-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{"ipv6": "true"})
+	id, v4Before, macBefore := harness.RunContainer(t, ctx, netName, ctrName)
+	v6Before := linkGlobalV6(t, ctx, id, harness.IPAcquisitionBudget)
+	if v6Before == "" {
+		t.Fatal("no global IPv6 appeared before restart")
+	}
+	t.Logf("before restart: v4=%s v6=%s mac=%s", v4Before, v6Before, macBefore)
+
+	if err := cli.ContainerRestart(ctx, id, container.StopOptions{}); err != nil {
+		t.Fatalf("ContainerRestart: %v", err)
+	}
+
+	// The endpoint is torn down and recreated; wait for the v6 to
+	// reappear on the link before reading the settled values.
+	v6After := linkGlobalV6(t, ctx, id, harness.IPAcquisitionBudget)
+	if v6After == "" {
+		t.Fatalf("container did not re-acquire a global IPv6 within %v after restart", harness.IPAcquisitionBudget)
+	}
+	insV6 := inspectV6(t, ctx, cli, id, netName)
+	ins, err := cli.ContainerInspect(ctx, id)
+	if err != nil {
+		t.Fatalf("ContainerInspect: %v", err)
+	}
+	var v4After, macAfter string
+	if ep := ins.NetworkSettings.Networks[netName]; ep != nil {
+		v4After, macAfter = ep.IPAddress, ep.MacAddress
+	}
+	t.Logf("after restart:  v4=%s v6=%s (inspect v6=%s) mac=%s", v4After, v6After, insV6, macAfter)
+
+	if macAfter != macBefore {
+		t.Errorf("MAC changed across restart: before=%s after=%s (tombstone not honored)", macBefore, macAfter)
+	}
+	if v6After != v6Before {
+		t.Errorf("IPv6 changed across restart: before=%s after=%s (tombstone v6 not requested as preferred address)", v6Before, v6After)
+	}
+	if v4After != v4Before {
+		t.Errorf("IPv4 changed across restart: before=%s after=%s", v4Before, v4After)
+	}
+	if insV6 != "" && !net.ParseIP(insV6).Equal(net.ParseIP(v6After)) {
+		t.Errorf("inspect IPv6 %s != live link IPv6 %s after restart", insV6, v6After)
 	}
 }
 


### PR DESCRIPTION
References #213 (the v1.2.0 release PR batch-closes it). Builds on #152 (dhcpcd), now merged.

## Problem
Two IPv6 inputs were captured but silently dropped, because busybox udhcpc6 had no v6 equivalent of `-r`:
1. **`--ip6`** (libnetwork `Interface.AddressIPv6`) — `CreateEndpoint` logged a warning and proceeded unhinted.
2. **Tombstone v6 hint** — the prior endpoint's v6 was preserved end-to-end but only logged, so a restarting dual-stack container kept its v4 address (via `-r`) while its v6 could change.

## Fix
#152 moved the v6 client to **dhcpcd**, which *can* request a preferred IA_NA address (the `ia_na <iaid> / ADDR` directive + `DHCPClientOptions.PreferredV6` already exist). This PR is the plugin-layer plumbing on top:

- `resolveExplicitV6` validates `--ip6` (mirrors `resolveExplicitV4`; CIDR in, bare out; rejects v4/unspecified).
- **Bridge one-shot** (`network.go`) and **macvlan/ipvlan one-shot** (`parent_attached.go`) carry the requested v6 — explicit `--ip6` first, else the tombstone v6 on restart — into `clientOpts.PreferredV6`.
- **Persistent client** (`dhcp_manager.go`) requests the recovered v6 on plugin-restart recovery (mirrors the existing v4 `RequestedIP` stickiness), so recovery works even with no one-shot.
- The accepted-but-ignored `CreateEndpoint` warning is **removed**.

The un-hinted path is unchanged: empty values omit the directive.

## Acceptance (from #213)
- [x] A requested v6 (`--ip6` or tombstone-inherited) is sent as the DHCPv6 preferred address.
- [x] Integration test: dual-stack container keeps its v6 across `docker restart` (v6 sibling of `TestTombstoneRestart_PreservesMACAndIP`).
- [x] The `CreateEndpoint` warning is removed.

## Tests & verification
- Unit: `TestResolveExplicitV6` (mirrors the v4 cases). The `ia_na` rendering is already covered by #152's `dhcpcd_test.go`.
- Integration: `TestTombstoneRestart_PreservesIPv6` (runs on the integration runner).
- `go build`/`vet`/`staticcheck`/`gofmt` clean; unit suite green; integration package compiles (root-gated at runtime).
- Docs corrected: `reference.md` and `parent-attached-modes.md` previously stated v6 requests were ignored — updated to describe the v1.2.0 behavior. (mkdocs `--strict` validated by the Pages build job.)