### PR TITLE
ci(integration): opt-in hosted cross-check lane (#238)

### DIFF
--- a/.github/workflows/integration-hosted.yml
+++ b/.github/workflows/integration-hosted.yml
@@ -28,16 +28,20 @@ name: Integration (hosted cross-check)
 # See integration.yml for the self-hosted rationale this mirrors.
 #
 # SECURITY: the test steps run as root via sudo. Only workflow_dispatch
-# triggers this — forks cannot start it, so there is no
-# untrusted-PR-as-root exposure.
+# and schedule trigger this — never push/pull_request, so a fork PR
+# can't start it and there is no untrusted-PR-as-root exposure (the
+# scheduled run executes the default branch's own code).
 on:
-  # On-demand only for now. The weekly schedule is intentionally NOT
-  # enabled yet: this lane currently fails on #247 (dhcpcd writes kernel
-  # sysctls on interface setup, which EROFS on a read-only /proc/sys),
-  # so a cron would be a weekly red alarm with no new signal. The #247
-  # fix re-enables the schedule once the lane goes green:
-  #   schedule:
-  #     - cron: '17 4 * * 1'   # weekly Mon 04:17 UTC, off-peak odd minute
+  # Weekly cron + on-demand. The schedule was held until #247 landed:
+  # the lane fell over on a read-only /proc/sys (dhcpcd writes kernel
+  # sysctls on interface setup), so a cron would have been a weekly red
+  # alarm with no new signal. #247 is fixed (the client remounts
+  # /proc/sys rw in its private mount namespace) and this lane was
+  # validated green against the fix, so the cron is now live. Note: a
+  # scheduled trigger only fires once this file is on the default
+  # branch, so it starts running after the next release reaches main.
+  schedule:
+    - cron: '17 4 * * 1'   # weekly Mon 04:17 UTC, off-peak odd minute
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/integration-hosted.yml
+++ b/.github/workflows/integration-hosted.yml
@@ -1,0 +1,104 @@
+name: Integration (hosted cross-check)
+
+# OPT-IN portability cross-check — NOT a gate and NOT a fallback.
+#
+# This runs the live integration suite on a stock GitHub-hosted
+# `ubuntu-latest` runner to answer one question the self-hosted
+# `dhcp-ci` pool can't: does the plugin work against a vanilla distro's
+# Docker, on a runner we don't build or control? It surfaces
+# assumptions baked into our purpose-built runner image (the pre-baked
+# Go toolchain, the nested-daemon model, host config) that
+# integration.yml is blind to by construction.
+#
+# It is deliberately:
+#   * NOT wired to push / pull_request — never gates a PR or a release.
+#   * NOT a required status check — a red here is an FYI about the
+#     hosted environment, not a regression signal against our code.
+#   * NOT a substitute for an offline self-hosted runner. GitHub
+#     Actions has no label-based failover; outage resilience is the
+#     second-runner-VM track, not this lane.
+#
+# Feasibility note (corrects the old "infeasible on hosted" lore): a
+# hosted runner is a full VM with passwordless sudo, so CAP_NET_ADMIN,
+# veth/netns ops, dnsmasq and binding UDP/67 all work. The historical
+# blocker was Docker Engine version — our runner image pins Engine >=28
+# and hosted used to lag. As of ubuntu-24.04 the hosted image ships
+# Docker Server 28.x (same engine major), so a hosted run is now on a
+# COMPARABLE engine and its results are meaningful rather than noise.
+# See integration.yml for the self-hosted rationale this mirrors.
+#
+# SECURITY: the test steps run as root via sudo. Only workflow_dispatch
+# and schedule trigger this — forks cannot start it, so there is no
+# untrusted-PR-as-root exposure.
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Monday 04:17 UTC. Off-peak, odd minute to avoid the
+    # top-of-hour cron stampede on GitHub's scheduler.
+    - cron: '17 4 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  integration-hosted:
+    runs-on: ubuntu-latest
+    # Same 35m budget as integration.yml: main suite + failure-injection
+    # suite (~9 min of deliberate DHCP-timing waits) + plugin build +
+    # margin. Hosted hardware is unproven for this suite — the first
+    # dispatch runs calibrate whether this holds (see #238).
+    timeout-minutes: 35
+    env:
+      # Distinct tag from :integration (self-hosted) and :golang-cover
+      # (coverage). The VM is ephemeral so collisions can't happen, but
+      # a self-describing ref keeps logs unambiguous.
+      INTEGRATION_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:integration-hosted
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Hosted runners have no pre-baked toolchain (unlike the dhcp-ci
+      # image, which bakes go.mod's Go and skips setup-go). Pin to the
+      # go.mod minor so the cross-check tracks our real toolchain.
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: '1.26'
+
+      # Record the environment under test — the whole point of this lane
+      # is to know exactly which hosted Docker/Go a green (or red) ran
+      # against. Fail loudly if the engine ever regresses below 28.
+      - name: Show environment under test
+        run: |
+          go version
+          docker version
+          server_major="$(docker version -f '{{.Server.Version}}' | cut -d. -f1)"
+          if [ "${server_major}" -lt 28 ]; then
+            echo "::warning::hosted Docker Engine ${server_major}.x < 28 — below our pinned floor; results may diverge from self-hosted"
+          fi
+
+      # Build + install the plugin from THIS tree, exactly as
+      # integration.yml does, just under a hosted-specific tag.
+      - name: Build + install integration plugin
+        run: |
+          make PLUGIN_NAME=ghcr.io/claymore666/docker-net-dhcp PLUGIN_TAG=integration-hosted plugin
+          docker plugin rm -f "${INTEGRATION_PLUGIN_REF}" 2>/dev/null || true
+          docker plugin create "${INTEGRATION_PLUGIN_REF}" plugin
+          docker plugin set "${INTEGRATION_PLUGIN_REF}" LOG_LEVEL=trace
+          docker plugin enable "${INTEGRATION_PLUGIN_REF}"
+
+      # The Makefile targets require root (netns/veth/UDP-67). Hosted
+      # runs as the `runner` user with passwordless sudo, so wrap with
+      # sudo — and forward PATH (for the setup-go toolchain) and the
+      # plugin ref explicitly, since sudo resets the environment.
+      - name: Run integration tests
+        run: sudo env "PATH=$PATH" "INTEGRATION_PLUGIN_REF=$INTEGRATION_PLUGIN_REF" make integration-test
+
+      - name: Run failure-injection tests
+        run: sudo env "PATH=$PATH" "INTEGRATION_PLUGIN_REF=$INTEGRATION_PLUGIN_REF" make integration-test-failure
+
+      # Belt-and-braces on an ephemeral VM, kept for parity with
+      # integration.yml so the two workflows read the same.
+      - name: Tear down integration plugin
+        if: always()
+        run: |
+          docker plugin disable "${INTEGRATION_PLUGIN_REF}" 2>/dev/null || true
+          docker plugin rm -f "${INTEGRATION_PLUGIN_REF}" 2>/dev/null || true

--- a/.github/workflows/integration-hosted.yml
+++ b/.github/workflows/integration-hosted.yml
@@ -82,6 +82,23 @@ jobs:
             echo "::warning::hosted Docker Engine ${server_major}.x < 28 — below our pinned floor; results may diverge from self-hosted"
           fi
 
+      # Host-side fixture dependencies the dhcp-ci runner image bakes in
+      # but a stock hosted runner lacks: dnsmasq (the test-spawned DHCP
+      # server on veth pairs) and ping (the failure-injection suite's
+      # L2-reachability check). Use dnsmasq-BASE, not the dnsmasq
+      # package: it ships the /usr/sbin/dnsmasq binary the fixtures exec
+      # directly, WITHOUT the systemd service that would otherwise start
+      # on this (systemd-having) host and contend for UDP/53+67 with the
+      # per-test dnsmasq instances. iputils-ping is usually preinstalled;
+      # listed for parity with the runner image and to fail loud if not.
+      - name: Install integration fixture dependencies
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            dnsmasq-base iputils-ping
+          # The harness execs this absolute path (test/integration/harness)
+          test -x /usr/sbin/dnsmasq && /usr/sbin/dnsmasq --version | head -1
+
       # Build + install the plugin from THIS tree, exactly as
       # integration.yml does, just under a hosted-specific tag.
       - name: Build + install integration plugin

--- a/.github/workflows/integration-hosted.yml
+++ b/.github/workflows/integration-hosted.yml
@@ -31,6 +31,13 @@ name: Integration (hosted cross-check)
 # and schedule trigger this — forks cannot start it, so there is no
 # untrusted-PR-as-root exposure.
 on:
+  # TEMPORARY (reverted before merge): branch-scoped push trigger so the
+  # lane can be validated on a real hosted runner pre-merge —
+  # workflow_dispatch only fires for workflows already on the default
+  # branch, so it cannot be dispatched from a feature branch.
+  push:
+    branches:
+      - ci/238-hosted-integration-crosscheck
   workflow_dispatch:
   schedule:
     # Weekly, Monday 04:17 UTC. Off-peak, odd minute to avoid the

--- a/.github/workflows/integration-hosted.yml
+++ b/.github/workflows/integration-hosted.yml
@@ -28,21 +28,17 @@ name: Integration (hosted cross-check)
 # See integration.yml for the self-hosted rationale this mirrors.
 #
 # SECURITY: the test steps run as root via sudo. Only workflow_dispatch
-# and schedule trigger this — forks cannot start it, so there is no
+# triggers this — forks cannot start it, so there is no
 # untrusted-PR-as-root exposure.
 on:
-  # TEMPORARY (reverted before merge): branch-scoped push trigger so the
-  # lane can be validated on a real hosted runner pre-merge —
-  # workflow_dispatch only fires for workflows already on the default
-  # branch, so it cannot be dispatched from a feature branch.
-  push:
-    branches:
-      - ci/238-hosted-integration-crosscheck
+  # On-demand only for now. The weekly schedule is intentionally NOT
+  # enabled yet: this lane currently fails on #247 (dhcpcd writes kernel
+  # sysctls on interface setup, which EROFS on a read-only /proc/sys),
+  # so a cron would be a weekly red alarm with no new signal. The #247
+  # fix re-enables the schedule once the lane goes green:
+  #   schedule:
+  #     - cron: '17 4 * * 1'   # weekly Mon 04:17 UTC, off-peak odd minute
   workflow_dispatch:
-  schedule:
-    # Weekly, Monday 04:17 UTC. Off-peak, odd minute to avoid the
-    # top-of-hour cron stampede on GitHub's scheduler.
-    - cron: '17 4 * * 1'
 
 permissions:
   contents: read

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,9 +1,13 @@
 name: Integration
 
 # Live integration tests against the plugin. Run on the self-hosted
-# `dhcp-ci` runners because they need privileges (CAP_NET_ADMIN,
-# mount/netns ops, bind UDP/67) and a real DHCP server (dnsmasq) —
-# neither is feasible on free GitHub-hosted runners.
+# `dhcp-ci` runners: they need privileges (CAP_NET_ADMIN, mount/netns
+# ops, bind UDP/67) and a real DHCP server (dnsmasq). Those work on a
+# GitHub-hosted VM too (full root via sudo) — the reason this lane is
+# self-hosted is control and parity: a purpose-built image pinning the
+# toolchain and Docker Engine >=28, pooled for parallelism, gives a
+# stable per-PR gate. A stock hosted runner is exercised separately and
+# non-gating by integration-hosted.yml (#238) as a portability check.
 #
 # The `dhcp-ci` runners are ephemeral: one container = one job, each
 # with its own nested Docker daemon (image ghcr.io/claymore666/

--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ Contributions are welcome.
   - **Green CI:** every PR must pass the required checks — unit tests,
     `staticcheck`, the live integration suite, `govulncheck`, and `actionlint` —
     before it can be merged.
+  - **Hosted cross-check:** a separate, *non-required* workflow runs the
+    integration suite on a stock GitHub-hosted runner on a weekly schedule
+    (and on demand) to validate the plugin against a vanilla distro's Docker.
+    It is a portability probe, not a PR gate — a red there flags the hosted
+    environment, not your change.
 - **Security vulnerabilities:** do **not** open a public issue — follow the
   private process described in [SECURITY.md](SECURITY.md).
 


### PR DESCRIPTION
Closes #238.

## What

Adds `integration-hosted.yml`: an **opt-in, non-gating** lane that runs
the live integration + failure-injection suites on a stock
`ubuntu-latest` runner. It's a portability cross-check — "does the
plugin work against a vanilla distro's Docker, on a runner we don't
build?" — distinct from the self-hosted gate, not redundant with it.

- Triggers: `workflow_dispatch` + weekly `schedule`. **Not** wired to
  push/PR, **not** a required check. A red flags the hosted
  environment, not a regression.
- Uses `actions/setup-go` (hosted has no pre-baked toolchain) and runs
  the root-requiring Make targets via `sudo`, forwarding `PATH` and
  `INTEGRATION_PLUGIN_REF`.
- Distinct plugin tag (`:integration-hosted`) to keep logs unambiguous.

## Why now

The historical "infeasible on hosted" reasoning was Docker Engine
version — we pin Engine ≥28 and hosted used to lag. `ubuntu-24.04` now
ships **Docker 28.x** (same engine major), so a hosted run is on a
*comparable* engine and its results are meaningful. Privileges/DHCP
were never the real blocker (a hosted runner is a full root VM).

Also corrects `integration.yml`'s header (the suite *is* feasible on
hosted; self-hosted is about control/parity) and documents the
non-required cross-check in the README.

## Validation

GitHub only lets `workflow_dispatch` fire for workflows already on the
default branch (`main`), so the lane can't be dispatched from a feature
branch. To exercise it for real pre-merge, this branch carries a
**temporary** branch-scoped `push` trigger.

- [ ] Hosted spike green on `ubuntu-latest` (both suites)
- [ ] Temporary `push` trigger reverted (lane back to dispatch+schedule only)

## Non-goals

- Not a fallback for self-hosted outages (Actions has no label-based
  failover — that's the second-runner track).
- Never gates a PR or release.
