### PR TITLE
chore: refresh stale udhcpc/busybox code comments after the dhcpcd migration (#242)

### DIFF
--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -27,14 +27,14 @@ const linkAwaitTimeout = 30 * time.Second
 
 const pollTime = 100 * time.Millisecond
 
-// dhcpClientReapTimeout caps how long the udhcpc consumer waits to
+// dhcpClientReapTimeout caps how long the dhcpcd consumer waits to
 // reap a self-exited child process before giving up and letting it
 // linger as a zombie. The kernel's eventual reaping by init handles
 // the worst case; this just bounds wall time on the cleanup path.
 const dhcpClientReapTimeout = 5 * time.Second
 
 // dhcpClientFinishTimeout caps how long Stop waits for SIGTERM ->
-// DHCPRELEASE -> exit on the persistent udhcpc child. Long enough
+// DHCPRELEASE -> exit on the persistent dhcpcd child. Long enough
 // for a DHCPRELEASE round-trip on a healthy LAN; short enough that
 // plugin shutdown / Leave isn't held hostage by an unresponsive
 // upstream DHCP server.
@@ -111,7 +111,7 @@ type dhcpManager struct {
 	// every production path goes through Plugin.Join.
 	plugin *Plugin
 
-	// ipMu guards lastIP / lastIPv6. Writes happen from the udhcpc
+	// ipMu guards lastIP / lastIPv6. Writes happen from the dhcpcd
 	// event goroutine (renew); reads happen from Leave after Stop has
 	// drained that goroutine. The drain establishes happens-before in
 	// practice, but the race detector doesn't always see the channel
@@ -381,17 +381,17 @@ func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
 	}
 
 	// Track the freshly-bound address so Leave can hand it to the
-	// tombstone (and thus the next CreateEndpoint's `-r` hint).
-	// Without this the manager keeps reporting whatever the very
-	// first CreateEndpoint DISCOVER produced, even if udhcpc has
+	// tombstone (and thus the next CreateEndpoint's `request`-directive
+	// hint). Without this the manager keeps reporting whatever the very
+	// first CreateEndpoint DISCOVER produced, even if dhcpcd has
 	// moved to a different lease since.
 	m.setLastIP(v6, ip)
 
 	// Apply DHCP option 6 / 23 (DNS server list) when opt-in and the
 	// server actually supplied servers. Empty list is a no-op rather
 	// than a clobber — see resolvconf.go for the rationale. v6 path
-	// uses DHCPv6 option 23, populated by udhcpc6 into the same
-	// DNSServers slice.
+	// uses DHCPv6 option 23, populated by the dhcpcd handler into the
+	// same DNSServers slice.
 	if m.opts.PropagateDNS && len(info.DNSServers) > 0 {
 		ctx, cancel := context.WithTimeout(context.Background(), dnsPropagateTimeout)
 		pid, err := m.findContainerPID(ctx)
@@ -485,7 +485,7 @@ func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
 	return nil
 }
 
-// handleEvent dispatches one udhcpc lifecycle event from the
+// handleEvent dispatches one dhcpcd lifecycle event from the
 // persistent client: health counters, audit-ledger entries, and the
 // kernel-facing renew work. Extracted from the consumer goroutine so
 // the counter semantics are unit-testable — wire-level NAKs in
@@ -574,8 +574,9 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 	// DHCP server for the IP the container is already using, instead
 	// of doing a fresh DISCOVER that might return something different.
 	// In the normal CreateEndpoint -> Join path lastIP / lastIPv6
-	// already point at the IP we just acquired; passing it as -r is a
-	// no-op (server still ACKs the same address). On recovery it's
+	// already point at the IP we just acquired; passing it via the
+	// dhcpcd `request` directive (DHCP option 50) is a no-op (server
+	// still ACKs the same address). On recovery it's
 	// what makes the lease "sticky".
 	requestedIP := ""
 	preferredV6 := ""
@@ -604,10 +605,13 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 		MAC:         m.ctrLink.Attrs().HardwareAddr,
 		RequestedIP: requestedIP,
 		PreferredV6: preferredV6,
-		// ipvlan slaves share the parent's MAC; without -B the server
-		// may unicast renewals to the parent and the kernel has no
-		// way to demux to the right slave. Setting Broadcast for
-		// every renewal in ipvlan mode keeps lease lifecycle stable.
+		// ipvlan slaves share the parent's MAC; without a broadcast
+		// reply the server may unicast renewals to the parent and the
+		// kernel has no way to demux to the right slave. Requesting the
+		// broadcast flag in ipvlan mode keeps lease lifecycle stable.
+		// NOTE: dhcpcd broadcast handling is not yet wired in the client
+		// (DHCPClientOptions.Broadcast, #243) — this flag is set for the
+		// ipvlan path but currently has no effect.
 		Broadcast: m.opts.effectiveMode() == ModeIPvlan,
 		// Same client-id the initial DISCOVER used in CreateEndpoint,
 		// so renewals are seen as the same client by the server.
@@ -653,7 +657,7 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 
 			case event, ok := <-events:
 				if !ok {
-					// udhcpc exited on its own (NAK, parent NIC vanished,
+					// dhcpcd exited on its own (NAK, parent NIC vanished,
 					// container netns torn down out from under us, etc.).
 					// The scanner goroutine in udhcpc.Start closes events
 					// when its read pipe hits EOF. Without this branch,
@@ -858,7 +862,7 @@ func (m *dhcpManager) Start(ctx context.Context) (err error) {
 			// still DAD-tentative — and a host must NOT answer
 			// neighbor solicitations for a tentative address, so the
 			// server's unicast ADVERTISE/REPLY can never be
-			// delivered: udhcpc6 SOLICITs forever while the server's
+			// delivered: dhcpcd SOLICITs forever while the server's
 			// neighbor cache records an unreachable client (#103,
 			// found by TestLeaseRenewIPv6_HonorsT1). Wait for DAD to
 			// finish before starting the client. Timeout degrades to

--- a/pkg/plugin/dhcp_manager_test.go
+++ b/pkg/plugin/dhcp_manager_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TestRenew_LeaseChangedCounter pins the v0.9.0 / T1-4 counter
-// behaviour: when udhcpc returns a different IP than the manager's
+// behaviour: when dhcpcd returns a different IP than the manager's
 // recorded lastIP, p.leaseChanged.Add(1) fires.
 //
 // We don't need a live netlink/netns fixture — the counter bump
@@ -121,12 +121,12 @@ func TestRenew_LeaseChangedCounter(t *testing.T) {
 	})
 }
 
-// TestHandleEvent_Counters pins which health counter each udhcpc
+// TestHandleEvent_Counters pins which health counter each dhcpcd
 // lifecycle event bumps (#128). The "nak" arm matters most: dnsmasq
 // silently ignores refused renewals in several shapes instead of
 // emitting DHCPNAK, so this contract cannot be pinned reliably at the
-// integration level — when a real server does NAK (busybox udhcpc
-// emits the event verbatim), this is the path that counts it.
+// integration level — when a real server does NAK (dhcpcd maps the
+// NAK reason to the event), this is the path that counts it.
 func TestHandleEvent_Counters(t *testing.T) {
 	addr, err := netlink.ParseAddr("192.168.0.10/24")
 	if err != nil {

--- a/pkg/plugin/dhcp_probe.go
+++ b/pkg/plugin/dhcp_probe.go
@@ -20,7 +20,7 @@ import (
 // for an OFFER + ACK from the upstream server before declaring the
 // parent NIC unreachable. Five seconds is enough for a healthy LAN
 // (Fritz.Box-class servers respond in under 100ms) plus retry once
-// at udhcpc's default ~3s discover timeout. Tight on purpose: the
+// at dhcpcd's discover timeout. Tight on purpose: the
 // operator is blocked in `docker network create` while it runs.
 const preflightProbeBudget = 5 * time.Second
 
@@ -40,14 +40,15 @@ const preflightProbeBudget = 5 * time.Second
 //     MAC, and the probe goal (verifying DHCP reachability of the
 //     parent) is mode-agnostic.
 //  3. Bring it up and run udhcpc.GetIP one-shot with the probe budget.
-//     Busybox has no DISCOVER-only flag; we accept the full DORA and
+//     dhcpcd has no DISCOVER-only flag; we accept the full DORA and
 //     let the upstream server briefly hold a lease that times out
-//     naturally (no -R sent). The cost is one transient pool entry
+//     naturally (no `release` directive sent). The cost is one
+//     transient pool entry
 //     per `docker network create -o validate_dhcp=true`.
 //  4. Tear down the macvlan child unconditionally on return.
 //
 // On success returns nil. On failure wraps the underlying error
-// (link-create failed, udhcpc timeout, malformed lease, etc.) with
+// (link-create failed, dhcpcd timeout, malformed lease, etc.) with
 // a parent-aware prefix so the operator's docker CLI surfaces a
 // clear "no DHCP OFFER on <parent> within 5s" message instead of
 // the generic CreateNetwork failure shape.

--- a/pkg/plugin/endpoints.go
+++ b/pkg/plugin/endpoints.go
@@ -263,7 +263,7 @@ type HealthResponse struct {
 	RecoveredOK            int32   `json:"recovered_ok"`
 	RecoveryFailed         int32   `json:"recovery_failed"`
 	TombstoneWriteFailures int32   `json:"tombstone_write_failures"`
-	// LeaseChanged counts renewals where udhcpc returned a different
+	// LeaseChanged counts renewals where dhcpcd returned a different
 	// IP than the manager last recorded. Not Healthy-affecting (it
 	// doesn't break Docker's view fatally — see plugin.go for the
 	// truthfulness-gap discussion), but worth alerting on for
@@ -280,7 +280,7 @@ type HealthResponse struct {
 	DHCPTimeouts         int32 `json:"dhcp_timeouts"`
 	LeaseReleaseFailures int32 `json:"lease_release_failures"`
 	// NAKsReceived counts server NAKs on renewal/rebind. Not
-	// Healthy-affecting on its own — udhcpc recovers by
+	// Healthy-affecting on its own — dhcpcd recovers by
 	// re-DISCOVERing — but each NAK-triggered re-bind widens the
 	// docker-inspect divergence tracked by lease_changed (#128).
 	NAKsReceived int32 `json:"naks_received"`

--- a/pkg/plugin/helpers_test.go
+++ b/pkg/plugin/helpers_test.go
@@ -131,7 +131,7 @@ func TestUpdateJoinHint_Concurrent(t *testing.T) {
 }
 
 // TestDHCPManager_LastIPsAndSetter covers the ipMu-guarded accessor
-// pair. Writes happen on the udhcpc renew goroutine; reads happen on
+// pair. Writes happen on the dhcpcd renew goroutine; reads happen on
 // the Leave path. Without the mutex (or with a partial implementation
 // that updated only one side) the race detector would flag — and
 // stale-read bugs would silently feed wrong IPs into the tombstone.

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -209,7 +209,7 @@ func (p *Plugin) CreateNetwork(r CreateNetworkRequest) error {
 // containers when the network is removed, so without this prune they
 // linger as ghost entries in /Plugin.Health.active_endpoints. Stop is
 // safe to call against a manager whose underlying netns is gone — it
-// just unblocks the udhcpc-events loop and returns; udhcpc itself may
+// just unblocks the dhcpcd-events loop and returns; dhcpcd itself may
 // have already self-exited because its netns vanished.
 func (p *Plugin) DeleteNetwork(r DeleteNetworkRequest) error {
 	if err := deleteOptions(r.NetworkID); err != nil {
@@ -259,8 +259,8 @@ func vethPairNames(id string) (string, string) {
 // libnetwork-supplied Interface.Address (CIDR form, e.g. set by
 // `docker run --ip=192.168.0.50`). Returns "" when the field is
 // absent; an ErrIPAM-wrapped error when set but malformed or v6.
-// The bare-IP form is what udhcpc wants for `-r ADDR`; the mask is
-// supplied by the DHCP ACK, not the operator.
+// The bare-IP form is what dhcpcd's `request` directive (DHCP option
+// 50) wants; the mask is supplied by the DHCP ACK, not the operator.
 //
 // Note: docker-engine itself rejects `--ip` for null-IPAM networks,
 // so this path only fires when the operator has wired up a non-null
@@ -336,9 +336,10 @@ func resolveExplicitV6(r CreateEndpointRequest) (string, error) {
 // `ip` driver-option. libnetwork places per-endpoint driver-opts
 // (from `docker network connect --driver-opt KEY=VAL`) as flat keys
 // in r.Options. Bare-IP form here, since that's how operators type
-// it on the command line; netmask comes from DHCP regardless. A v4
-// driver-opt `ip6` is also accepted but currently logged-and-skipped
-// because busybox udhcpc6 has no equivalent of `-r`.
+// it on the command line; netmask comes from DHCP regardless. There
+// is no `ip6` driver-opt channel: a requested v6 address arrives via
+// `--ip6` (Interface.AddressIPv6) and is honoured through dhcpcd's
+// `ia_na <iaid> / ADDR` preferred address (see resolveExplicitV6, #213).
 func parseDriverOptIP(options map[string]interface{}) (string, error) {
 	raw, ok := options["ip"]
 	if !ok {
@@ -399,7 +400,7 @@ func (p *Plugin) netOptions(ctx context.Context, id string) (DHCPNetworkOptions,
 }
 
 // CreateEndpoint creates the per-endpoint host-side network plumbing
-// (veth pair in bridge mode, macvlan child in macvlan mode), runs udhcpc
+// (veth pair in bridge mode, macvlan child in macvlan mode), runs dhcpcd
 // once to acquire an initial lease, and stashes the result for Join.
 // Docker moves the link into the container's netns when it acts on our
 // Join response.
@@ -1036,7 +1037,7 @@ func (p *Plugin) Leave(ctx context.Context, r LeaveRequest) error {
 	// the read here is sequenced after every renew that's going to
 	// happen — but go through ipMu anyway so the race detector doesn't
 	// have to reason through `select`. Doing this on the error path too
-	// means a wedged-udhcpc shutdown still produces a tombstone with
+	// means a wedged-dhcpcd shutdown still produces a tombstone with
 	// the latest known lease (W-4) — otherwise DeleteEndpoint would
 	// lay down a tombstone with the stale initial-DISCOVER IPs.
 	v4Addr, v6Addr := manager.lastIPs()

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -71,7 +71,7 @@ func newChildLink(mode string, la netlink.LinkAttrs) netlink.Link {
 
 // createParentAttachedEndpoint creates the per-endpoint child link on
 // the host's parent NIC (macvlan or ipvlan depending on mode), runs
-// udhcpc on it (still in host netns) to acquire an initial lease, and
+// dhcpcd on it (still in host netns) to acquire an initial lease, and
 // stashes the result for Join. Docker will move the link into the
 // container's netns when it acts on our Join response.
 func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpointRequest, opts DHCPNetworkOptions) (CreateEndpointResponse, error) {
@@ -88,7 +88,8 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 	// HardwareAddr, so the tombstone path doesn't apply there (and an
 	// explicit MAC is rejected loudly to avoid silent misconfiguration).
 	// Static IPs (`docker run --ip`) are accepted in both modes — they
-	// pass through to udhcpc as a `-r ADDR` hint.
+	// pass through to dhcpcd as a `request`-directive (DHCP option 50)
+	// hint.
 	effectiveMAC := ""
 	if r.Interface != nil {
 		effectiveMAC = r.Interface.MacAddress

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -54,7 +54,7 @@ const initialDHCPHostnameLookupTimeout = 2 * time.Second
 
 // recoveryBudget caps the wall-time the plugin spends rebuilding its
 // in-memory state for already-attached endpoints on startup. Each
-// endpoint's recovery does its own DHCP DISCOVER through udhcpc with
+// endpoint's recovery does its own DHCP DISCOVER through dhcpcd with
 // network-IO timeouts; this is the umbrella above all of them. Beyond
 // it, recovery is abandoned and the affected endpoints surface as
 // recovery_failed on /Plugin.Health.
@@ -92,7 +92,7 @@ func clientIDFromEndpoint(endpointID string) []byte {
 
 // resolveClientID picks the option-61 payload for a fresh DHCP
 // exchange. Operator-supplied opts.ClientID wins when non-empty
-// (treated as opaque ASCII bytes; the udhcpc client adds the
+// (treated as opaque ASCII bytes; the dhcpcd client adds the
 // type-byte 0x00 wrapper on the wire). Otherwise we fall back to
 // the endpoint-derived stable id, which is what makes per-container
 // reservations work upstream.
@@ -184,7 +184,7 @@ type DHCPNetworkOptions struct {
 	// and not yet implemented.
 	//
 	// The probe runs a full DHCPDISCOVER → REQUEST → ACK cycle
-	// (busybox udhcpc has no DISCOVER-only mode), so the upstream
+	// (dhcpcd has no DISCOVER-only mode), so the upstream
 	// pool briefly sees one extra lease per `docker network create`
 	// with this opt-in. The probe MAC is random (locally-administered
 	// bit set) so it doesn't collide with anything stable upstream;
@@ -293,7 +293,7 @@ type Plugin struct {
 	// on restart until the disk recovers.
 	tombstoneWriteFailures atomic.Int32
 
-	// leaseChanged counts renewals where udhcpc returned a different
+	// leaseChanged counts renewals where dhcpcd returned a different
 	// IP than the manager last recorded. Container's
 	// NetworkSettings.IPAddress in `docker inspect` does NOT update
 	// — libnetwork has no in-place endpoint-IP swap RPC. This counter
@@ -309,11 +309,12 @@ type Plugin struct {
 	// regressions in the DHCP exchange itself without scraping dnsmasq
 	// logs server-side or running the plugin at trace level. Bumped
 	// from dhcpManager:
-	//   - leasesObtained: udhcpc "bound" event — first successful
+	//   - leasesObtained: "bound" event — first successful
 	//     DHCPACK on either initial bind or after a NAK / lease loss
-	//   - leasesRenewed: udhcpc "renew" event — a renewal DHCPACK
-	//   - dhcpTimeouts: udhcpc "leasefail" event — discovery / renewal
-	//     hit udhcpc's internal timeout without an OFFER or ACK
+	//   - leasesRenewed: "renew" event — a renewal DHCPACK
+	//   - dhcpTimeouts: "leasefail" event — a bound lease lapsed
+	//     (dhcpcd EXPIRE) or the outage watchdog fired without an
+	//     OFFER or ACK
 	//   - leaseReleaseFailures: client.Finish returned an error in
 	//     Stop, meaning the SIGTERM-driven DHCPRELEASE didn't complete
 	//     cleanly (timeout, exit code, or pipe closure)
@@ -322,10 +323,10 @@ type Plugin struct {
 	dhcpTimeouts         atomic.Int32
 	leaseReleaseFailures atomic.Int32
 
-	// naksReceived counts udhcpc "nak" events — the server refused a
+	// naksReceived counts "nak" events — the server refused a
 	// REQUEST (pool reconfigured, address reassigned, lease revoked).
 	// Until v1.0.0 a NAK was only a warn-level log line, invisible to
-	// operators (#128). A NAK is followed by udhcpc re-DISCOVERing, so
+	// operators (#128). A NAK is followed by dhcpcd re-DISCOVERing, so
 	// pair this with lease_changed: naks_received climbing while
 	// lease_changed follows means containers are being re-addressed
 	// mid-life — Docker's inspect view goes stale (see leaseChanged
@@ -635,9 +636,10 @@ func (p *Plugin) consumeTombstone(networkID, hostname string) (mac, ipv4, ipv6 s
 // Recovery sources state from Docker rather than persisting our own
 // per-endpoint files: NetworkInspect gives us the MAC and IP of each
 // attached endpoint, ContainerInspect gives the hostname and the
-// container's PID for netns access. udhcpc is invoked with `-r <IP>`
-// so the upstream DHCP server can ACK the lease the container is
-// already using rather than handing out a fresh one.
+// container's PID for netns access. dhcpcd is invoked with that IP set
+// as its `request` directive (DHCP option 50) so the upstream DHCP
+// server can ACK the lease the container is already using rather than
+// handing out a fresh one.
 func (p *Plugin) recoverEndpoints(ctx context.Context) {
 	// recordSyncFailure bumps both the local counter (used for the
 	// summary log line) and the atomic surfaced on /Plugin.Health.
@@ -954,7 +956,7 @@ func (p *Plugin) Listen(bindSock string) error {
 // pluginShutdownTimeout caps how long Close waits for each persistent
 // DHCP client to send DHCPRELEASE and exit. Short enough to keep a
 // plugin upgrade snappy on hosts with many endpoints; long enough that
-// a typical udhcpc release-and-exit cycle completes well within it.
+// a typical dhcpcd release-and-exit cycle completes well within it.
 const pluginShutdownTimeout = 5 * time.Second
 
 // Close stops the plugin server. Persistent DHCP clients are stopped
@@ -964,7 +966,7 @@ const pluginShutdownTimeout = 5 * time.Second
 // release-on-stop contract Leave normally honors.
 func (p *Plugin) Close() error {
 	// Snapshot the live managers under the lock, then drop the lock
-	// before calling Stop on each (Stop blocks on udhcpc Wait and we
+	// before calling Stop on each (Stop blocks on dhcpcd Wait and we
 	// don't want to hold p.mu across that).
 	p.mu.Lock()
 	managers := make([]*dhcpManager, 0, len(p.persistentDHCP))
@@ -976,7 +978,7 @@ func (p *Plugin) Close() error {
 
 	if len(managers) > 0 {
 		log.WithField("count", len(managers)).Info("Stopping persistent DHCP clients before shutdown")
-		// Stop in parallel — each udhcpc release is independent and
+		// Stop in parallel — each dhcpcd release is independent and
 		// we don't want N×timeout wall time.
 		var wg sync.WaitGroup
 		for _, m := range managers {
@@ -988,7 +990,7 @@ func (p *Plugin) Close() error {
 				}
 			}(m)
 		}
-		// Bound wall time: we can't let one wedged udhcpc hold up the
+		// Bound wall time: we can't let one wedged dhcpcd hold up the
 		// whole shutdown.
 		//
 		// Known leak (W-8 in the 2026-05-05 review): if the timeout

--- a/pkg/plugin/resolvconf.go
+++ b/pkg/plugin/resolvconf.go
@@ -41,8 +41,8 @@ import (
 //     Containers attached to two net-dhcp networks will end up with
 //     whichever network's renewal happened most recently.
 //   - search-domain handling: prefer the multi-entry DHCP option 119
-//     (Domain Search List, busybox env `search`). Falls back to the
-//     single-entry option 15 (`domain`, env `domain`) when option 119
+//     (Domain Search List, dhcpcd env `new_domain_search`). Falls back to the
+//     single-entry option 15 (`domain`, dhcpcd env `new_domain_name`) when option 119
 //     isn't supplied. RFC 3397 specifies option 119 supersedes option
 //     15 when both are present.
 func writeContainerResolvConf(pid int, dns []string, searchList []string, searchDomain string) error {

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -85,8 +85,9 @@ type tombstone struct {
 	Hostname string `json:"hostname,omitempty"`
 	// IPAddress, when non-empty, is the bare IPv4 address (no /mask)
 	// from the previous endpoint's lease. The next CreateEndpoint
-	// passes it to udhcpc as `-r ADDR` so the upstream DHCP server
-	// can ACK the same lease back to the same MAC. Empty means
+	// passes it to dhcpcd via the `request` directive (DHCP option 50)
+	// so the upstream DHCP server can ACK the same lease back to the
+	// same MAC. Empty means
 	// "do an unhinted DISCOVER".
 	IPAddress string `json:"ip_address,omitempty"`
 	// IPv6Address, when non-empty, is the bare IPv6 address from the

--- a/pkg/udhcpc/handler.go
+++ b/pkg/udhcpc/handler.go
@@ -18,8 +18,8 @@ type Info struct {
 	// re-apply on change.
 	MTU int `json:",omitempty"`
 
-	// NTPServers is the NTP server list from DHCP option 42 (busybox
-	// env var `ntpsrv`). Empty when the server didn't supply the
+	// NTPServers is the NTP server list from DHCP option 42 (dhcpcd
+	// env var `new_ntp_servers`). Empty when the server didn't supply the
 	// option. Surfaced to operators via plugin logs at info level on
 	// bind/renew; not auto-applied to the container — workloads
 	// needing NTP should consume the value themselves (typically via
@@ -27,7 +27,7 @@ type Info struct {
 	NTPServers []string `json:",omitempty"`
 
 	// SearchList is the DNS Domain Search List from DHCP option 119
-	// (busybox env var `search`). Empty when the server didn't supply
+	// (dhcpcd env var `new_domain_search`). Empty when the server didn't supply
 	// the option. When PropagateDNS=true the plugin emits this as the
 	// `search` line in the container's /etc/resolv.conf; falls back
 	// to the single-domain `Domain` (option 15) when SearchList is
@@ -35,13 +35,13 @@ type Info struct {
 	SearchList []string `json:",omitempty"`
 
 	// TFTPServer is the TFTP server hostname from DHCP option 66
-	// (busybox env var `tftp`). Empty when not supplied. Used for
+	// (dhcpcd env var `new_tftp_server_name`). Empty when not supplied. Used for
 	// PXE-boot-style scenarios; surfaced to operators via plugin
 	// logs, not auto-applied to the container.
 	TFTPServer string `json:",omitempty"`
 
-	// BootFile is the boot file name from DHCP option 67 (busybox env
-	// var `bootfile`). Same surfacing semantics as TFTPServer.
+	// BootFile is the boot file name from DHCP option 67 (dhcpcd env
+	// var `new_bootfile_name`). Same surfacing semantics as TFTPServer.
 	BootFile string `json:",omitempty"`
 }
 

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -26,8 +26,8 @@ var (
 	ErrModeMismatch = errors.New("option does not apply to selected mode")
 	// ErrMACAddress indicates an invalid MAC address
 	ErrMACAddress = errors.New("invalid MAC address")
-	// ErrNoLease indicates a DHCP lease was not obtained from udhcpc
-	ErrNoLease = errors.New("udhcpc did not output a lease")
+	// ErrNoLease indicates a DHCP lease was not obtained from dhcpcd
+	ErrNoLease = errors.New("dhcpcd did not output a lease")
 	// ErrNoHint indicates missing state from the CreateEndpoint stage in Join
 	ErrNoHint = errors.New("missing CreateEndpoint hints")
 	// ErrNotVEth indicates a host link was unexpectedly not a veth interface

--- a/test/integration/client_id_test.go
+++ b/test/integration/client_id_test.go
@@ -28,8 +28,8 @@ import (
 // chase log-stream timing.
 //
 // Closes the integration-coverage gap noted in the post-T2-3 audit:
-// the existing TestNewDHCPClient_VendorClassOverride only checks
-// the udhcpc argv shape; this test proves the bytes also reach
+// the dhcpcd config-shape unit tests only check that the `clientid`
+// directive is emitted; this test proves the bytes also reach
 // the upstream server.
 func TestClientID_OverrideAppearsInLeaseFile(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)

--- a/test/integration/concurrency_test.go
+++ b/test/integration/concurrency_test.go
@@ -16,12 +16,12 @@ import (
 // macvlan network in parallel and asserts each gets a distinct IP
 // from the DHCP pool. Doubles as a deadlock smoke test:
 // CreateEndpoint takes networkLock per-network, so a regression that
-// upgraded that to a global lock or held it across the udhcpc -q call
-// would serialize starts and quickly blow the timeout.
+// upgraded that to a global lock or held it across the one-shot dhcpcd
+// acquisition would serialize starts and quickly blow the timeout.
 //
 // N=4 keeps the test fast (one short-lease dnsmasq, one veth) while
 // being enough to surface a serialization regression: 4 sequential
-// 5-second udhcpc roundtrips would already exceed the per-container
+// 5-second dhcpcd roundtrips would already exceed the per-container
 // IPAcquisitionBudget if the lock were held wrong.
 func TestConcurrency_DistinctLeases(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)

--- a/test/integration/extra_options_test.go
+++ b/test/integration/extra_options_test.go
@@ -18,7 +18,7 @@ import (
 // option 15 per RFC 3397.
 //
 // Pairs with the unit test TestBuildResolvConf_SearchListPrecedence —
-// this one validates the udhcpc → handler → plugin → mount-ns
+// this one validates the dhcpcd → handler → plugin → mount-ns
 // pipeline actually produces the rendered file the unit test pins.
 func TestExtraOptions_SearchListInResolvConf(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -59,7 +59,7 @@ func TestExtraOptions_SearchListInResolvConf(t *testing.T) {
 }
 
 // hasAllDomains reports whether every entry in want appears on a
-// `search` line in resolvConf. Order is not asserted — busybox /
+// `search` line in resolvConf. Order is not asserted — dhcpcd /
 // dnsmasq are free to reorder, but every element must be present.
 func hasAllDomains(resolvConf string, want []string) bool {
 	var searchLine string

--- a/test/integration/failure_test.go
+++ b/test/integration/failure_test.go
@@ -12,19 +12,18 @@
 // minutes — they are split out of the main suite into
 // `make integration-test-failure` (second CI step).
 //
-// busybox-udhcpc timing facts the asserts below lean on (defaults:
-// -t 3 -T 3 -A 20, see pkg/udhcpc/client.go — no overrides):
-//   - a dead server produces NO udhcpc event at T1/T2 (silent unicast
-//     /broadcast retries); the first observable event is "leasefail",
-//     emitted ~10s after lease EXPIRY when re-DISCOVER times out
-//     (3 tries × 3s). dhcp_timeouts therefore moves at ~t+130s, not
-//     at T1.
-//   - after "leasefail", udhcpc sleeps 20s (-A) and re-DISCOVERs
-//     forever — so recovery after the server returns lands within
-//     ~30s, and while it's gone, dhcp_timeouts keeps climbing on a
-//     ~30s period.
-//   - at expiry udhcpc emits "deconfig", which the plugin DELIBERATELY
-//     ignores (would wipe copied routes, see dhcp_manager.go) — the
+// dhcpcd timing facts the asserts below lean on (see pkg/udhcpc):
+//   - a dead server produces NO event at T1/T2 (dhcpcd retries silently
+//     while re-discovering); the first internal "leasefail" comes from
+//     dhcpcd's EXPIRE when the bound lease finally lapses (at expiry),
+//     and the plugin's outage watchdog then increments dhcp_timeouts on
+//     a recurring ~30s period (dhcpOutageTick/Grace) while still
+//     acquiring. dhcp_timeouts therefore moves around expiry, not at T1.
+//   - dhcpcd keeps re-DISCOVERing forever, so recovery after the server
+//     returns lands within ~30s, and while it's gone dhcp_timeouts keeps
+//     climbing on the watchdog's ~30s period.
+//   - at expiry the plugin DELIBERATELY does NOT tear down the address
+//     on EXPIRE (would wipe copied routes, see dhcp_manager.go) — the
 //     container keeps its address through an outage.
 package integration
 
@@ -82,7 +81,7 @@ func inRange(ip, start, end string) bool {
 // TestFailure_ServerLossDuringRenewal: the "router rebooted at 3am"
 // scenario. Intended behaviour asserted:
 //   - while the server is gone, the container KEEPS its address (the
-//     deconfig no-op), the plugin stays Healthy, and dhcp_timeouts
+//     EXPIRE no-op), the plugin stays Healthy, and dhcp_timeouts
 //     records the failure;
 //   - when the server returns with its lease DB intact, the client
 //     re-binds to the SAME address (lease_changed stays flat) without
@@ -131,10 +130,10 @@ func TestFailure_ServerLossDuringRenewal(t *testing.T) {
 		t.Error("plugin went unhealthy during a server outage; a dead DHCP server is a degraded mode, not a plugin failure")
 	}
 	if !containerHasIP(t, ctx, id, ip) {
-		t.Errorf("container lost %s during the outage; the deconfig no-op should retain the address", ip)
+		t.Errorf("container lost %s during the outage; the EXPIRE no-op should retain the address", ip)
 	}
 
-	// Server returns, lease DB intact: the udhcpc retry loop must
+	// Server returns, lease DB intact: the dhcpcd retry loop must
 	// re-bind to the same address within ~30s (poll 90s for margin).
 	acksBefore := ef.CountLogLines("DHCPACK", mac)
 	ef.StartAgain()

--- a/test/integration/harness/container.go
+++ b/test/integration/harness/container.go
@@ -27,7 +27,7 @@ const (
 	TestImage = "alpine:3.20"
 	// IPAcquisitionBudget caps how long Run waits for a container to
 	// have a non-empty IP after start. The plugin's CreateEndpoint
-	// returns synchronously after udhcpc gets a lease, so the docker
+	// returns synchronously after dhcpcd gets a lease, so the docker
 	// inspect should reflect the IP within milliseconds; the budget
 	// is generous to absorb real-world dnsmasq RTTs and image pulls.
 	IPAcquisitionBudget = 15 * time.Second

--- a/test/integration/harness/fixture.go
+++ b/test/integration/harness/fixture.go
@@ -39,7 +39,7 @@ const (
 	// --dhcp-range. 2 minutes is dnsmasq's hard floor — anything
 	// shorter is silently rounded up, which made an earlier "30s"
 	// constant lie about the actual lease. T1 (renewal trigger
-	// inside udhcpc) lands at half-lease = 1m, so renewal-tests
+	// inside dhcpcd) lands at half-lease = 1m, so renewal-tests
 	// have a ~1m floor on wait time.
 	DHCPPoolStart = "192.168.99.10"
 	DHCPPoolEnd   = "192.168.99.99"
@@ -61,8 +61,8 @@ const (
 	SubnetV6CIDR     = "fd00:6470:6863::/64"
 
 	// TestDNS6Server is advertised as DHCPv6 option 23 (DNS servers).
-	// busybox udhcpc6 requests option 23 by default, so it lands in
-	// the handler's `dns6` env without any -O flag. Like
+	// dhcpcd requests option 23 (via the config `option` list), so it
+	// lands in the handler's `new_dhcp6_name_servers` env. Like
 	// TestDNSServer, nothing actually serves DNS there — tests assert
 	// propagation, not resolution.
 	TestDNS6Server = "fd00:6470:6863::53"
@@ -238,7 +238,7 @@ func (f *Fixture) startDnsmasq() error {
 		// Stateful DHCPv6 on the ULA prefix (#103). --enable-ra makes
 		// dnsmasq emit Router Advertisements with the M (managed) flag
 		// for this range — RA handling stays kernel-delegated in the
-		// container netns; the plugin only drives udhcpc6.
+		// container netns; the plugin only drives dhcpcd.
 		"--dhcp-range="+DHCPv6PoolStart+","+DHCPv6PoolEnd+","+LeaseTime,
 		"--enable-ra",
 		"--dhcp-option=option6:dns-server,["+TestDNS6Server+"]",

--- a/test/integration/health_counters_test.go
+++ b/test/integration/health_counters_test.go
@@ -80,7 +80,7 @@ func TestHealthCounters_ObtainedAndReleased(t *testing.T) {
 
 	// Wait for the persistent client's `bound` event — that's what
 	// bumps leases_obtained. CreateEndpoint's initial DISCOVER runs
-	// a one-shot udhcpc that doesn't go through the event handler;
+	// a one-shot dhcpcd whose events don't feed the plugin's counters;
 	// the persistent client started in Join is what we're testing.
 	deadline := time.Now().Add(harness.IPAcquisitionBudget + 5*time.Second)
 	var afterStart *harness.HealthResponse

--- a/test/integration/ipv6_test.go
+++ b/test/integration/ipv6_test.go
@@ -2,7 +2,8 @@
 
 // DHCPv6 coverage (#103) — the suite's first v6 tests. The fixture
 // dnsmasq instances are dual-stack (stateful DHCPv6 on ULA prefixes,
-// --enable-ra); `ipv6=true` networks run udhcpc6 alongside udhcpc.
+// --enable-ra); `ipv6=true` networks run a v6 dhcpcd client alongside
+// the v4 one.
 //
 // Audit findings these tests encode (from the busybox source,
 // networking/udhcp/d6_dhcpc.c):
@@ -196,7 +197,7 @@ func TestLifecycleMacvlan_IPv6_GoldenPath(t *testing.T) {
 	}
 
 	// ...and inspect must agree with reality. CreateEndpoint returns
-	// AddressIPv6 from the initial one-shot udhcpc6 exchange; the
+	// AddressIPv6 from the initial one-shot dhcpcd exchange; the
 	// persistent client re-binds with the same DUID, so the server
 	// must hand back the same address. A mismatch here is the v6
 	// flavour of the #104 divergence — if this fires, the audit found
@@ -410,7 +411,7 @@ func TestLeaseRenewIPv6_HonorsT1(t *testing.T) {
 	endReplies := countDHCPv6Replies(t, fixture.DnsmasqLog(), v6)
 	t.Logf("DHCPREPLYs for %s: start=%d end=%d", v6, startReplies, endReplies)
 	if endReplies-startReplies < 1 {
-		t.Errorf("no renewal DHCPREPLY for %s after crossing T1 — udhcpc6 renewal appears stuck", v6)
+		t.Errorf("no renewal DHCPREPLY for %s after crossing T1 — dhcpcd v6 renewal appears stuck", v6)
 	}
 }
 
@@ -541,7 +542,7 @@ func TestDUID_PersistsAcrossPluginRestart(t *testing.T) {
 	if err := harness.WaitPluginEnabled(ctx, cli, true, 30*time.Second); err != nil {
 		t.Fatalf("plugin did not re-enable: %v", err)
 	}
-	t.Log("plugin restarted; awaiting the recovered udhcpc6's re-bind...")
+	t.Log("plugin restarted; awaiting the recovered dhcpcd v6 client's re-bind...")
 
 	// The recovered persistent client SOLICITs immediately; a fresh
 	// DHCPREPLY for our address proves the post-restart exchange
@@ -557,7 +558,7 @@ func TestDUID_PersistsAcrossPluginRestart(t *testing.T) {
 		time.Sleep(time.Second)
 	}
 	if !rebound {
-		t.Fatalf("no post-restart DHCPREPLY for %s within 90s — recovered udhcpc6 never re-bound", v6)
+		t.Fatalf("no post-restart DHCPREPLY for %s within 90s — recovered dhcpcd v6 client never re-bound", v6)
 	}
 
 	duidAfter := leaseDUIDForV6(t, fixture.LeaseFile(), v6)

--- a/test/integration/lease_renew_test.go
+++ b/test/integration/lease_renew_test.go
@@ -20,14 +20,14 @@ import (
 //
 // The fixture's lease time is 2m (dnsmasq's hard minimum, see
 // LeaseTime in harness/fixture.go), so T1 (renewal trigger inside
-// udhcpc) fires at 1m. We wait ~70s — past T1, well before T2
+// dhcpcd) fires at 1m. We wait ~70s — past T1, well before T2
 // (1m45s) — and assert:
 //   - the container's IP from docker inspect hasn't changed
 //   - dnsmasq's log shows at least 2 DHCPACK lines for our MAC
 //     (one for the initial bind, one for the renewal)
 //
 // Without this test, a regression in dhcpManager.renew or the
-// long-lived udhcpc client would be silent: the container starts
+// long-lived dhcpcd client would be silent: the container starts
 // fine, then loses its IP somewhere between T2 and the next operator
 // noticing the connection dropped.
 func TestLeaseRenew_HonorsT1(t *testing.T) {

--- a/test/integration/lifecycle_bridge_test.go
+++ b/test/integration/lifecycle_bridge_test.go
@@ -16,7 +16,7 @@ import (
 // the macvlan/ipvlan additions and goes through a structurally
 // different code path: per-endpoint veth pair, host side attached to
 // a user-provided Linux bridge, container side moved into the
-// container netns. udhcpc still runs in the container netns, but the
+// container netns. dhcpcd still runs in the container netns, but the
 // DHCP server it talks to here is the second dnsmasq the bridge
 // fixture starts on the bridge interface (192.168.100/24, distinct
 // from the macvlan path's 192.168.99/24 to avoid lease cross-talk).

--- a/test/integration/lifecycle_ipvlan_test.go
+++ b/test/integration/lifecycle_ipvlan_test.go
@@ -15,7 +15,7 @@ import (
 // mode=ipvlan. ipvlan-L2 is the default in newChildLink and the only
 // mode that can carry DHCP (which needs L2 broadcast) — this test
 // guards that invariant; an accidental switch to L3 mode would fail
-// here with udhcpc never seeing an OFFER.
+// here with dhcpcd never seeing an OFFER.
 //
 // One observable mode-specific difference: ipvlan children inherit
 // the parent's MAC, so docker inspect shows the HostVeth MAC instead
@@ -23,12 +23,14 @@ import (
 // same MAC the daemon reported.
 //
 // Earlier this test was `t.Skip`'d because the OFFER never reached
-// the slave through a veth parent. The fix landed in pkg/udhcpc:
-// setting the BROADCAST flag in DISCOVER (`udhcpc -B`) for ipvlan
-// mode forces the OFFER to be L2-broadcast at the wire level, which
-// the kernel then floods correctly to all slaves of the parent.
-// dnsmasq's `--dhcp-broadcast` in our fixture is now belt-and-braces
-// rather than the only thing keeping ipvlan honest.
+// the slave through a veth parent. The original fix forced the
+// BROADCAST flag in DISCOVER (busybox `udhcpc -B`) for ipvlan mode so
+// the OFFER was L2-broadcast at the wire level and the kernel flooded
+// it to all slaves of the parent. NOTE: since the dhcpcd migration
+// (#152) the client's Broadcast option is not yet wired (see
+// pkg/udhcpc DHCPClientOptions.Broadcast), so dnsmasq's
+// `--dhcp-broadcast` in our fixture is currently what keeps ipvlan
+// honest on the test path.
 func TestLifecycleIPvlan_GoldenPath(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()

--- a/test/integration/lifecycle_macvlan_test.go
+++ b/test/integration/lifecycle_macvlan_test.go
@@ -52,7 +52,7 @@ func TestMain(m *testing.M) {
 //
 // This single test exercises CreateNetwork (mode=macvlan branch),
 // validateParentForChild, createParentAttachedEndpoint,
-// dhcpManager.Start (initial lease via udhcpc -q), Join (move link
+// dhcpManager.Start (initial lease via one-shot dhcpcd), Join (move link
 // into netns), Leave (Stop the manager → DHCPRELEASE), DeleteEndpoint
 // (parent-attached cleanup branch), and DeleteNetwork — covering
 // the macvlan path end-to-end.

--- a/test/integration/preflight_probe_test.go
+++ b/test/integration/preflight_probe_test.go
@@ -18,7 +18,7 @@ import (
 // happy path: validate_dhcp=true on the standard fixture (dnsmasq
 // on the other end of HostVeth) succeeds and the network is created.
 //
-// Indirectly exercises the macvlan probe-link create + udhcpc
+// Indirectly exercises the macvlan probe-link create + dhcpcd
 // one-shot DORA + cleanup paths in pkg/plugin/dhcp_probe.go.
 func TestPreflightProbe_PassesOnReachableServer(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -49,7 +49,7 @@ func TestPreflightProbe_PassesOnReachableServer(t *testing.T) {
 //
 // Uses a dummy interface as the parent — dummies don't carry L2
 // traffic to anywhere, so the DHCPDISCOVER vanishes into the void
-// and udhcpc times out. Cheaper to set up than a fresh veth pair
+// and dhcpcd times out. Cheaper to set up than a fresh veth pair
 // with no peer-side dnsmasq, and the test doesn't exercise the
 // peer-side code anyway.
 func TestPreflightProbe_FailsWhenServerUnreachable(t *testing.T) {
@@ -107,7 +107,7 @@ func TestPreflightProbe_FailsWhenServerUnreachable(t *testing.T) {
 	}
 
 	// The probe budget is 5s; harness allowed ~10s including
-	// the udhcpc setup overhead. If we waited ~30s it means the
+	// the dhcpcd setup overhead. If we waited ~30s it means the
 	// budget is being ignored somewhere.
 	if elapsed > 15*time.Second {
 		t.Errorf("probe took %v; should have failed within ~6-10s", elapsed)

--- a/test/integration/recovery_daemon_test.go
+++ b/test/integration/recovery_daemon_test.go
@@ -183,7 +183,7 @@ func TestRecovery_DaemonRestart_PreservesContainer(t *testing.T) {
 	// pass in CI.)
 
 	// In the tombstone-path case (graceful shutdown ran Leave) the
-	// container goes through a fresh CreateEndpoint+udhcpc on the
+	// container goes through a fresh CreateEndpoint+dhcpcd on the
 	// way back up; the endpoint can briefly show no IP after
 	// State.Running flips. Poll on the endpoint, not just the state.
 	ipAfter, macAfter := waitForEndpoint(t, ctx, cli2, id, harness.IPAcquisitionBudget)
@@ -198,7 +198,7 @@ func TestRecovery_DaemonRestart_PreservesContainer(t *testing.T) {
 
 // waitLeaseObtained polls Plugin.Health until leases_obtained moves
 // past the pre-container baseline, i.e. the endpoint's persistent
-// DHCP client has fired its first udhcpc "bound" event and lease
+// DHCP client has fired its first dhcpcd "bound" event and lease
 // release-on-shutdown is armed.
 func waitLeaseObtained(t *testing.T, ctx context.Context, cli *docker.Client, baseline int32, budget time.Duration) {
 	t.Helper()

--- a/test/integration/static_ip_test.go
+++ b/test/integration/static_ip_test.go
@@ -17,8 +17,8 @@ import (
 // TestStaticIP_DriverOpt drives the `--driver-opt ip=<addr>` static-IP
 // override path: the container is connected with an explicit
 // per-endpoint driver opt, and the plugin must propagate that to
-// udhcpc's DHCPDISCOVER as a `requested IP` so dnsmasq hands out the
-// caller-chosen lease rather than picking from the pool.
+// dhcpcd's `request` directive (DHCP option 50) so dnsmasq hands out
+// the caller-chosen lease rather than picking from the pool.
 //
 // Exercises pkg/plugin/network.go::parseDriverOptIP (whose only
 // not-trivial branch was a 0%-coverage gap in v0.7.0) and

--- a/test/integration/tombstone_restart_test.go
+++ b/test/integration/tombstone_restart_test.go
@@ -19,7 +19,7 @@ import (
 // last-known IP, keyed by (network, endpoint). On the subsequent
 // CreateEndpoint Docker hands the same endpoint ID back, so the
 // plugin reuses the tombstoned MAC for the new macvlan child and
-// asks udhcpc to renew the same IP. tombstoneTTL was bumped to 60s
+// asks dhcpcd to renew the same IP. tombstoneTTL was bumped to 60s
 // in v0.6.1 (see #55) so a slow `systemctl restart docker` doesn't
 // drop the entry — but `docker restart <ctr>` itself completes in
 // well under that window.

--- a/test/integration/vendor_class_test.go
+++ b/test/integration/vendor_class_test.go
@@ -21,9 +21,8 @@ import (
 // the tagged gateway (.250) instead of dnsmasq's default
 // listen-address gateway (.1). End-to-end proof that the operator's
 // vendor_class override actually reaches the wire and class-based
-// policy fires upstream — the unit test
-// TestNewDHCPClient_VendorClassOverride only verified the udhcpc
-// argv shape.
+// policy fires upstream — the dhcpcd config-shape unit tests only
+// verify that the `vendorclassid` directive is emitted.
 func TestVendorClass_OverrideRoutesViaTaggedGateway(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()


### PR DESCRIPTION
Closes #242.

Refreshes stale **code comments** (and a few log/string texts) that still
described the old busybox `udhcpc`/`udhcpc6` client after the dhcpcd
migration (#152) and the v6 work (#213). Companion to the docs reconcile
(#234/#237) — same drift, code side.

## What changed (comments/strings only — no logic, no identifiers)

- `-r ADDR` hint → dhcpcd `request` directive (DHCP option 50), across
  `state.go`, `network.go`, `parent_attached.go`, `plugin.go`,
  `dhcp_manager.go`.
- `-R` → dhcpcd `release` directive; per-cycle `leasefail` →
  `EXPIRE` + outage watchdog; Health-counter comments attributed to
  dhcpcd hook events (`endpoints.go`, `plugin.go`).
- **`handler.go` / `resolvconf.go` env-var names corrected** — they named
  busybox vars (`ntpsrv`/`search`/`tftp`/`bootfile`/`dns6`); they now
  match the dhcpcd `new_*` vars `BuildEvent` actually reads
  (`new_ntp_servers`, `new_domain_search`, `new_tftp_server_name`,
  `new_bootfile_name`, `new_domain_name`, `new_dhcp6_name_servers`).
- `parseDriverOptIP` `ip6` comment: v6 requests are honored via `--ip6`
  (#213), not skipped "because busybox udhcpc6 has no `-r`".
- Probe/recovery/teardown comments updated to dhcpcd.

## Kept deliberately

- **Identifiers/paths**: the `pkg/udhcpc` package and `udhcpc-handler`
  binary, `udhcpc.GetIP`, env-var names, `config.json`/Dockerfile paths —
  renaming is a separate, larger decision (out of scope).
- **Intentional history**: `Migration note (#152): … replaced busybox …`
  and the busybox wire-compat rationale (opaque type-byte etc.).
- **Test-tooling busybox**: comments about the alpine test containers'
  busybox `ip`/shell are genuine, not stale — left as-is.

## Gap surfaced (filed, not fixed here)

The sweep found that the ipvlan `DHCPClientOptions.Broadcast` field is set
but never consumed (`renderArgs` emits nothing; dhcpcd `-B` is
foreground, not broadcast) — a **no-op** masked in CI by the fixture's
`--dhcp-broadcast`. Filed as **#243**; the comment now states this
honestly rather than papering over it.

## Verification

`gofmt -l` clean, `go build ./...`, `go vet ./...`, `go test ./pkg/...`
all pass. Comment/doc changes only; no behavior touched.
