### PR TITLE
fix(ipvlan): wire the dhcpcd broadcast directive (#243)

### DIFF
--- a/pkg/plugin/dhcp_probe.go
+++ b/pkg/plugin/dhcp_probe.go
@@ -109,6 +109,12 @@ func runDHCPProbe(ctx context.Context, parent string) error {
 		// false negatives when class-based policy denies the
 		// probe but would accept the real container.
 		MAC: probeMAC,
+		// Request a broadcast reply (#243). The probe is a transient
+		// reachability check from a brand-new random MAC; asking the
+		// server to broadcast its OFFER makes the probe robust whether
+		// or not the server unicasts back to an unconfigured client,
+		// so a reachable server is never reported as unreachable.
+		Broadcast: true,
 	})
 	if err != nil {
 		if errors.Is(err, util.ErrNoLease) || errors.Is(err, context.DeadlineExceeded) {

--- a/pkg/udhcpc/client.go
+++ b/pkg/udhcpc/client.go
@@ -83,8 +83,9 @@ type DHCPClientOptions struct {
 	VendorClass string
 
 	// Broadcast requests an L2-broadcast reply (ipvlan-L2, where every
-	// slave shares the parent MAC). NOTE: dhcpcd broadcast handling is
-	// not yet wired here — tracked for the ipvlan path; see #152.
+	// slave shares the parent MAC). Emitted as the dhcpcd `broadcast`
+	// directive (v4 only) — the busybox `-B` equivalent; see renderConfig
+	// and #243.
 	Broadcast bool
 
 	HandlerScript string
@@ -145,6 +146,7 @@ func NewDHCPClient(iface string, opts *DHCPClientOptions) (*DHCPClient, error) {
 		ClientID:    opts.ClientID,
 		RequestedIP: opts.RequestedIP,
 		PreferredV6: opts.PreferredV6,
+		Broadcast:   opts.Broadcast,
 		Handler:     handler,
 		ConfigPath:  configPath,
 		EventFIFO:   fifoPath,

--- a/pkg/udhcpc/dhcpcd.go
+++ b/pkg/udhcpc/dhcpcd.go
@@ -97,6 +97,7 @@ type dhcpcdParams struct {
 	ClientID    []byte // v4 option 61 raw payload; nil/empty omits (v4 only)
 	RequestedIP string // v4 preferred address (request directive); "" omits
 	PreferredV6 string // v6 IA_NA preferred address; "" omits
+	Broadcast   bool   // request a broadcast reply (v4 only; ipvlan-L2 shared MAC)
 
 	Handler    string // hook script path (-c)
 	ConfigPath string // where the rendered config will be written (-f)
@@ -176,6 +177,17 @@ func renderConfig(p dhcpcdParams) string {
 	// `-R`). The one-shot acquisition deliberately keeps its lease (-1 -p).
 	if !p.Once {
 		fmt.Fprintf(&b, "release\n")
+	}
+
+	// ipvlan-L2 slaves all share the parent NIC's MAC, so a unicast
+	// OFFER/ACK addressed to that MAC during initial acquisition can't be
+	// demuxed to the right slave (the slave's IP isn't on the link yet).
+	// The `broadcast` directive sets the DHCP BROADCAST flag so the server
+	// replies via L2 broadcast — the dhcpcd equivalent of busybox `-B`
+	// (#243). v4-only: the flag is a DHCPv4 concept. dhcpcd only auto-sets
+	// it for non-Ethernet links, so ipvlan needs it forced.
+	if p.Broadcast && !p.V6 {
+		fmt.Fprintf(&b, "broadcast\n")
 	}
 
 	if p.Hostname != "" {

--- a/pkg/udhcpc/dhcpcd_test.go
+++ b/pkg/udhcpc/dhcpcd_test.go
@@ -224,6 +224,33 @@ func TestRenderConfig_ReleaseOnlyForPersistent(t *testing.T) {
 	}
 }
 
+// TestRenderConfig_BroadcastOnlyForIPvlanV4 covers the ipvlan-required
+// broadcast directive (#243): when Broadcast is set on a v4 client the
+// config emits the standalone `broadcast` directive (the dhcpcd
+// equivalent of busybox `-B`), so the server replies with an L2
+// broadcast OFFER that all ipvlan slaves on the shared parent MAC can
+// receive. It must be absent when Broadcast is unset, and absent for v6
+// (the BROADCAST flag is a DHCPv4 concept). Uses hasLine so the always-
+// present `broadcast_address` option-request line can't false-positive.
+func TestRenderConfig_BroadcastOnlyForIPvlanV4(t *testing.T) {
+	mac := mustMAC(t, "de:ad:be:ef:00:01")
+
+	withBcast := renderConfig(dhcpcdParams{Iface: "eth0", MAC: mac, Broadcast: true})
+	if !hasLine(withBcast, "broadcast") {
+		t.Errorf("v4 broadcast client missing `broadcast` directive:\n%s", withBcast)
+	}
+
+	noBcast := renderConfig(dhcpcdParams{Iface: "eth0", MAC: mac})
+	if hasLine(noBcast, "broadcast") {
+		t.Errorf("non-broadcast client must not emit `broadcast`:\n%s", noBcast)
+	}
+
+	v6Bcast := renderConfig(dhcpcdParams{Iface: "eth0", MAC: mac, V6: true, Broadcast: true})
+	if hasLine(v6Bcast, "broadcast") {
+		t.Errorf("v6 client must not emit `broadcast` (v4-only flag):\n%s", v6Bcast)
+	}
+}
+
 // TestRenderConfig_RequestsPropagatedOptions: because `-f <config>`
 // bypasses /etc/dhcpcd.conf, the config must explicitly request every
 // option the plugin propagates, or dhcpcd never learns them (the busybox

--- a/test/integration/harness/fixture.go
+++ b/test/integration/harness/fixture.go
@@ -263,14 +263,16 @@ func (f *Fixture) startDnsmasq() error {
 		// tests that don't opt-in are unaffected.
 		"--dhcp-vendorclass=set:"+dnsmasqVCTag+","+TestVendorClass,
 		"--dhcp-option=tag:"+dnsmasqVCTag+",3,"+TestTaggedGateway,
-		// dhcp-broadcast forces OFFER/ACK to be sent as L2 broadcast
-		// regardless of the client's broadcast flag. Required for
-		// ipvlan-L2 mode: the slave's IP isn't registered with the
-		// parent's ipvlan until the lease is configured (chicken &
-		// egg), so unicast OFFERs addressed to parent MAC can't be
-		// routed to the slave during initial DHCP. Real LAN DHCP
-		// servers typically broadcast anyway; this matches that.
-		"--dhcp-broadcast",
+		// NOTE: this fixture deliberately does NOT pass --dhcp-broadcast.
+		// dnsmasq honours the client's BROADCAST flag, so it broadcasts
+		// OFFER/ACK only when the client asks. ipvlan-L2 needs that
+		// (shared parent MAC ⇒ a unicast OFFER can't be demuxed to the
+		// right slave during initial acquisition), and the plugin now
+		// sets it via the dhcpcd `broadcast` directive for ipvlan (#243).
+		// Forcing --dhcp-broadcast here would mask a regression in that
+		// client-side flag — so the ipvlan lifecycle test exercises the
+		// real path. bridge/macvlan use distinct MACs and get unicast
+		// replies, which is fine.
 		"--log-dhcp",
 		"--log-facility=-",
 	)

--- a/test/integration/lifecycle_ipvlan_test.go
+++ b/test/integration/lifecycle_ipvlan_test.go
@@ -23,14 +23,14 @@ import (
 // same MAC the daemon reported.
 //
 // Earlier this test was `t.Skip`'d because the OFFER never reached
-// the slave through a veth parent. The original fix forced the
-// BROADCAST flag in DISCOVER (busybox `udhcpc -B`) for ipvlan mode so
-// the OFFER was L2-broadcast at the wire level and the kernel flooded
-// it to all slaves of the parent. NOTE: since the dhcpcd migration
-// (#152) the client's Broadcast option is not yet wired (see
-// pkg/udhcpc DHCPClientOptions.Broadcast), so dnsmasq's
-// `--dhcp-broadcast` in our fixture is currently what keeps ipvlan
-// honest on the test path.
+// the slave through a veth parent. The fix forces the BROADCAST flag
+// in DISCOVER for ipvlan mode so the OFFER is L2-broadcast at the wire
+// level and the kernel floods it to all slaves of the parent — the
+// plugin sets this via the dhcpcd `broadcast` directive (#243; was
+// busybox `udhcpc -B` before the #152 migration). The fixture
+// deliberately does NOT pass dnsmasq `--dhcp-broadcast`, so this test
+// genuinely exercises that client-side flag: if it regressed, ipvlan
+// acquisition here would hang.
 func TestLifecycleIPvlan_GoldenPath(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()


### PR DESCRIPTION
Closes #243.

## Bug

ipvlan-L2 slaves share the parent NIC's MAC, so a unicast OFFER/ACK to
that MAC during **initial acquisition** can't be demuxed to the right
slave. busybox set the DHCP BROADCAST flag for this (`udhcpc -B`). The
dhcpcd port (#223) declared `DHCPClientOptions.Broadcast` but **never
consumed it**: `dhcpcdParams` had no `Broadcast` field, so the value —
correctly set for ipvlan at both call sites (`parent_attached.go` one-shot
and `dhcp_manager.go` persistent) — was dropped before `renderConfig`,
and dhcpcd's `-B` is *foreground*, not broadcast.

Net: a **regression vs v1.1.x** for ipvlan against a unicasting DHCP
server, masked in CI by the fixture's `--dhcp-broadcast`. Found while
refreshing stale comments (#242).

## Fix

Plumb `Broadcast` into `dhcpcdParams` and emit the dhcpcd **`broadcast`**
directive (v4 only) in `renderConfig` — verified against `dhcpcd.conf(5)`
for the pinned **10.3.2**: *"Instructs the DHCP server to broadcast
replies back to the client."* (dhcpcd only auto-sets it for non-Ethernet
links, so ipvlan must force it.)

## Tests

- **Unit:** re-add the coverage removed in #223 —
  `TestRenderConfig_BroadcastOnlyForIPvlanV4` (present for v4+Broadcast,
  absent otherwise and for v6; uses `hasLine` so the always-present
  `broadcast_address` option-request can't false-positive).
- **Integration:** drop `--dhcp-broadcast` from the shared dnsmasq
  fixture so the ipvlan lifecycle test exercises the **real client-side
  flag** rather than the server-forced broadcast that hid the bug.
  bridge/macvlan use distinct MACs (unicast replies) and are unaffected.

## Verification

`gofmt`/`go build`/`go vet`/`go test ./pkg/...` pass locally. The
all-three-modes verification (the point of dropping the fixture crutch)
runs as the PR's **`integration`** check on the self-hosted runner — local
`sudo` is password-gated so I couldn't run it by hand. Without this fix,
the ipvlan lifecycle test now *hangs* on acquisition (the regression);
with it, the client requests broadcast and dnsmasq honours it.
