### PR TITLE
fix(dhcpcd): remount /proc/sys rw so interface setup survives a read-only proc (#247)

### DIFF
--- a/pkg/udhcpc/client.go
+++ b/pkg/udhcpc/client.go
@@ -6,12 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
 	"syscall"
 
 	log "github.com/sirupsen/logrus"
@@ -32,7 +34,74 @@ const (
 	// mounted here (see Start). Identity (DUID/IAID) is pinned via
 	// literal config, so a fresh empty state dir is harmless.
 	dhcpcdStateDir = "/var/lib/dhcpcd"
+
+	// procSysPath is the kernel sysctl tree dhcpcd writes during
+	// interface setup — net/ipv4/conf/<if>/promote_secondaries (v4,
+	// fatal if it fails) and net/ipv6/conf/<if>/{autoconf,accept_ra}
+	// (v6). It is mounted read-only in the managed-plugin rootfs (and in
+	// stock Docker containers, where runc remounts it ro), so those
+	// writes returned EROFS and dhcpcd's if_init aborted with a
+	// misleading "interface not found", failing every lease (#247).
+	// `--noconfigure` does not suppress the writes — dhcpcd does them
+	// regardless of observe-only mode. We remount it read-write inside
+	// the client's private mount namespace (see mountPrep), which is
+	// invisible to the host and to other containers.
+	procSysPath = "/proc/sys"
+
+	// stderrTailMax caps the dhcpcd stderr retained to fold into a
+	// non-zero exit error — enough for the operative diagnostic line(s)
+	// without unbounded growth from a chatty trace.
+	stderrTailMax = 4 << 10
 )
+
+// mountPrep is the shell run inside the `unshare -m` mount namespace
+// before exec'ing dhcpcd. It (1) shadows the host-shared dhcpcd state
+// dir with a private tmpfs (see dhcpcdStateDir) and (2) flips /proc/sys
+// read-write so dhcpcd's interface-setup sysctl writes succeed (see
+// procSysPath, #247). Both mounts are local to this client's mount
+// namespace. Their stderr is swallowed: each can legitimately be a
+// no-op (state dir already private, /proc/sys already rw) or refused
+// (userns-locked mount) — a genuinely blocked sysctl write still
+// surfaces via dhcpcd's own stderr, captured into the exit error.
+func mountPrep() string {
+	return fmt.Sprintf(
+		"mount -t tmpfs tmpfs %s 2>/dev/null; "+
+			"mount -o remount,bind,rw %s 2>/dev/null; "+
+			"exec \"$0\" \"$@\"",
+		dhcpcdStateDir, procSysPath)
+}
+
+// tailWriter retains the last up-to-max bytes written to it. dhcpcd's
+// stderr is teed to the debug log and to one of these, so a non-zero
+// exit can surface the real cause (e.g. "Read-only file system")
+// instead of a bare "exit status 1" (#247). It is written only by the
+// os/exec output-copy goroutine and read only after cmd.Wait returns
+// (which joins that goroutine), so no locking is needed.
+type tailWriter struct {
+	max int
+	buf []byte
+}
+
+func (w *tailWriter) Write(p []byte) (int, error) {
+	w.buf = append(w.buf, p...)
+	if len(w.buf) > w.max {
+		w.buf = w.buf[len(w.buf)-w.max:]
+	}
+	return len(p), nil
+}
+
+// condense renders the retained stderr as a compact single line: blank
+// lines dropped, the rest joined with "; ", suitable for folding into
+// an error message.
+func (w *tailWriter) condense() string {
+	var lines []string
+	for _, ln := range strings.Split(string(w.buf), "\n") {
+		if ln = strings.TrimSpace(ln); ln != "" {
+			lines = append(lines, ln)
+		}
+	}
+	return strings.Join(lines, "; ")
+}
 
 // validIfaceName accepts only a kernel-legal network interface name: 1–15
 // characters (IFNAMSIZ-1), starting with an alphanumeric (so it can never
@@ -96,8 +165,9 @@ type DHCPClient struct {
 	Opts *DHCPClientOptions
 
 	cmd     *exec.Cmd
-	workDir string   // per-client temp dir: generated config + event FIFO
-	fifo    *os.File // read+keep-alive (O_RDWR) end of the event FIFO
+	workDir string      // per-client temp dir: generated config + event FIFO
+	fifo    *os.File    // read+keep-alive (O_RDWR) end of the event FIFO
+	stderr  *tailWriter // last bytes of dhcpcd stderr, for the exit error
 
 	waitErr  error
 	waitDone chan struct{} // closed when cmd.Wait() returns
@@ -169,19 +239,21 @@ func NewDHCPClient(iface string, opts *DHCPClientOptions) (*DHCPClient, error) {
 	// Wait target it directly. `sh -c '... exec "$0" "$@"'` passes the
 	// dhcpcd argv as $0/$@, avoiding any quoting of paths.
 	dargs := renderArgs(params)
-	mountExec := fmt.Sprintf("mount -t tmpfs tmpfs %s 2>/dev/null; exec \"$0\" \"$@\"", dhcpcdStateDir)
-	wrapped := append([]string{"unshare", "-m", "/bin/sh", "-c", mountExec}, dargs...)
+	wrapped := append([]string{"unshare", "-m", "/bin/sh", "-c", mountPrep()}, dargs...)
 
 	c := &DHCPClient{
 		Opts:    opts,
 		cmd:     exec.Command(wrapped[0], wrapped[1:]...),
 		workDir: workDir,
 		fifo:    fifo,
+		stderr:  &tailWriter{max: stderrTailMax},
 	}
 	// dhcpcd's own logs (stdout/stderr) go to logrus at debug level; the
-	// structured events come over the FIFO, not these streams.
+	// structured events come over the FIFO, not these streams. stderr is
+	// additionally tee'd into a bounded tail buffer so a non-zero exit
+	// can report dhcpcd's real diagnostic, not just "exit status 1" (#247).
 	c.cmd.Stdout = log.StandardLogger().WriterLevel(log.DebugLevel)
-	c.cmd.Stderr = log.StandardLogger().WriterLevel(log.DebugLevel)
+	c.cmd.Stderr = io.MultiWriter(log.StandardLogger().WriterLevel(log.DebugLevel), c.stderr)
 
 	log.WithField("cmd", c.cmd.Args).Trace("new dhcpcd client")
 	return c, nil
@@ -274,7 +346,16 @@ func (c *DHCPClient) Start() (chan Event, error) {
 	// the FIFO (ending the scanner, which closes events) and records the
 	// exit status for Finish/Wait.
 	go func() {
-		c.waitErr = c.cmd.Wait()
+		werr := c.cmd.Wait()
+		// Wait has joined the stderr-copy goroutine, so the tail buffer is
+		// complete and safe to read here. Fold dhcpcd's own diagnostic into
+		// the error so callers see the real cause (#247).
+		if werr != nil {
+			if tail := c.stderr.condense(); tail != "" {
+				werr = fmt.Errorf("%w: %s", werr, tail)
+			}
+		}
+		c.waitErr = werr
 		c.fifo.Close()
 		close(c.waitDone)
 	}()

--- a/pkg/udhcpc/client_test.go
+++ b/pkg/udhcpc/client_test.go
@@ -186,3 +186,57 @@ func TestNewDHCPClient_FIFOWiredIntoConfig(t *testing.T) {
 		t.Errorf("event FIFO not created: %v", err)
 	}
 }
+
+func TestMountPrep_RemountsProcSysRW(t *testing.T) {
+	script := mountPrep()
+	// dhcpcd's interface setup writes /proc/sys, which is ro in the
+	// managed-plugin rootfs; the wrapper must flip it rw in the private
+	// mount namespace before exec (#247). It must still mount the
+	// per-client tmpfs state dir and exec dhcpcd via $0/$@.
+	for _, want := range []string{
+		"mount -t tmpfs tmpfs " + dhcpcdStateDir,
+		"mount -o remount,bind,rw " + procSysPath,
+		`exec "$0" "$@"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("mountPrep missing %q\n---\n%s", want, script)
+		}
+	}
+	// The remount must precede exec, or dhcpcd starts before /proc/sys is
+	// writable.
+	if strings.Index(script, "remount,bind,rw") > strings.Index(script, `exec "$0"`) {
+		t.Errorf("remount must run before exec\n---\n%s", script)
+	}
+}
+
+func TestNewDHCPClient_WrapsRemountIntoCommand(t *testing.T) {
+	c := newTestClient(t, "eth0", &DHCPClientOptions{MAC: mustMAC(t, "de:ad:be:ef:00:01")})
+	// The mount-prep script rides as the `sh -c` argument; assert the
+	// /proc/sys remount actually reaches the spawned command.
+	if !hasArg(c.cmd.Args, mountPrep()) {
+		t.Errorf("mount-prep script not wired into command; args: %v", c.cmd.Args)
+	}
+}
+
+func TestTailWriter_CapsAndCondenses(t *testing.T) {
+	w := &tailWriter{max: 8}
+	// Writes beyond max retain only the trailing bytes.
+	for _, s := range []string{"hello\n", "world\n"} {
+		if _, err := w.Write([]byte(s)); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	if got := string(w.buf); got != "o\nworld\n" {
+		t.Errorf("tail not capped to last %d bytes: %q", w.max, got)
+	}
+
+	// condense drops blank lines and joins the rest with "; ".
+	w2 := &tailWriter{max: stderrTailMax}
+	_, _ = w2.Write([]byte("dhcpcd: eth0: if_init: Read-only file system\n\n  \nexiting\n"))
+	if got, want := w2.condense(), "dhcpcd: eth0: if_init: Read-only file system; exiting"; got != want {
+		t.Errorf("condense() = %q, want %q", got, want)
+	}
+	if (&tailWriter{max: stderrTailMax}).condense() != "" {
+		t.Errorf("empty tail should condense to empty string")
+	}
+}


### PR DESCRIPTION
Closes #247.

## Bug

The dhcpcd client (introduced in #152, on `dev`, unreleased) **fails to
obtain any lease on hosts where its `/proc/sys` is mounted read-only** —
the managed-plugin rootfs, and stock Docker containers where runc
remounts `/proc/sys` ro. dhcpcd writes kernel sysctls during interface
setup:

| Sysctl | When | On read-only `/proc/sys` |
|---|---|---|
| `net/ipv4/conf/<if>/promote_secondaries` | v4 `if_init` | **Fatal** → client dies → misleading `interface not found` |
| `net/ipv6/conf/<if>/autoconf`, `accept_ra` | v6 `if_setup_inet6` | logged, survives |

The write returns `EROFS`, dhcpcd aborts, and `CreateEndpoint` fails
with `failed to get initial IP address via DHCP: exit status 1`.
`--noconfigure` does **not** suppress these writes — they are part of
dhcpcd taking over the interface, done regardless of observe-only mode.

busybox never touched these sysctls, so **no released version (v1.1.1
and earlier) is affected** — this is a pre-release regression of the
dhcpcd migration, surfaced by the opt-in hosted CI cross-check (#238 /
#241) on a stock `ubuntu-latest` runner. It passes on the self-hosted
runner, which is why it slipped through until the hosted lane existed.

## Fix

Remount `/proc/sys` read-write inside the client's **existing private
(`unshare -m`) mount namespace**, alongside the state-dir tmpfs that was
already mounted there. The remount:

- is **local to the dhcpcd child** — invisible to the host and to other
  containers (same isolation the state-dir tmpfs already relies on);
- needs **no new capability** — the plugin already holds
  `CAP_SYS_ADMIN`;
- is **idempotent** — a no-op where `/proc/sys` is already writable
  (e.g. the self-hosted runner), so it harms neither environment.

Also tee dhcpcd's stderr into a bounded tail buffer and fold it into the
non-zero-exit error, so a future failure reports dhcpcd's **real**
diagnostic (e.g. `Read-only file system`) instead of a bare `exit
status 1` (acceptance criterion 3).

## Tests

- **Unit:** `mountPrep` emits the `/proc/sys` remount before `exec` and
  keeps the state-dir tmpfs; the remount is wired into the spawned
  command; `tailWriter` caps to the trailing bytes and `condense`
  collapses multi-line stderr into a single diagnostic.
- **Integration (acceptance):** the real EROFS path is exercised by the
  #241 hosted `ubuntu-latest` lane. Pending on this PR:
  - [ ] #241 `integration-hosted` lane green end-to-end (both suites).
  - [ ] re-enable the weekly `schedule` in `integration-hosted.yml`
    (handled together with #241's temporary push-trigger revert).

## Verification

`go build ./...`, `go test ./pkg/... ./cmd/...`, `go vet`, and
`staticcheck ./pkg/udhcpc/...` all clean locally. New helpers are
100% unit-covered; the EROFS path itself is covered by the hosted lane,
not the unit suite (it needs a privileged `unshare -m`).