### PR TITLE
ci: automate release version-pin bump + pin-consistency gate (#251)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,11 +73,18 @@ jobs:
           bash scripts/test-govulncheck-gate.sh
           bash scripts/test-check-option-docs.sh
           bash scripts/test-check-apk-pins.sh
+          bash scripts/test-check-version-pins.sh
 
       # Every driver-option key the code parses must be documented in
       # docs/reference.md — an undocumented option turns CI red (#132).
       - name: Option-docs drift check
         run: bash scripts/check-option-docs.sh
+
+      # Every published-image pin in README/docs must agree on one
+      # version — catches a partial release bump (#251). Bump them with
+      # scripts/bump-version.sh vX.Y.Z.
+      - name: Version-pin consistency check
+        run: bash scripts/check-version-pins.sh
 
   staticcheck:
     runs-on: ubuntu-latest

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -146,19 +146,17 @@ the `vX.Y.Z` milestone (the workflow leans on this for the
 "Closes" list in the release PR).
 
 1. **Branch off `dev`:** `git checkout -b release/vX.Y.Z origin/dev`
-2. **Bump install pins** in:
-   - `README.md` — every `docker plugin install ghcr.io/...:vPREV`
-     and `docker network create -d ghcr.io/...:vPREV` snippet.
-     Leave historical references like `As of vPREV every PR...`
-     alone — those are facts about when something started, not
-     install instructions.
-   - `docs/parent-attached-modes.md` — the `STATE_DIR` override
-     example.
-   - `docs/reference.md` — install/upgrade snippets, the Health
-     `curl` example, and the Compose `driver:` example all pin the
-     version.
-   Verify with
-   `grep -n vPREV README.md docs/parent-attached-modes.md docs/reference.md`.
+2. **Bump install pins:** `scripts/bump-version.sh vX.Y.Z` (#251). It
+   rewrites every published-image pin
+   (`ghcr.io/.../docker-net-dhcp:vPREV` in the `plugin install` /
+   `network create` / `driver:` / `plugin inspect` snippets across
+   `README.md` and `docs/`) to the new tag, and leaves bare `vX.Y.Z`
+   feature markers and historical prose (`As of vPREV every PR...`,
+   `v1.1.0 onward`) alone — the image ref is what tells a pin from
+   prose. Verify with `git diff` and `scripts/check-version-pins.sh`
+   (the same gate `test.yaml` runs: every pin must agree on one
+   version). The gate also fails CI if a future hand-edit leaves the
+   pins inconsistent.
 3. **Documentation review — PR-driven against the milestone.** Don't
    review from memory; review from the change set. List every PR on the
    `vX.Y.Z` milestone and reconcile each one's user-visible change

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Release version-pin bump (#251): rewrite the published-image version
+# pins in README.md and docs/ to a new release tag. Run on the release
+# branch (runbook step 2) instead of hand-editing each snippet.
+#
+# Only occurrences of the plugin image reference
+#   ghcr.io/claymore666/docker-net-dhcp:vX.Y.Z
+# are rewritten, so install/usage snippets (plugin install, network
+# create, driver:, plugin inspect) all move to the new version while
+# bare "vX.Y.Z" feature markers and historical prose ("as of v1.2.0",
+# "v1.1.0 onward") are left untouched — the image ref is the thing that
+# distinguishes a pin from prose.
+#
+# Idempotent and old-version-agnostic: it rewrites whatever version each
+# pin currently carries, so a partially-bumped tree self-heals.
+#
+# Usage: scripts/bump-version.sh vX.Y.Z   (run from the repo root)
+set -euo pipefail
+
+VER="${1:-}"
+case "$VER" in
+    v[0-9]*.[0-9]*.[0-9]*) ;;
+    *)
+        echo "usage: $0 vX.Y.Z (e.g. v1.2.0)" >&2
+        exit 2
+        ;;
+esac
+
+IMAGE="ghcr.io/claymore666/docker-net-dhcp"
+# Escape dots for the regex (the image ref has none beyond the host, but
+# keep it correct if the constant ever changes).
+IMAGE_RE="${IMAGE//./\\.}"
+
+files=()
+for f in README.md docs/*.md; do
+    [ -f "$f" ] && files+=("$f")
+done
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "FAIL  no README.md / docs/*.md found — run from the repo root" >&2
+    exit 2
+fi
+
+changed=0
+for f in "${files[@]}"; do
+    before="$(cat "$f")"
+    # Rewrite the version that immediately follows the image ref.
+    sed -i -E "s#(${IMAGE_RE}:)v[0-9]+\.[0-9]+\.[0-9]+#\1${VER}#g" "$f"
+    if [ "$before" != "$(cat "$f")" ]; then
+        echo "bumped  $f"
+        changed=$((changed + 1))
+    fi
+done
+
+if [ "$changed" -eq 0 ]; then
+    echo "no image pins changed (already at ${VER}?)"
+else
+    echo "bumped image pins to ${VER} in ${changed} file(s)"
+fi

--- a/scripts/check-version-pins.sh
+++ b/scripts/check-version-pins.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Version-pin consistency gate (#251): every published-image pin in the
+# docs must point at the SAME version. A pin is any occurrence of the
+# plugin image reference
+#   ghcr.io/claymore666/docker-net-dhcp:vX.Y.Z
+# (plugin install / network create / driver: / plugin inspect snippets).
+# If two pins disagree, a release bump was applied to some snippets but
+# not others — the failure mode scripts/bump-version.sh exists to avoid,
+# and this gate catches it on any branch.
+#
+# It does NOT assert the pins equal the latest release tag: the release
+# branch legitimately leads it (pins bumped to the version about to
+# ship, before the tag exists). Internal agreement is the invariant that
+# holds everywhere.
+#
+# Bare "vX.Y.Z" feature markers in prose carry no image ref and are
+# correctly ignored.
+#
+# Usage: check-version-pins.sh [<file>...]
+#   defaults: README.md docs/*.md (run from the repo root)
+set -u
+
+IMAGE="ghcr.io/claymore666/docker-net-dhcp"
+
+files=("$@")
+if [ "${#files[@]}" -eq 0 ]; then
+    for f in README.md docs/*.md; do
+        [ -f "$f" ] && files+=("$f")
+    done
+fi
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "usage: $0 [<file>...]  (no README.md / docs/*.md found)" >&2
+    exit 2
+fi
+
+# Collect "<version> <file>" for every pin, and the unique version set.
+pins="$(grep -hoE "${IMAGE}:v[0-9]+\.[0-9]+\.[0-9]+" "${files[@]}" 2>/dev/null \
+    | sed -E "s#.*:##" | sort)"
+versions="$(printf '%s\n' "$pins" | grep -v '^$' | sort -u)"
+
+count="$(printf '%s\n' "$versions" | grep -c . || true)"
+
+if [ "$count" -eq 0 ]; then
+    echo "FAIL  no image pins found in: ${files[*]}" >&2
+    echo "      expected at least one ${IMAGE}:vX.Y.Z install snippet." >&2
+    exit 1
+fi
+
+if [ "$count" -gt 1 ]; then
+    # shellcheck disable=SC2086  # word-split the newline list into a space-joined line
+    echo "FAIL  install pins disagree: $(printf '%s ' $versions)" >&2
+    echo
+    echo "Every ${IMAGE}:vX.Y.Z pin must point at the same version."
+    echo "Run: scripts/bump-version.sh <vX.Y.Z>"
+    echo
+    echo "Per-file pin versions:"
+    for f in "${files[@]}"; do
+        fv="$(grep -hoE "${IMAGE}:v[0-9]+\.[0-9]+\.[0-9]+" "$f" 2>/dev/null \
+            | sed -E "s#.*:##" | sort -u | paste -sd' ' -)"
+        [ -n "$fv" ] && echo "  $f: $fv"
+    done
+    exit 1
+fi
+
+echo "PASS  all install pins at ${versions}"
+exit 0

--- a/scripts/test-check-version-pins.sh
+++ b/scripts/test-check-version-pins.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Table-driven tests for check-version-pins.sh and bump-version.sh
+# (#251). Synthesizes README/docs fixtures with image-ref pins and bare
+# prose markers, asserting: agreeing pins pass; a disagreeing pin fails
+# and is named; no pins is an explicit failure; bare "vX.Y.Z" prose is
+# never treated as a pin; and bump-version rewrites only the pins (not
+# the prose) and leaves the tree internally consistent.
+set -u
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$DIR/check-version-pins.sh"
+BUMP="$DIR/bump-version.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+IMAGE="ghcr.io/claymore666/docker-net-dhcp"
+
+# A fixture repo root with a README and a docs/ dir.
+seed() {
+    rm -rf "$TMP/repo"
+    mkdir -p "$TMP/repo/docs"
+    cat > "$TMP/repo/README.md" <<EOF
+Install:
+
+    docker plugin install ${IMAGE}:v1.1.1
+
+Every release (v1.0.0 onward) is signed and attested.
+EOF
+    cat > "$TMP/repo/docs/reference.md" <<EOF
+Create a network:
+
+    docker network create -d ${IMAGE}:v1.1.1 mynet
+
+The Docker-visible v6 address is renewed as of v1.2.0 (#152).
+
+Compose:
+
+    driver: ${IMAGE}:v1.1.1
+EOF
+}
+
+failures=0
+run_check() {
+    local name="$1" want_exit="$2"
+    ( cd "$TMP/repo" && bash "$CHECK" ) > "$TMP/out" 2>&1
+    local got_exit=$?
+    if [ "$got_exit" -eq "$want_exit" ]; then
+        echo "PASS: $name"
+    else
+        echo "FAIL: $name (want exit $want_exit, got $got_exit)"
+        sed 's/^/    /' "$TMP/out"
+        failures=$((failures + 1))
+    fi
+}
+
+# 1. All pins agree -> green.
+seed
+run_check "agreeing pins pass" 0
+
+# 2. One pin disagrees -> red, and the offending version is named.
+seed
+sed -i "s#${IMAGE}:v1.1.1#${IMAGE}:v1.0.0#" "$TMP/repo/docs/reference.md"  # first hit only
+run_check "disagreeing pins fail" 1
+grep -q 'v1.0.0' "$TMP/out" || { echo "FAIL: disagreement not named"; failures=$((failures + 1)); }
+grep -q 'v1.1.1' "$TMP/out" || { echo "FAIL: other version not named"; failures=$((failures + 1)); }
+
+# 3. No image pins at all -> explicit failure (not silent green).
+seed
+rm -f "$TMP/repo/README.md"
+printf 'no pins here, just prose mentioning v1.2.0\n' > "$TMP/repo/docs/reference.md"
+run_check "no pins fails" 1
+
+# 4. Bare "vX.Y.Z" prose is not a pin: a doc with one real pin plus
+#    several bare-version mentions (different versions) still passes.
+seed
+cat >> "$TMP/repo/docs/reference.md" <<'EOF'
+
+Notes: works since v1.0.0; v6 renewal is v1.2.0+; signed since v1.1.0.
+EOF
+run_check "bare-version prose ignored" 0
+
+# 5. bump-version rewrites only the pins and leaves the tree consistent.
+seed
+( cd "$TMP/repo" && bash "$BUMP" v1.2.0 ) > "$TMP/out" 2>&1 \
+    || { echo "FAIL: bump-version exited nonzero"; sed 's/^/    /' "$TMP/out"; failures=$((failures + 1)); }
+# All three pins now at v1.2.0.
+if [ "$(grep -hoE "${IMAGE}:v[0-9.]+" "$TMP/repo/README.md" "$TMP/repo/docs/reference.md" | sort -u | paste -sd' ' -)" = "${IMAGE}:v1.2.0" ]; then
+    echo "PASS: bump moved every pin to v1.2.0"
+else
+    echo "FAIL: bump left disagreeing pins"; failures=$((failures + 1))
+fi
+# The historical prose markers are untouched.
+grep -q 'v1.0.0 onward' "$TMP/repo/README.md" || { echo "FAIL: bump rewrote historical prose"; failures=$((failures + 1)); }
+grep -q 'renewed as of v1.2.0' "$TMP/repo/docs/reference.md" || { echo "FAIL: feature marker disturbed"; failures=$((failures + 1)); }
+# And the consistency gate is green afterwards.
+( cd "$TMP/repo" && bash "$CHECK" ) > /dev/null 2>&1 \
+    && echo "PASS: gate green after bump" \
+    || { echo "FAIL: gate red after bump"; failures=$((failures + 1)); }
+
+# 6. bump-version rejects a malformed version argument.
+seed
+( cd "$TMP/repo" && bash "$BUMP" 1.2.0 ) > /dev/null 2>&1
+if [ $? -eq 2 ]; then echo "PASS: bump rejects bad version"; else echo "FAIL: bump accepted bad version"; failures=$((failures + 1)); fi
+
+# 7. check bad usage (no files anywhere) -> exit 2.
+mkdir -p "$TMP/empty"
+( cd "$TMP/empty" && bash "$CHECK" ) > /dev/null 2>&1
+if [ $? -eq 2 ]; then echo "PASS: check bad usage exits 2"; else echo "FAIL: check bad usage"; failures=$((failures + 1)); fi
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures test(s) failed"
+    exit 1
+fi
+echo "all check-version-pins tests passed"


### PR DESCRIPTION
Closes #251.

## What

- **`scripts/bump-version.sh vX.Y.Z`** — rewrites every published-image
  pin (`ghcr.io/claymore666/docker-net-dhcp:vX.Y.Z` in `plugin install`
  / `network create` / `driver:` / `plugin inspect` snippets across
  `README.md` + `docs/`) to a new tag. Old-version-agnostic and
  idempotent. Replaces the runbook step-2 hand-edit.
- **`scripts/check-version-pins.sh`** — gate asserting all image-ref
  pins agree on one version. Catches a partial/forgotten bump on any
  branch; does **not** require the pins to equal the latest release tag
  (the release branch legitimately leads it). Wired into `test.yaml`
  beside the other `check-*` gates.
- **`scripts/test-check-version-pins.sh`** — table-driven self-test of
  both scripts (CLAUDE.md: gates are themselves tested).
- Runbook step 2 → `scripts/bump-version.sh vX.Y.Z`.

## Why keyed on the image ref

Install pins always carry `docker-net-dhcp:vX.Y.Z`; feature/historical
markers are bare `vX.Y.Z` in prose (`(v1.2.0+)`, "as of v1.2.0",
"v1.1.0 onward"). Keying the rewrite and the gate on the image ref bumps
every pin and provably never touches prose — verified by the self-test
and by running the gate against the current docs (all pins consistently
`v1.1.1`; the v1.0.0/v1.2.0 prose mentions are correctly ignored).

## Validation

`scripts/test-check-version-pins.sh` passes (8 cases: agreement,
disagreement-named, no-pins, bare-prose-ignored, bump-rewrites-only-pins,
gate-green-after-bump, bad-version-rejected, bad-usage). Will be used for
the v1.2.0 pin bump on the release branch, exercising it on a real
release.