### PR TITLE
docs: v1.2.0 release prep (#251 bump tool first use)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ like any other machine. Bridge, macvlan, and ipvlan attachment modes.
 Install the plugin:
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.1
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.2.0
 ```
 
 It requests `host` networking, the host PID namespace, the Docker
@@ -43,7 +43,7 @@ already have a host bridge `my-bridge` on your LAN — see
 [bridge mode](docs/bridge-mode.md) for that one-time setup):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.2.0 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 
 docker run --rm -ti --network my-dhcp-net alpine ip address show

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,6 +44,48 @@ migration tracked in #178). They are accepted at the advisory level in
 older AuthZ finding (GHSA-x744-4wpc-v9h2 = GO-2026-4887), and will be
 re-evaluated when the module migration lands.
 
+## v1.2.0
+
+A DHCP-client modernization release. The plugin's DHCP client changes
+from BusyBox `udhcpc`/`udhcpc6` to **`dhcpcd`**, run observe-only
+(`--noconfigure`) so the plugin keeps sole ownership of interface
+configuration. This unblocks DHCPv6 feature parity and adds per-family
+observability. **Driver options and the plugin manifest are unchanged**;
+bridge / macvlan / ipvlan UX is identical to v1.1.x.
+
+What changed:
+
+- **dhcpcd replaces busybox udhcpc/udhcpc6** (#152). The DHCPv6 IA is now
+  unified across the one-shot acquisition and the persistent client (both
+  present an identical DUID-LL + IAID derived from the endpoint's stable
+  MAC), so the **Docker-visible IPv6 address is renewed** instead of being
+  acquired once and left to expire.
+- **Requested/preferred IPv6 address** (#213): a recorded or
+  `--ip6` / `AddressIPv6`-requested address is surfaced to the DHCPv6
+  client as an IA_NA preferred-address hint, and carried across restarts
+  in the tombstone — the v6 counterpart of the existing v4 behaviour.
+- **Per-family health counters** (#212): `lease_changed_v6`,
+  `leases_obtained_v6`, `leases_renewed_v6`, `dhcp_timeouts_v6`,
+  `naks_received_v6` on `/Plugin.Health`. The un-suffixed counters remain
+  v4+v6 totals, so the v4 share is the aggregate minus its `*_v6`.
+- **ipvlan DHCP broadcast** (#243): the broadcast flag is now actually
+  emitted for ipvlan-L2 initial acquisition (where slaves share the parent
+  MAC). The dhcpcd port had declared the option but dropped it — a
+  regression vs v1.1.x, fixed before release.
+- **Robustness**: dhcpcd's interface-setup sysctl writes now succeed on
+  hosts where the plugin's `/proc/sys` is read-only (#247), and network
+  IDs are validated before they reach state-file paths (#232,
+  path-injection hardening).
+- **Project**: a versioned documentation site (#133), governance /
+  code-of-conduct / security-assurance docs (#216), a Trivy rootfs CVE
+  scan and an opt-in hosted CI cross-check lane (#143, #238), and an
+  automated release version-pin bump with a consistency gate (#251).
+
+Operator-visible compatibility: the v4 client-id is still sent with the
+type-0 ("opaque") prefix the busybox path used, so existing DHCP server
+reservations keyed on it keep matching after the upgrade. No action is
+required to upgrade from v1.1.x.
+
 ## v1.1.1
 
 A compliance and project-hygiene release. **There are no functional
@@ -1074,9 +1116,9 @@ docker network create \
 
 In `mode=macvlan` the plugin creates a macvlan child on the named
 parent NIC (submode `bridge`, so children on the same parent can talk to
-each other), runs `udhcpc` on it to acquire a lease from the LAN's DHCP
+each other), runs `dhcpcd` on it to acquire a lease from the LAN's DHCP
 server, and hands the link to libnetwork. Docker moves the link into the
-container's network namespace; a persistent `udhcpc` keeps the lease
+container's network namespace; a persistent `dhcpcd` keeps the lease
 alive for the life of the endpoint and sends `DHCPRELEASE` on container
 stop so the upstream server doesn't accumulate stale leases.
 
@@ -1138,7 +1180,7 @@ The plugin requests the following privileges (same as upstream):
 - network: `host`
 - host pid namespace: `true`
 - mount: `/var/run/docker.sock`
-- capabilities: `CAP_NET_ADMIN`, `CAP_SYS_ADMIN`, `CAP_SYS_PTRACE`
+- capabilities: `CAP_NET_ADMIN`, `CAP_SYS_ADMIN`
 
 ## Backward compatibility
 
@@ -1210,9 +1252,10 @@ changes to include `daemon.*`. New vulnerabilities reported in
 
 ## Known limitations
 
-- The DHCP exchange uses BusyBox `udhcpc` / `udhcpc6`. Anything that
-  requires a fuller DHCP client (vendor extensions beyond `-V`,
-  RFC3315 reconfigure, etc.) is not supported.
+- The DHCP exchange uses `dhcpcd` (one process per family), run
+  observe-only (`--noconfigure`) so the plugin keeps sole ownership of
+  interface configuration. Features outside what dhcpcd performs in that
+  mode (e.g. RFC 3315 reconfigure handling) are not surfaced.
 - One DHCP-served network per container. Joining additional bridges
   works but may interact in surprising ways with the routing rules
   installed by the persistent client.
@@ -1223,13 +1266,13 @@ changes to include `daemon.*`. New vulnerabilities reported in
   a renewal cycle. The renewed IP is at least surfaced to the
   next restart's tombstone, so it isn't lost.
 - IPv6 lease tracking lands in tombstones (so the data flows through
-  CreateEndpoint/Leave/DeleteEndpoint), but the request hint isn't
-  surfaced to `udhcpc6` — busybox has no `-r` equivalent for v6.
-  IPv6 endpoints get whatever the DHCPv6 server assigns; with a
-  stable MAC and a server that keys reservations on
-  client-id/MAC, that's typically the same address. Switching to a
-  DHCPv6 client that supports preferred-address requests is a
-  future enhancement.
+  CreateEndpoint/Leave/DeleteEndpoint), and as of v1.2.0 the recorded
+  address is surfaced to the DHCPv6 client as an IA_NA preferred-address
+  hint (the dhcpcd migration, #152, replaced busybox `udhcpc6`, which had
+  no `-r` equivalent for v6). A `--ip6` / `AddressIPv6` request is honored
+  the same way. The server is still free to assign a different address;
+  with a stable MAC and reservation-keyed server that is typically the
+  same one.
 - Concurrent `docker restart` of multiple containers on the same
   DHCP network within ~10 seconds falls back to fresh MACs (the
   tombstone mechanism requires exactly one match to avoid swapping

--- a/docs/bridge-mode.md
+++ b/docs/bridge-mode.md
@@ -37,7 +37,7 @@ sudo dhcpcd my-bridge
 ## 2. Create the network
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.2.0 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 ```
 
@@ -45,7 +45,7 @@ With IPv6 as well (the `docker network create --ipv6` flag does **not**
 work with the null IPAM driver; use the `ipv6` driver option instead):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.2.0 \
   --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
 ```
 
@@ -100,7 +100,7 @@ services:
       - dhcp
 networks:
   dhcp:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.1.1
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.2.0
     driver_opts:
       bridge: my-bridge
       ipv6: 'true'

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ like any other machine. Bridge, macvlan, and ipvlan attachment modes.
 Install the plugin:
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.1
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.2.0
 ```
 
 It requests `host` networking, the host PID namespace, the Docker
@@ -34,7 +34,7 @@ already have a host bridge `my-bridge` on your LAN — see
 [Bridge mode](bridge-mode.md) for that one-time setup):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.2.0 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 
 docker run --rm -ti --network my-dhcp-net alpine ip address show

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -313,7 +313,7 @@ exact create incantation (note: the Docker-level `--ipv6` flag does
 NOT work with the null IPAM driver and is not what you want):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.2.0 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 -o ipv6=true \
     lan-dhcp6

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,7 +27,7 @@ The plugin publishes to two registries; GHCR is primary:
 for unattended):
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.1.1
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.2.0
 ```
 
 Privileges requested: `network: host`, host PID namespace, the Docker
@@ -93,7 +93,7 @@ You bring an existing Linux bridge that is L2-connected to the LAN
 (see [`bridge-mode.md`](bridge-mode.md) for the bridge setup itself):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.2.0 \
     --ipam-driver null \
     -o bridge=my-bridge \
     my-dhcp-net
@@ -105,7 +105,7 @@ No host changes — containers get per-container kernel-generated MACs
 as macvlan children of a host NIC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.2.0 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 \
     lan-dhcp
@@ -119,7 +119,7 @@ security, hostile vSwitches, some Wi-Fi APs). The DHCP server must
 key reservations on DHCP option 61 (client identifier), not MAC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.1.1 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.2.0 \
     --ipam-driver null \
     -o mode=ipvlan -o parent=eth0 \
     lan-dhcp
@@ -202,7 +202,7 @@ Set with `docker plugin set <plugin> NAME=value`; take effect after
 JSON liveness + counters on the plugin's UNIX socket:
 
 ```bash
-PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.1.1)
+PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.2.0)
 curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
     http://localhost/Plugin.Health | jq .
 ```
@@ -224,7 +224,6 @@ curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
 | `naks_received` | no | (v1.0.0+) The server NAKed a renewal/rebind (v4+v6 aggregate). `dhcpcd` recovers by re-acquiring, so each NAK is typically followed by `leases_obtained` — and, if the address moved, `lease_changed` — bumps. Climbing alongside `lease_changed` means containers are being re-addressed mid-life. |
 | `ledger_write_failures` | no | Failed `audit_log` ledger appends — degrades forensics, not networking. Operators using `audit_log` alert on this. |
 | `lease_changed_v6`, `leases_obtained_v6`, `leases_renewed_v6`, `dhcp_timeouts_v6`, `naks_received_v6` | no | (v1.2.0+) The IPv6-only share of the matching aggregate above (#212). Each counts only the v6 client's events; the v4 share is the aggregate minus its `*_v6`. On a dual-stack host this isolates the v6-specific NAK/timeout signal the aggregate hides. `lease_release_failures` and `ledger_write_failures` have no per-family split. |
-| `lease_changed_v6`, `leases_obtained_v6`, `leases_renewed_v6`, `dhcp_timeouts_v6`, `naks_received_v6` | no | (v1.2.0+) Per-family breakdown: the IPv6 share of the matching aggregate above. The un-suffixed counters stay v4+v6 totals, so the IPv4 share is `<counter> − <counter>_v6`. On a dual-stack host this isolates a v6-specific NAK or timeout that the aggregate alone would hide. |
 
 ### Plugin log
 
@@ -274,7 +273,7 @@ Compose-managed alternative (network lifecycle tied to the project):
 ```yaml
 networks:
   lan:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.1.1
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.2.0
     driver_opts:
       mode: macvlan
       parent: eth0


### PR DESCRIPTION
Release-branch prep for **v1.2.0** (runbook steps 2–4). Lands on `dev`;
the `dev` → `main` `Release v1.2.0` PR follows.

## Pins (step 2)
First real use of `scripts/bump-version.sh v1.2.0` (#251): bumped every
published-image pin v1.1.1 → v1.2.0 across README + docs/. It caught
pins in `docs/bridge-mode.md` and `docs/index.md` that the runbook's
manual file list didn't enumerate — the automation's first save.
`scripts/check-version-pins.sh` is green.

## RELEASE_NOTES (step 4)
Added the `## v1.2.0` section: dhcpcd replaces busybox (#152),
requested/preferred IPv6 (#213), per-family health counters (#212),
ipvlan broadcast fix (#243), read-only `/proc/sys` + networkID hardening
(#247 / #232), and the docs-site / governance / CI items.

## Doc-review fixes (step 3 — PR-driven against the milestone)
Reconciling every merged v1.2.0 PR against the docs surfaced real drift:

- **`docs/reference.md`** — removed a **duplicated** per-family health-
  counter table row (a merge artifact: two near-identical rows for the
  same `*_v6` counters; kept the complete one that references #212 and
  notes which counters have no per-family split).
- **`RELEASE_NOTES.md` living sections** (the frozen `## vX` history is
  untouched): the macvlan description and two "Known limitations" bullets
  still described the client as busybox `udhcpc` and called the v6
  preferred-address request a "future enhancement" — both shipped here.
  Also fixed the capability list to match the manifest (`CAP_NET_ADMIN` +
  `CAP_SYS_ADMIN`; it wrongly listed `CAP_SYS_PTRACE`).

The rest of README/docs was read top-to-bottom and is consistent with
what v1.2.0 ships (option tables are also machine-gated by
`check-option-docs.sh`).

## Verified
`check-version-pins.sh`, `check-option-docs.sh`, `go build`, `go vet`
all green locally.