### PR TITLE
fix(coverage): forward GOCOVERDIR to the dhcpcd hook (#258)

### DIFF
--- a/pkg/udhcpc/client.go
+++ b/pkg/udhcpc/client.go
@@ -220,6 +220,10 @@ func NewDHCPClient(iface string, opts *DHCPClientOptions) (*DHCPClient, error) {
 		Handler:     handler,
 		ConfigPath:  configPath,
 		EventFIFO:   fifoPath,
+		// Forward our own GOCOVERDIR to the hook so its coverage counters
+		// survive dhcpcd's environment scrub (cover build only; unset and
+		// thus omitted in production). See renderConfig.
+		CoverDir: os.Getenv("GOCOVERDIR"),
 	}
 	if err := os.WriteFile(configPath, []byte(renderConfig(params)), 0o600); err != nil {
 		return cleanup(fmt.Errorf("failed to write dhcpcd config: %w", err))

--- a/pkg/udhcpc/dhcpcd.go
+++ b/pkg/udhcpc/dhcpcd.go
@@ -102,6 +102,7 @@ type dhcpcdParams struct {
 	Handler    string // hook script path (-c)
 	ConfigPath string // where the rendered config will be written (-f)
 	EventFIFO  string // FIFO the handler writes events to (env directive); "" omits
+	CoverDir   string // GOCOVERDIR to forward to the hook (cover build only); "" omits
 }
 
 // renderConfig produces the dhcpcd.conf text for p. Only directives
@@ -140,6 +141,17 @@ func renderConfig(p dhcpcdParams) string {
 	// process environment).
 	if p.EventFIFO != "" {
 		fmt.Fprintf(&b, "env %s=%s\n", EventFIFOEnv, p.EventFIFO)
+	}
+
+	// Forward GOCOVERDIR to the hook in the coverage-instrumented build
+	// so cmd/udhcpc-handler's `-cover` counters are written and merged.
+	// dhcpcd scrubs the environment, so — like the FIFO above — it has to
+	// ride the `env` directive; otherwise the handler (a separate process
+	// dhcpcd execs per event) loses GOCOVERDIR and emits nothing, and the
+	// package drops out of the coverage ratchet entirely. Empty in
+	// production (GOCOVERDIR unset), so this is a no-op there.
+	if p.CoverDir != "" {
+		fmt.Fprintf(&b, "env GOCOVERDIR=%s\n", p.CoverDir)
 	}
 
 	// Keep dhcpcd off host/system files.

--- a/pkg/udhcpc/dhcpcd_test.go
+++ b/pkg/udhcpc/dhcpcd_test.go
@@ -199,6 +199,20 @@ func TestRenderConfig_EventFIFO(t *testing.T) {
 	}
 }
 
+func TestRenderConfig_CoverDir(t *testing.T) {
+	mac := mustMAC(t, "de:ad:be:ef:00:01")
+	// present → GOCOVERDIR rides the `env` directive so the hook's -cover
+	// counters survive dhcpcd's environment scrub (cover build only).
+	conf := renderConfig(dhcpcdParams{Iface: "eth0", MAC: mac, CoverDir: "/coverage"})
+	if !hasLine(conf, "env GOCOVERDIR=/coverage") {
+		t.Errorf("config missing env GOCOVERDIR directive:\n%s", conf)
+	}
+	// absent (production) → no GOCOVERDIR line.
+	if strings.Contains(renderConfig(dhcpcdParams{Iface: "eth0", MAC: mac}), "GOCOVERDIR") {
+		t.Error("config emitted GOCOVERDIR with no CoverDir set")
+	}
+}
+
 // TestRenderConfig_ReleaseOnlyForPersistent: the persistent client emits
 // `release` (busybox -R: DHCPRELEASE on graceful stop, which the
 // docker-restart / daemon-restart IP-stability tests rely on); the


### PR DESCRIPTION
Closes #258. Unblocks the v1.2.0 Coverage ratchet (release PR #257).

## Problem
First Coverage run since the dhcpcd migration (#152) failed:
`cmd/udhcpc-handler: in baseline but absent from coverage output`. dhcpcd
scrubs the environment before exec'ing its hook, so the handler (a
separate process) lost the `GOCOVERDIR` it used to inherit under busybox
and stopped emitting `-cover` counters. Collection regression only — the
handler runs fine in production.

## Fix
Forward `GOCOVERDIR` to the hook via dhcpcd's `env` directive (the same
mechanism the event FIFO already uses), gated on it being set. Production
never sets it → no-op; the `-cover` build (`config-cover.json` sets
`GOCOVERDIR=/coverage`) gets the handler's counters back.

Rejected the alternative of dropping `cmd/udhcpc-handler` from the
ratchet baseline — that permanently blinds the ratchet to real, exercised
code, against its intent.

## Tests
- Unit: `TestRenderConfig_CoverDir` — `GOCOVERDIR` emitted as an `env`
  directive when set, omitted otherwise.
- The fix's real effect (handler reappears in coverage) is verified by
  the Coverage workflow re-running on #257 once this lands on `dev`.

`go build` / `go test ./pkg/udhcpc/...` / `go vet` green locally.