### PR TITLE
fix(release): migrate cosign sign-blob/verify-blob to the v3 bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,13 +250,13 @@ jobs:
           # Manifest covers the tarball AND the SBOMs, so the single
           # keyless signature below attests all release assets at once.
           sha256sum "$ART" sbom.spdx.json sbom.cdx.json > checksums.txt
-          # Keyless (Fulcio/OIDC) signature over the checksum manifest.
-          # Emits a detached signature and the short-lived signing
-          # certificate; both are public and verified against the Actions
-          # OIDC issuer.
+          # Keyless (Fulcio/OIDC) signature over the checksum manifest,
+          # emitted as a Sigstore bundle (cosign v3 default; the v2
+          # --output-signature/--output-certificate pair was removed —
+          # the bundle carries signature + short-lived cert in one public
+          # file, verified against the Actions OIDC issuer).
           cosign sign-blob --yes \
-            --output-signature checksums.txt.sig \
-            --output-certificate checksums.txt.pem \
+            --bundle checksums.txt.sigstore.json \
             "checksums.txt"
           echo "Signed release artifacts:"
           cat checksums.txt
@@ -290,8 +290,7 @@ jobs:
             sbom.spdx.json
             sbom.cdx.json
             checksums.txt
-            checksums.txt.sig
-            checksums.txt.pem
+            checksums.txt.sigstore.json
           retention-days: 7
           if-no-files-found: error
 
@@ -414,8 +413,7 @@ jobs:
 
           ```sh
           cosign verify-blob \
-            --certificate checksums.txt.pem \
-            --signature checksums.txt.sig \
+            --bundle checksums.txt.sigstore.json \
             --certificate-identity-regexp '^https://github.com/claymore666/docker-net-dhcp/.github/workflows/release.yml@' \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             checksums.txt
@@ -443,7 +441,7 @@ jobs:
           else
             PRE="--prerelease=false"
           fi
-          FILES="net-dhcp-plugin-${TAG}-linux-amd64.tar.gz sbom.spdx.json sbom.cdx.json checksums.txt checksums.txt.sig checksums.txt.pem"
+          FILES="net-dhcp-plugin-${TAG}-linux-amd64.tar.gz sbom.spdx.json sbom.cdx.json checksums.txt checksums.txt.sigstore.json"
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             # Re-dispatch of an existing tag: refresh assets + metadata.
             # shellcheck disable=SC2086

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -569,7 +569,7 @@ endpoint operation everything is back to disk-served.
 Override the location via the `STATE_DIR` env var on the plugin:
 
 ```bash
-docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.1.1 STATE_DIR=/some/other/path
+docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.2.0 STATE_DIR=/some/other/path
 ```
 
 ## Plugin env vars

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -247,10 +247,10 @@ the `vX.Y.Z` milestone (the workflow leans on this for the
    ```sh
    gh release view vX.Y.Z   # body = the RELEASE_NOTES section; assets:
                             #   net-dhcp-plugin-vX.Y.Z-linux-amd64.tar.gz
-                            #   checksums.txt{,.sig,.pem}
+                            #   checksums.txt + checksums.txt.sigstore.json
    # Re-verify the signature the way a downstream consumer would:
    cosign verify-blob \
-     --certificate checksums.txt.pem --signature checksums.txt.sig \
+     --bundle checksums.txt.sigstore.json \
      --certificate-identity-regexp '^https://github.com/claymore666/docker-net-dhcp/.github/workflows/release.yml@' \
      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
      checksums.txt

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -4,12 +4,16 @@
 # branch (runbook step 2) instead of hand-editing each snippet.
 #
 # Only occurrences of the plugin image reference
-#   ghcr.io/claymore666/docker-net-dhcp:vX.Y.Z
+#   ghcr.io/<namespace>/docker-net-dhcp:vX.Y.Z
 # are rewritten, so install/usage snippets (plugin install, network
 # create, driver:, plugin inspect) all move to the new version while
 # bare "vX.Y.Z" feature markers and historical prose ("as of v1.2.0",
 # "v1.1.0 onward") are left untouched — the image ref is the thing that
-# distinguishes a pin from prose.
+# distinguishes a pin from prose. The namespace is matched generically
+# (not just claymore666) so placeholder examples like
+# "ghcr.io/<your-namespace>/docker-net-dhcp:vX.Y.Z" bump too — that
+# placeholder surviving a release at the old tag was the drift this
+# generalisation closes.
 #
 # Idempotent and old-version-agnostic: it rewrites whatever version each
 # pin currently carries, so a partially-bumped tree self-heals.
@@ -26,10 +30,11 @@ case "$VER" in
         ;;
 esac
 
-IMAGE="ghcr.io/claymore666/docker-net-dhcp"
-# Escape dots for the regex (the image ref has none beyond the host, but
-# keep it correct if the constant ever changes).
-IMAGE_RE="${IMAGE//./\\.}"
+# Match the plugin image at any namespace: ghcr.io/<ns>/docker-net-dhcp.
+# The namespace is one path segment (the real claymore666 or a doc
+# placeholder like <your-namespace>); the distinctive suffix is the
+# image name, which is what separates a pin from prose.
+IMAGE_RE='ghcr\.io/[^/[:space:]]+/docker-net-dhcp'
 
 files=()
 for f in README.md docs/*.md; do


### PR DESCRIPTION
Closes #264.

The `v1.2.0-rc1` dry-run failed in **Package and sign release artifact**:

```
Error: signing checksums.txt: create bundle file: open : no such file or directory
```

The `cosign-installer` bump moved the installed cosign binary to **v3.0.6**, which removed `sign-blob`’s `--output-signature` / `--output-certificate` pair in favour of a single Sigstore **bundle**. `release.yml` only runs on tags, so this was first exercised by the rc dry-run.

## Changes
- **sign**: `cosign sign-blob --bundle checksums.txt.sigstore.json checksums.txt`
- **upload + GitHub Release**: carry `checksums.txt.sigstore.json` instead of `.sig`/`.pem`
- **verify snippets** (release notes + runbook): `cosign verify-blob --bundle checksums.txt.sigstore.json ... checksums.txt`

## rc-window doc items folded in
- bump the stale `ghcr.io/<your-namespace>/docker-net-dhcp:v1.1.1` placeholder in `parent-attached-modes.md` to `v1.2.0`
- generalise `bump-version.sh` to match the image at **any** namespace (one path segment), so placeholder examples bump too — that placeholder surviving at the old tag was this gap

## Validation
- `actionlint .github/workflows/release.yml` → clean
- regex bumps canonical + `<your-namespace>` placeholder + arbitrary namespace; leaves prose (`as of v1.1.0 onward`) untouched
- `bump-version.sh` idempotent on the now-all-`v1.2.0` tree; pin gate + gate self-test green
- The signing path itself re-runs end-to-end in the **v1.2.0-rc2** dry-run (this PR fixes a tag-only workflow, so the merge CI does not exercise it).