### PR TITLE
Release v1.2.0 — cosign v3 signing fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,13 +250,13 @@ jobs:
           # Manifest covers the tarball AND the SBOMs, so the single
           # keyless signature below attests all release assets at once.
           sha256sum "$ART" sbom.spdx.json sbom.cdx.json > checksums.txt
-          # Keyless (Fulcio/OIDC) signature over the checksum manifest.
-          # Emits a detached signature and the short-lived signing
-          # certificate; both are public and verified against the Actions
-          # OIDC issuer.
+          # Keyless (Fulcio/OIDC) signature over the checksum manifest,
+          # emitted as a Sigstore bundle (cosign v3 default; the v2
+          # --output-signature/--output-certificate pair was removed —
+          # the bundle carries signature + short-lived cert in one public
+          # file, verified against the Actions OIDC issuer).
           cosign sign-blob --yes \
-            --output-signature checksums.txt.sig \
-            --output-certificate checksums.txt.pem \
+            --bundle checksums.txt.sigstore.json \
             "checksums.txt"
           echo "Signed release artifacts:"
           cat checksums.txt
@@ -290,8 +290,7 @@ jobs:
             sbom.spdx.json
             sbom.cdx.json
             checksums.txt
-            checksums.txt.sig
-            checksums.txt.pem
+            checksums.txt.sigstore.json
           retention-days: 7
           if-no-files-found: error
 
@@ -414,8 +413,7 @@ jobs:
 
           ```sh
           cosign verify-blob \
-            --certificate checksums.txt.pem \
-            --signature checksums.txt.sig \
+            --bundle checksums.txt.sigstore.json \
             --certificate-identity-regexp '^https://github.com/claymore666/docker-net-dhcp/.github/workflows/release.yml@' \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             checksums.txt
@@ -443,7 +441,7 @@ jobs:
           else
             PRE="--prerelease=false"
           fi
-          FILES="net-dhcp-plugin-${TAG}-linux-amd64.tar.gz sbom.spdx.json sbom.cdx.json checksums.txt checksums.txt.sig checksums.txt.pem"
+          FILES="net-dhcp-plugin-${TAG}-linux-amd64.tar.gz sbom.spdx.json sbom.cdx.json checksums.txt checksums.txt.sigstore.json"
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             # Re-dispatch of an existing tag: refresh assets + metadata.
             # shellcheck disable=SC2086

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -569,7 +569,7 @@ endpoint operation everything is back to disk-served.
 Override the location via the `STATE_DIR` env var on the plugin:
 
 ```bash
-docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.1.1 STATE_DIR=/some/other/path
+docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.2.0 STATE_DIR=/some/other/path
 ```
 
 ## Plugin env vars

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -247,10 +247,10 @@ the `vX.Y.Z` milestone (the workflow leans on this for the
    ```sh
    gh release view vX.Y.Z   # body = the RELEASE_NOTES section; assets:
                             #   net-dhcp-plugin-vX.Y.Z-linux-amd64.tar.gz
-                            #   checksums.txt{,.sig,.pem}
+                            #   checksums.txt + checksums.txt.sigstore.json
    # Re-verify the signature the way a downstream consumer would:
    cosign verify-blob \
-     --certificate checksums.txt.pem --signature checksums.txt.sig \
+     --bundle checksums.txt.sigstore.json \
      --certificate-identity-regexp '^https://github.com/claymore666/docker-net-dhcp/.github/workflows/release.yml@' \
      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
      checksums.txt

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -4,12 +4,16 @@
 # branch (runbook step 2) instead of hand-editing each snippet.
 #
 # Only occurrences of the plugin image reference
-#   ghcr.io/claymore666/docker-net-dhcp:vX.Y.Z
+#   ghcr.io/<namespace>/docker-net-dhcp:vX.Y.Z
 # are rewritten, so install/usage snippets (plugin install, network
 # create, driver:, plugin inspect) all move to the new version while
 # bare "vX.Y.Z" feature markers and historical prose ("as of v1.2.0",
 # "v1.1.0 onward") are left untouched — the image ref is the thing that
-# distinguishes a pin from prose.
+# distinguishes a pin from prose. The namespace is matched generically
+# (not just claymore666) so placeholder examples like
+# "ghcr.io/<your-namespace>/docker-net-dhcp:vX.Y.Z" bump too — that
+# placeholder surviving a release at the old tag was the drift this
+# generalisation closes.
 #
 # Idempotent and old-version-agnostic: it rewrites whatever version each
 # pin currently carries, so a partially-bumped tree self-heals.
@@ -26,10 +30,11 @@ case "$VER" in
         ;;
 esac
 
-IMAGE="ghcr.io/claymore666/docker-net-dhcp"
-# Escape dots for the regex (the image ref has none beyond the host, but
-# keep it correct if the constant ever changes).
-IMAGE_RE="${IMAGE//./\\.}"
+# Match the plugin image at any namespace: ghcr.io/<ns>/docker-net-dhcp.
+# The namespace is one path segment (the real claymore666 or a doc
+# placeholder like <your-namespace>); the distinctive suffix is the
+# image name, which is what separates a pin from prose.
+IMAGE_RE='ghcr\.io/[^/[:space:]]+/docker-net-dhcp'
 
 files=()
 for f in README.md docs/*.md; do


### PR DESCRIPTION
Follow-up release merge for v1.2.0: brings the cosign v3 `sign-blob` bundle fix (#265) onto `main` so the release workflow can sign artifacts.

The initial release merge (#257) shipped to `main` and the `v1.2.0-rc1` dry-run then surfaced a release-workflow regression: cosign v3 removed `sign-blob`’s `--output-signature`/`--output-certificate` flags. #265 migrates signing + verification to the Sigstore `--bundle` form, and folds in two rc-window doc items.

Closes #264.

After this merges, the corrected signing path is exercised by the `v1.2.0-rc2` dry-run before the real `v1.2.0` tag.