### PR TITLE
fix(release): retag :latest onto the signed version digest with crane (#267)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,15 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # crane retags `:latest` onto the version manifest's exact digest
+      # (#267) — `docker buildx imagetools create` re-wraps a plugin
+      # manifest in a new index, changing the digest; crane preserves it.
+      # Go is already set up above, so install pinned from source.
+      - name: Install crane
+        run: |
+          go install github.com/google/go-containerregistry/cmd/crane@v0.21.6
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
@@ -137,21 +146,23 @@ jobs:
       # default PLUGIN_NAME already points at GHCR — passing it
       # explicitly here keeps the workflow self-documenting.
       #
-      # Each registry gets two pushes: the version tag AND `:latest`,
-      # so consumers can pin (`:v0.8.0`) or just track tip (`:latest`).
-      # docker plugin doesn't support tag aliasing the way regular
-      # images do — every tag is a separate push of the same rootfs.
-      # The Make `create` target rebuilds only the plugin handle, not
-      # the underlying rootfs image, so the second push is fast.
-      # `:latest` is guarded: pre-release tags never move it (and would
-      # otherwise also let a dispatch of an OLD tag silently regress
-      # what `:latest` points at — only bare vX.Y.Z tags may move it).
+      # `:latest` is published by RETAGGING the version tag's pushed
+      # manifest, not by a second build (#267). A separate `make push`
+      # re-ran `docker plugin create`, which re-tars the rootfs
+      # non-reproducibly — so the old `:latest` got its own digest,
+      # distinct from `:vX.Y.Z` AND uncovered by the cosign signature
+      # (cosign signs by digest). `imagetools create --tag` points
+      # `:latest` at the exact manifest `:vX.Y.Z` already has, so the two
+      # share one digest and the single signature below covers both.
+      # `:latest` is guarded: pre-release tags never move it (and this
+      # also stops a dispatch of an OLD tag from silently regressing what
+      # `:latest` points at — only bare vX.Y.Z tags may move it).
       - name: Push to GHCR
         run: make PLUGIN_NAME="${GHCR_NAME}" PLUGIN_TAG="${{ steps.tag.outputs.tag }}" push
 
-      - name: Push :latest to GHCR
+      - name: Tag :latest to the published GHCR digest
         if: steps.tag.outputs.prerelease != 'true'
-        run: make PLUGIN_NAME="${GHCR_NAME}" PLUGIN_TAG="latest" push
+        run: crane tag "${GHCR_NAME}:${{ steps.tag.outputs.tag }}" latest
 
       # Same plugin to Docker Hub when credentials are present. Make
       # rebuilds the rootfs with the Hub-prefixed name; the underlying
@@ -160,9 +171,29 @@ jobs:
         if: env.HAS_HUB_CREDS == 'true'
         run: make PLUGIN_NAME="${HUB_NAME}" PLUGIN_TAG="${{ steps.tag.outputs.tag }}" push
 
-      - name: Push :latest to Docker Hub
+      - name: Tag :latest to the published Docker Hub digest
         if: env.HAS_HUB_CREDS == 'true' && steps.tag.outputs.prerelease != 'true'
-        run: make PLUGIN_NAME="${HUB_NAME}" PLUGIN_TAG="latest" push
+        run: crane tag "${HUB_NAME}:${{ steps.tag.outputs.tag }}" latest
+
+      # Guard against #267 ever regressing: a real release must leave
+      # `:latest` resolving to the exact digest the version tag (and the
+      # cosign signature) carries. Hard-fail the release otherwise.
+      - name: Verify :latest resolves to the signed version digest
+        if: steps.tag.outputs.prerelease != 'true'
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          v=$(crane digest "${GHCR_NAME}:${TAG}")
+          l=$(crane digest "${GHCR_NAME}:latest")
+          [ "$v" = "$l" ] || { echo "::error::GHCR :latest ($l) != :${TAG} ($v)"; exit 1; }
+          echo "GHCR  :latest == :${TAG}  ($v)"
+          if [ "${HAS_HUB_CREDS}" = "true" ]; then
+            hv=$(crane digest "${HUB_NAME}:${TAG}")
+            hl=$(crane digest "${HUB_NAME}:latest")
+            [ "$hv" = "$hl" ] || { echo "::error::Hub :latest ($hl) != :${TAG} ($hv)"; exit 1; }
+            echo "Hub   :latest == :${TAG}  ($hv)"
+          fi
 
       # Refresh the Docker Hub long description from the repo's README
       # so the Hub page never drifts from what's on GitHub. Short
@@ -207,9 +238,10 @@ jobs:
       # Sign the published plugin images by digest (#173). docker plugins
       # are OCI artifacts, so cosign signs them like any image once we
       # resolve the registry manifest digest — `docker buildx imagetools
-      # inspect` reads it despite the plugin media type. :latest and the
-      # version tag share one digest, so one signature per registry covers
-      # both. The GHCR digest is exported for the provenance step below.
+      # inspect` reads it despite the plugin media type. Because `:latest`
+      # is retagged to the version manifest above (#267), the two share one
+      # digest, so this one signature per registry covers both. The GHCR
+      # digest is exported for the provenance step below.
       - name: Sign published images (cosign keyless)
         id: signimg
         env:


### PR DESCRIPTION
Closes #267.

`:latest` was published by a **second** `make push`, which re-ran `docker plugin create` and re-tarred the rootfs non-reproducibly — so `:latest` got its **own** digest, distinct from `:vX.Y.Z` and **uncovered by the cosign signature** (cosign signs by digest). Confirmed live during the v1.2.0 release.

## Why not `imagetools create`
The issue first proposed `docker buildx imagetools create`. **Validated live and rejected:** on a docker-plugin manifest it wraps the manifest in a new **index**, again changing the top-level digest (`:v1.2.0`=`sha256:123c155…` plain manifest → imagetools output `sha256:11f30e6…` index). `:latest` would still be unsigned.

## Fix (crane)
`crane tag :vX.Y.Z latest` adds the tag to the **existing** manifest digest without re-wrapping — verified digest-identical against the live v1.2.0 manifest, so `:latest` == the signed version digest and the per-digest signature covers it.
- install crane via `go install` (release job already sets up Go), pinned `@v0.21.6`
- both `:latest` pushes → `crane tag` (still guarded: pre-release tags never move `:latest`)
- **real-release assertion**: hard-fail if `:latest` ⧧ the version digest on either registry

## Validation status
- `actionlint .github/workflows/release.yml` → clean
- retag mechanism proven manually on the live v1.2.0 plugin manifest (crane digest identical)
- **Caveat (per CLAUDE.md, flagged):** the retag is `:latest`-only (guarded off for rc), so the **v1.3.0 rc dry-run will not exercise this wiring**. The mechanism is proven manually; the new assertion guards every real release. First real exercise: the v1.3.0 release.

## Cleanup note
A live test left a harmless `ghcr.io/claymore666/docker-net-dhcp:latest-test-267` tag pointing at the real v1.2.0 digest; it shares v1.2.0's GHCR version so it needs a manual single-tag delete in the package UI.