### PR TITLE
test(integration): tighten coarse poll intervals (#254)

### DIFF
--- a/test/integration/failure_test.go
+++ b/test/integration/failure_test.go
@@ -54,7 +54,11 @@ func failureHealth(t *testing.T, ctx context.Context, cli *docker.Client, budget
 				return h, true
 			}
 		}
-		time.Sleep(time.Second)
+		// Pure poll-until-condition: a tighter interval just returns
+		// closer to the moment the health state flips, without
+		// touching the caller's budget (#254). 250ms floor keeps the
+		// extra CPU off the timing-sensitive preflight probe.
+		time.Sleep(250 * time.Millisecond)
 	}
 	return last, false
 }
@@ -146,7 +150,9 @@ func TestFailure_ServerLossDuringRenewal(t *testing.T) {
 			recovered = true
 			break
 		}
-		time.Sleep(time.Second)
+		// 90s deadline unchanged; tighter poll only shrinks the
+		// overshoot past the re-bind ACK (#254).
+		time.Sleep(250 * time.Millisecond)
 	}
 	if !recovered {
 		t.Fatal("no DHCPACK for the container's MAC within 90s of the server returning")
@@ -247,7 +253,10 @@ func TestFailure_LeaseRefusedOnRenewal(t *testing.T) {
 		if liveIP != "" {
 			break
 		}
-		time.Sleep(2 * time.Second)
+		// Each iteration is a docker exec, so hold a 500ms floor
+		// rather than the 250ms used for cheap log/health polls —
+		// still a quarter of the old 2s overshoot (#254).
+		time.Sleep(500 * time.Millisecond)
 	}
 	if liveIP == "" {
 		t.Fatalf("container never re-acquired from the new subnet's pool %s-%s; ip -4 addr:\n%s",

--- a/test/integration/ipv6_test.go
+++ b/test/integration/ipv6_test.go
@@ -512,7 +512,9 @@ func TestDUID_PersistsAcrossPluginRestart(t *testing.T) {
 		if duidBefore = leaseDUIDForV6(t, fixture.LeaseFile(), v6); duidBefore != "" {
 			break
 		}
-		time.Sleep(time.Second)
+		// Cheap lease-file read; 250ms poll trims overshoot, 30s
+		// deadline unchanged (#254).
+		time.Sleep(250 * time.Millisecond)
 	}
 	if duidBefore == "" {
 		t.Fatalf("no v6 lease entry for %s in the dnsmasq lease DB", v6)
@@ -555,7 +557,9 @@ func TestDUID_PersistsAcrossPluginRestart(t *testing.T) {
 			rebound = true
 			break
 		}
-		time.Sleep(time.Second)
+		// Cheap log read; 250ms poll trims overshoot past the
+		// post-restart REPLY, 90s deadline unchanged (#254).
+		time.Sleep(250 * time.Millisecond)
 	}
 	if !rebound {
 		t.Fatalf("no post-restart DHCPREPLY for %s within 90s — recovered dhcpcd v6 client never re-bound", v6)


### PR DESCRIPTION
Closes #254 *(stays open until the v1.3.0 release PR batch-closes it).*

## What
Five poll-until-condition loops slept at coarse 1–2s intervals, so each overshot the moment its bounded condition was met. Tightened to a 250ms floor (500ms for the docker-exec-driven re-acquisition loop):

| Site | Was | Now | Poll target |
|---|---|---|---|
| `failure_test.go:57` | 1s | 250ms | `/Plugin.Health` state flip |
| `failure_test.go:149` | 1s | 250ms | re-bind DHCPACK after server return |
| `failure_test.go:250` | 2s | 500ms | re-acquire in renumbered subnet (`docker exec`) |
| `ipv6_test.go:515` | 1s | 250ms | v6 lease-DB entry |
| `ipv6_test.go:558` | 1s | 250ms | v6 post-restart DHCPREPLY |

## Why it's safe
- Every loop is `for time.Now().Before(deadline)` — a faster poll just returns sooner; **deadline budgets and assertions are unchanged**.
- 250ms floor honours the issue's caution: keep extra CPU off the timing-sensitive preflight probe. The exec-driven loop holds 500ms to avoid exec churn over its ~135s window.
- Sleeps already at 100–500ms are left as-is; the real protocol-timing waits (the ~30s outage ticks) are untouched.

## Verification
`go vet -tags integration ./test/integration/` clean. Before/after wall-clock comes from this PR's own integration run vs. the pre-change baseline (~4m15s failure-injection step); will post the delta once it lands.