### PR TITLE
test(integration): drive lease renewal via advertised T1, not a short lease (#253)

### DIFF
--- a/test/integration/harness/ephemeral.go
+++ b/test/integration/harness/ephemeral.go
@@ -62,12 +62,39 @@ type EphemeralFixture struct {
 
 	poolStart, poolEnd string
 	serverCIDR         string
+
+	// renewT1 / renewT2 are server-advertised DHCP option 58
+	// (renewal) / 59 (rebind) times in seconds. dnsmasq's minimum
+	// *lease* is a hard 2m, so a renewal test can't ride a short
+	// lease — but the server may advertise T1/T2 explicitly,
+	// independent of lease length, and dhcpcd honours them. Zero
+	// means "don't set the option" (dhcpcd then derives T1/T2 from
+	// the lease as usual). See WithRenewTimes (#253).
+	renewT1, renewT2 int
+}
+
+// EphemeralOption configures an EphemeralFixture before its dnsmasq
+// starts. Options are applied in NewEphemeralFixture.
+type EphemeralOption func(*EphemeralFixture)
+
+// WithRenewTimes makes the fixture's dnsmasq advertise DHCP option 58
+// (T1, renewal) and option 59 (T2, rebind) at the given seconds,
+// regardless of the 2m lease floor. This lets a renewal test drive a
+// real DHCPACK-renewal on a fast clock (T1 small) instead of waiting
+// out half of a 2m lease. t1 must stay above dhcpcd's internal
+// renewal flooring to round-trip; t2 should exceed t1 so the test
+// observes a renewal, not a rebind (#253).
+func WithRenewTimes(t1, t2 int) EphemeralOption {
+	return func(ef *EphemeralFixture) {
+		ef.renewT1 = t1
+		ef.renewT2 = t2
+	}
 }
 
 // NewEphemeralFixture creates the veth pair and starts the
 // authoritative dnsmasq. Teardown is registered via t.Cleanup and is
 // idempotent against a previous panicked run's leftovers.
-func NewEphemeralFixture(t *testing.T) *EphemeralFixture {
+func NewEphemeralFixture(t *testing.T, opts ...EphemeralOption) *EphemeralFixture {
 	t.Helper()
 	if os.Geteuid() != 0 {
 		t.Fatalf("EphemeralFixture needs root (got uid=%d)", os.Geteuid())
@@ -87,6 +114,9 @@ func NewEphemeralFixture(t *testing.T) *EphemeralFixture {
 		poolStart:  EphemeralPoolStart,
 		poolEnd:    EphemeralPoolEnd,
 		serverCIDR: EphemeralServerAddr,
+	}
+	for _, opt := range opts {
+		opt(ef)
 	}
 	t.Cleanup(ef.teardown)
 
@@ -137,15 +167,15 @@ func (ef *EphemeralFixture) start() {
 	defer logF.Close()
 
 	startMark := ef.logSize()
-	ef.cmd = exec.Command("/usr/sbin/dnsmasq",
+	args := []string{
 		"--no-daemon",
 		"--conf-file=/dev/null",
 		"--port=0",
-		"--interface="+ephemeralDhcpVeth,
+		"--interface=" + ephemeralDhcpVeth,
 		"--bind-interfaces",
 		"--except-interface=lo",
-		"--dhcp-range="+ef.poolStart+","+ef.poolEnd+","+LeaseTime,
-		"--dhcp-leasefile="+ef.leaseFile,
+		"--dhcp-range=" + ef.poolStart + "," + ef.poolEnd + "," + LeaseTime,
+		"--dhcp-leasefile=" + ef.leaseFile,
 		"--dhcp-no-override",
 		// Authoritative: NAK requests for leases this instance
 		// doesn't recognise, like a real production server that owns
@@ -155,7 +185,18 @@ func (ef *EphemeralFixture) start() {
 		"--dhcp-broadcast",
 		"--log-dhcp",
 		"--log-facility=-",
-	)
+	}
+	// Explicit renewal/rebind times (options 58/59), independent of the
+	// 2m lease floor: lets a renewal test drive a fast DHCPACK-renewal
+	// instead of waiting out half the lease (#253). dnsmasq encodes
+	// these known options as 32-bit seconds.
+	if ef.renewT1 > 0 {
+		args = append(args, fmt.Sprintf("--dhcp-option=58,%d", ef.renewT1))
+	}
+	if ef.renewT2 > 0 {
+		args = append(args, fmt.Sprintf("--dhcp-option=59,%d", ef.renewT2))
+	}
+	ef.cmd = exec.Command("/usr/sbin/dnsmasq", args...)
 	ef.cmd.Stdout = logF
 	ef.cmd.Stderr = logF
 	ef.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/test/integration/ipv6_test.go
+++ b/test/integration/ipv6_test.go
@@ -75,8 +75,9 @@ func linkGlobalV6(t *testing.T, ctx context.Context, ctrID string, budget time.D
 }
 
 // countDHCPv6Replies counts DHCPREPLY lines mentioning addr in the
-// given dnsmasq log — the v6 sibling of countDHCPACKs. dnsmasq logs
-// one DHCPREPLY per blessed REQUEST/RENEW, so bind=1, renewal=2.
+// given dnsmasq log — the v6 sibling of the DHCPACK counting in the
+// lease-renew test. dnsmasq logs one DHCPREPLY per blessed
+// REQUEST/RENEW, so bind=1, renewal=2.
 func countDHCPv6Replies(t *testing.T, logPath, addr string) int {
 	t.Helper()
 	data, err := os.ReadFile(logPath)

--- a/test/integration/lease_renew_test.go
+++ b/test/integration/lease_renew_test.go
@@ -4,8 +4,6 @@ package integration
 
 import (
 	"context"
-	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -18,45 +16,64 @@ import (
 // it expires, and that the renewal goes through (DHCPACK from
 // dnsmasq) without disturbing the container's IP.
 //
-// The fixture's lease time is 2m (dnsmasq's hard minimum, see
-// LeaseTime in harness/fixture.go), so T1 (renewal trigger inside
-// dhcpcd) fires at 1m. We wait ~70s — past T1, well before T2
-// (1m45s) — and assert:
+// dnsmasq's minimum *lease* is a hard 2m, so we can't shorten the
+// lease to make renewal fire sooner. Instead this test runs on a
+// dedicated ephemeral fixture that advertises DHCP option 58 (T1,
+// renewal) / 59 (T2, rebind) explicitly — independent of the lease
+// length — via WithRenewTimes. dhcpcd honours the server-supplied
+// T1, so renewal fires at renewT1 (~12s) instead of half of a 2m
+// lease (~60s). We wait past T1, well before T2, and assert:
 //   - the container's IP from docker inspect hasn't changed
-//   - dnsmasq's log shows at least 2 DHCPACK lines for our MAC
-//     (one for the initial bind, one for the renewal)
+//   - the fixture's dnsmasq log shows at least 2 DHCPACK lines for
+//     our MAC (one for the initial bind, one for the renewal)
+//
+// The shared suite fixture's 2m lease is left untouched — every other
+// test depends on its stability (#253).
+//
+// The mechanism is self-validating: if dnsmasq doesn't honour the
+// advertised T1 (or dhcpcd floors it), no renewal ACK lands in the
+// shortened window and the assertions below fail — it never silently
+// passes.
 //
 // Without this test, a regression in dhcpManager.renew or the
 // long-lived dhcpcd client would be silent: the container starts
 // fine, then loses its IP somewhere between T2 and the next operator
 // noticing the connection dropped.
 func TestLeaseRenew_HonorsT1(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Second)
+	const (
+		renewT1 = 12 // seconds; dhcpcd renews here, above its floor
+		renewT2 = 25 // seconds; rebind — kept past the wait window
+		// Wait past T1 but comfortably before T2, so the only ACK we
+		// expect on top of the bind is a renewal ACK, not a rebind.
+		waitFor = 18 * time.Second
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
 	netName := "dh-itest-renew"
 	ctrName := "dh-itest-renew-ctr"
 
+	ef := harness.NewEphemeralFixture(t, harness.WithRenewTimes(renewT1, renewT2))
 	t.Cleanup(func() {
 		if t.Failed() {
-			fixture.DumpLogs(func(s string) { t.Log(s) })
+			ef.DumpLogs(func(s string) { t.Log(s) })
 		}
 	})
 
-	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{
+		"parent": harness.EphemeralHostVeth,
+	})
 	id, ipBefore, mac := harness.RunContainer(t, ctx, netName, ctrName)
 	t.Logf("initial: ip=%s mac=%s", ipBefore, mac)
 
-	startACKs := countDHCPACKs(t, mac)
+	startACKs := ef.CountLogLines("DHCPACK", mac)
 
-	// Sleep past T1 (60s for a 2m lease) but well before T2 (105s)
-	// to keep the assertion clean: the only ACK we expect on top of
-	// the bind is a renewal ACK, not a rebind.
-	t.Log("waiting 70s for lease renewal cycle...")
+	t.Logf("waiting %s for lease renewal cycle (T1=%ds, T2=%ds)...", waitFor, renewT1, renewT2)
 	select {
 	case <-ctx.Done():
 		t.Fatalf("context cancelled before renewal window: %v", ctx.Err())
-	case <-time.After(70 * time.Second):
+	case <-time.After(waitFor):
 	}
 
 	// Re-poll inspect: the IP must not have changed during the
@@ -79,38 +96,16 @@ func TestLeaseRenew_HonorsT1(t *testing.T) {
 		t.Errorf("IP changed during renewal window: before=%s after=%s (renewal client did not preserve lease)", ipBefore, ipAfter)
 	}
 
-	endACKs := countDHCPACKs(t, mac)
+	endACKs := ef.CountLogLines("DHCPACK", mac)
 	t.Logf("DHCPACKs for %s: start=%d, after=%d", mac, startACKs, endACKs)
 
 	// The initial bind is one ACK; a renewal is one more. We've
 	// waited past T1, so we expect at least one renewal ACK on top
 	// of the bind. Strictly: endACKs - startACKs >= 1, and total >= 2.
 	if endACKs-startACKs < 1 {
-		t.Errorf("no renewal DHCPACK observed for %s in the 22s wait window — renewal client appears stuck or dnsmasq is not handling the renewal request", mac)
+		t.Errorf("no renewal DHCPACK observed for %s in the %s wait window — renewal client appears stuck or dnsmasq is not handling the renewal request", mac, waitFor)
 	}
 	if endACKs < 2 {
 		t.Errorf("expected at least 2 DHCPACKs for %s (bind + renewal), got %d", mac, endACKs)
 	}
-}
-
-// countDHCPACKs reads the macvlan-fixture dnsmasq log and counts
-// "DHCPACK" lines that mention `mac`. dnsmasq emits one ACK line per
-// successful bind/renewal/rebind, so the count is a clean monotonic
-// proxy for "how many times has dnsmasq blessed a request from this
-// MAC". MAC matching is case-insensitive and substring-based — the
-// log format prints lowercase MAC late in the line.
-func countDHCPACKs(t *testing.T, mac string) int {
-	t.Helper()
-	data, err := os.ReadFile(fixture.DnsmasqLog())
-	if err != nil {
-		t.Fatalf("read dnsmasq log: %v", err)
-	}
-	macLower := strings.ToLower(mac)
-	count := 0
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.Contains(line, "DHCPACK") && strings.Contains(strings.ToLower(line), macLower) {
-			count++
-		}
-	}
-	return count
 }


### PR DESCRIPTION
Closes #253 *(stays open until the v1.3.0 release PR batch-closes it).*

## The pivot
The issue proposed giving the renewal test a dedicated fixture with a **short lease** (low tens of seconds). That can't work: **dnsmasq's minimum lease is a hard 2 minutes** — anything shorter is silently rounded up (it's why the shared fixture's `LeaseTime` is `2m`, and `harness/fixture.go:41` documents an earlier "30s" constant that "lied about the actual lease"). Shortening the lease can't move T1.

**The real lever** is server-advertised renewal time: T1 (renewal) / T2 (rebind) default to 0.5 / 0.875 of the lease, but a server *may* override them via DHCP **option 58 / 59**, independent of lease length — and dhcpcd honours the server-supplied T1. (Full design note on the issue.)

## What
- **harness:** `WithRenewTimes(t1, t2)` — a backward-compatible variadic option on `NewEphemeralFixture` (existing `(t)` callers untouched). When set, the fixture's dnsmasq advertises `--dhcp-option=58,<t1>` / `59,<t2>`.
- **lease_renew:** runs on a dedicated ephemeral fixture with **T1=12s / T2=25s** (`parent=EphemeralHostVeth` — the pattern the failure suite already uses), reading ACKs via `ef.CountLogLines`. Wait drops **70s → 18s**; ctx timeout 150s → 90s. The shared fixture's 2m lease is left untouched (other tests depend on it).

## Safety
- Assertion semantics identical: still a real DHCPACK-driven unicast renewal (≥1 renewal ACK on top of the bind, IP unchanged).
- **Self-validating:** if dnsmasq doesn't honour the advertised T1 (or dhcpcd floors it), no renewal ACK lands in the 18s window and the test *fails* — it never silently passes. The 12s T1 keeps margin above dhcpcd's internal renewal floor.

## Verification
`go vet -tags integration` clean. The ~50s wall-clock win and the T1-honoured behaviour are both confirmed by this PR's own integration run (the test is the proof).