### PR TITLE
ci(integration): cache the plugin build's Go module + build caches (#255)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
+# syntax=docker/dockerfile:1
+# The syntax directive enables BuildKit's RUN --mount=type=cache below.
+# Docker >= 23 (the runner is 26.1.5) defaults to BuildKit; the Makefile
+# also exports DOCKER_BUILDKIT=1 so the classic builder can never be
+# picked up and choke on the mount flags.
+
 FROM golang:1.26-alpine@sha256:7a3e50096189ad57c9f9f865e7e4aa8585ed1585248513dc5cda498e2f41812c AS builder
 
 # COVER_FLAGS is empty for the production build and `-cover -coverpkg=./...`
@@ -9,11 +15,22 @@ ARG COVER_FLAGS=
 
 WORKDIR /usr/local/src/docker-net-dhcp
 COPY go.* ./
-RUN go mod download
+# Persist the module cache across builds: unchanged go.* means no
+# re-download, and the modules survive even when the build layer is
+# invalidated by a code change (#255).
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY cmd/ ./cmd/
 COPY pkg/ ./pkg/
-RUN mkdir bin/ && go build $COVER_FLAGS -o bin/ ./cmd/...
+# The COPY above invalidates this layer on every code change, so go build
+# re-runs each PR — but the mounted build cache makes it INCREMENTAL:
+# only the packages that actually changed recompile, the rest are reused.
+# Go's build cache is keyed on source + flags, so the production and
+# -cover builds never reuse each other's objects (no stale-digest hazard).
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    mkdir bin/ && go build $COVER_FLAGS -o bin/ ./cmd/...
 
 
 FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ debug: $(BINARY)
 	sudo $< -log debug
 
 build: $(SOURCES)
-	docker build -t $(PLUGIN_NAME):rootfs .
+	DOCKER_BUILDKIT=1 docker build -t $(PLUGIN_NAME):rootfs .
 
 plugin/rootfs: build
 	mkdir -p plugin/rootfs
@@ -58,7 +58,7 @@ push: create
 # installs continue to use `make create enable` / the unparameterized
 # image. The two tags coexist on the same host without conflicting.
 build-cover: $(SOURCES)
-	docker build --build-arg COVER_FLAGS="-cover -coverpkg=./..." -t $(PLUGIN_NAME):rootfs-cover .
+	DOCKER_BUILDKIT=1 docker build --build-arg COVER_FLAGS="-cover -coverpkg=./..." -t $(PLUGIN_NAME):rootfs-cover .
 
 plugin-cover/rootfs: build-cover
 	mkdir -p plugin-cover/rootfs


### PR DESCRIPTION
Closes #255 *(stays open until the v1.3.0 release PR batch-closes it).*

## What
The plugin image is rebuilt every integration run (~43s build+install step). The `COPY cmd/ pkg/` invalidates the build layer on **any** code change, so `go build ./cmd/...` recompiled every package each PR with no incremental cache, and `go mod download` re-fetched modules.

Add BuildKit cache mounts to the builder stage:
- `/go/pkg/mod` on `go mod download` **and** `go build` — modules persist across builds and survive build-layer invalidation.
- `/root/.cache/go-build` on `go build` — the compile becomes **incremental**: only packages that actually changed recompile.

Mounts are runner-local (no registry cache to wire; cooperates with the forced-egress proxy — fewer module fetches through it). `Makefile` exports `DOCKER_BUILDKIT=1` on `build`/`build-cover` so the classic builder can't be picked up and choke on the mount flags (Docker ≥23 defaults to BuildKit anyway — belt-and-braces).

## Correctness (the stale-digest hazard #255 calls out)
Unchanged: the `COPY` still invalidates the build layer on a code change, so `go build` **always** re-runs — it just reuses cached objects. Go keys its build cache on source + flags, so the production and `-cover` builds never reuse each other's objects.

## Measured (local, this host)
Rebuild after a one-file code change:

| | rebuild |
|---|---|
| current dev (no cache) | **5s** (full recompile) |
| #255 (cache mounts) | **1s** (incremental) |

CI absolute saving will be larger (slower cores, behind the proxy). A cache **populates on first run**, so the CI win appears from the 2nd run onward; this PR's integration run validates the cache-mount build produces a correct, working plugin (the whole suite runs against it).