### PR TITLE
ci(integration): surface a per-test timing summary

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -90,15 +90,28 @@ jobs:
           docker plugin set "${INTEGRATION_PLUGIN_REF}" LOG_LEVEL=trace
           docker plugin enable "${INTEGRATION_PLUGIN_REF}"
 
+      # tee the verbose output so the timing-summary step below can
+      # report where the wall-clock went. The default Actions bash runs
+      # with `-o pipefail`, so a test failure still fails the step
+      # despite the pipe into tee.
       - name: Run integration tests
-        run: make integration-test
+        run: make integration-test 2>&1 | tee /tmp/itest-main.log
 
       # Failure-injection suite (#128): server loss, NAK on renewal,
       # lease expiry — each against a per-test ephemeral DHCP server.
       # Separate step so a red here is immediately distinguishable
       # from a main-suite regression.
       - name: Run failure-injection tests
-        run: make integration-test-failure
+        run: make integration-test-failure 2>&1 | tee /tmp/itest-failure.log
+
+      # Surface the slowest tests + total in the job log and step
+      # summary, so speedup work can target the biggest waits without
+      # digging through verbose output. Informational, always-run: it
+      # owns no pass/fail and tolerates a missing log (e.g. the failure
+      # step was skipped because the main suite already failed).
+      - name: Test timing summary
+        if: always()
+        run: scripts/integration-timing.sh /tmp/itest-main.log /tmp/itest-failure.log
 
       # Tear down so a follow-up workflow on the same runner doesn't
       # find a stale `:integration` plugin pinned to the previous

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,6 +74,7 @@ jobs:
           bash scripts/test-check-option-docs.sh
           bash scripts/test-check-apk-pins.sh
           bash scripts/test-check-version-pins.sh
+          bash scripts/test-integration-timing.sh
 
       # Every driver-option key the code parses must be documented in
       # docs/reference.md — an undocumented option turns CI red (#132).

--- a/scripts/integration-timing.sh
+++ b/scripts/integration-timing.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# integration-timing.sh — summarize per-test wall-clock from one or more
+# `go test -v` logs. Prints the slowest tests + total to stdout and, when
+# running under Actions, to the job's step summary.
+#
+# Informational only: it never fails the build (the test steps own
+# pass/fail), so it is safe to wire with `if: always()`.
+#
+# Why this exists: the integration suite is ~20 min of mostly deliberate
+# DHCP-protocol waits. This surfaces where the time actually goes — so
+# speedup work (e.g. #253's renewal cut) can target the biggest waits
+# without grepping verbose logs by hand. See test/integration/README.md.
+#
+# Usage: integration-timing.sh LOG [LOG...]
+#   TOPN=N  cap the table to the N slowest tests (default 25).
+set -u
+export LC_ALL=C   # stable numeric parse/sort on the locale-set runner
+
+TOPN="${TOPN:-25}"
+
+# Top-level results only: subtests are indented (leading whitespace) and
+# carry a '/' in the name, so anchoring at column 0 with a name class
+# that excludes '/' drops them and avoids double-counting under parents.
+rows="$(
+  for f in "$@"; do
+    [ -f "$f" ] || continue
+    grep -aoE '^--- (PASS|FAIL|SKIP): [A-Za-z0-9_]+ \([0-9]+\.[0-9]+s\)' "$f" || true
+  done \
+    | sed -E 's/^--- (PASS|FAIL|SKIP): ([A-Za-z0-9_]+) \(([0-9.]+)s\)/\3 \1 \2/' \
+    | sort -rn -k1,1
+)"
+
+if [ -z "$rows" ]; then
+  echo "integration-timing: no test result lines found in: $*"
+  exit 0
+fi
+
+total="$(printf '%s\n' "$rows" | awk '{s+=$1} END{printf "%.0f", s}')"
+count="$(printf '%s\n' "$rows" | grep -c '')"
+
+emit() {
+  printf 'Integration test timing — %s tests, sum %ss (~%s min)\n\n' \
+    "$count" "$total" "$((total / 60))"
+  printf '| # | secs | result | test |\n'
+  printf '|--:|-----:|:------:|:-----|\n'
+  printf '%s\n' "$rows" | head -n "$TOPN" \
+    | awk '{printf "| %d | %s | %s | %s |\n", NR, $1, $2, $3}'
+}
+
+emit
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  { printf '## ⏱ integration test timing\n\n'; emit; } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/scripts/test-integration-timing.sh
+++ b/scripts/test-integration-timing.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Table-driven tests for integration-timing.sh: feeds synthetic
+# `go test -v` output and asserts the summary picks top-level tests,
+# ignores subtests, sorts by duration desc, totals correctly, and
+# tolerates missing log files (it runs `if: always()`, after failures).
+set -u
+
+TOOL="$(dirname "$0")/integration-timing.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fail=0
+
+log="$TMP/a.log"
+cat > "$log" <<'EOF'
+=== RUN   TestAlpha
+--- PASS: TestAlpha (10.00s)
+=== RUN   TestBeta
+    --- PASS: TestBeta/sub_one (0.50s)
+--- PASS: TestBeta (3.00s)
+=== RUN   TestGamma
+--- FAIL: TestGamma (7.25s)
+PASS
+ok      example/pkg     20.300s
+EOF
+
+# Force the step-summary path off so the test never writes outside TMP.
+out="$(GITHUB_STEP_SUMMARY="" "$TOOL" "$log")"
+
+want() { # description, pattern
+  if printf '%s\n' "$out" | grep -qE "$2"; then
+    :
+  else
+    echo "FAIL: $1"; fail=1
+  fi
+}
+wantnot() { # description, pattern
+  if printf '%s\n' "$out" | grep -qE "$2"; then
+    echo "FAIL: $1"; fail=1
+  fi
+}
+
+# total = 10.00 + 3.00 + 7.25 = 20.25 -> %.0f -> 20
+want "total sums top-level only"            'sum 20s'
+want "count is 3 top-level tests"           '3 tests'
+want "slowest row is TestAlpha at 10s"      '\| 1 \| 10\.00 \| PASS \| TestAlpha \|'
+want "FAIL row is present"                  'FAIL \| TestGamma'
+wantnot "subtests are excluded"             'sub_one'
+
+# Missing files must not error (always() after a failed test step).
+if "$TOOL" "$TMP/does-not-exist.log" >/dev/null 2>&1; then :; else
+  echo "FAIL: missing log file errored"; fail=1
+fi
+
+# Step-summary file is appended to when GITHUB_STEP_SUMMARY is set.
+sumfile="$TMP/summary.md"
+GITHUB_STEP_SUMMARY="$sumfile" "$TOOL" "$log" >/dev/null
+if grep -q 'integration test timing' "$sumfile" 2>/dev/null; then :; else
+  echo "FAIL: step summary not written"; fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "PASS: integration-timing.sh"
+else
+  echo "SOME TESTS FAILED"
+fi
+exit "$fail"


### PR DESCRIPTION
Closes #276 *(stays open until the v1.3.0 release PR batch-closes it).*

## What
Every integration run now self-documents where its ~20 min goes — no more grepping verbose logs.

- **`scripts/integration-timing.sh`** — parses one or more `go test -v` logs, prints the slowest tests (top-level only; subtests excluded) + total to stdout and the Actions step summary. Informational: never fails the build; locale-pinned for a stable numeric sort on the runner.
- **`scripts/test-integration-timing.sh`** — table-driven self-test (sort, totals, subtest exclusion, missing-file tolerance, step-summary write), wired into the `test` job's gate self-tests alongside the other CI scripts.
- **`integration.yml`** — tee both test steps to logs and add an always-run "Test timing summary" step. The default Actions bash runs `-o pipefail`, so a test failure stays fatal despite the pipe into `tee`.

## Sample output
```
Integration test timing — 48 tests, sum 1131s (~18 min)
| # | secs | result | test |
|--:|-----:|:------:|:-----|
| 1 | 126.00 | PASS | TestFailure_LeaseRefusedOnRenewal |
| 2 | 96.00  | PASS | TestLeaseRenewIPv6_HonorsT1 |
...
```

## Why
This is the tooling that made #253's renewal target obvious. It already pointed at the next candidates: the failure suite (the dominant chunk) and the v6 renewal test — the latter investigated and filed as #275 (blocked by dnsmasq's v6 timer model).

## Verification
`scripts/test-integration-timing.sh` passes locally; `bash -n` + YAML parse clean. The step itself is exercised by this PR's own integration run (it'll print the table at the end).