### PR TITLE
feat(routes): honor DHCP classless static routes (option 121) (#260)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -146,13 +146,26 @@ Passed as `-o key=value` on `docker network create`, or under
 | `ipv6` | all | `false` | upstream; functional again in v1.0.0 | Also run stateful DHCPv6 (a second `dhcpcd` with `-6`) alongside DHCPv4 — see the [DHCPv6 section](parent-attached-modes.md#dhcpv6-ipv6true) for semantics and DUID/IAID identity. The Docker-visible v6 address is renewed as of v1.2.0 (#152). |
 | `lease_timeout` | all | `10s` | upstream | Budget for the up-front DHCP exchange at container creation. Raise on slow/relayed networks (`-o lease_timeout=60s`). |
 | `ignore_conflicts` | bridge | `false` | upstream | Skip the bridge-already-in-use check against other Docker networks. No-op in macvlan/ipvlan. |
-| `skip_routes` | all | `false` | upstream; all modes since v0.9.0 | Don't copy non-default static routes from the parent (bridge or NIC) into containers. v0.9.0 extended route-copying from bridge-only to all modes (#102); set `true` to restore the old macvlan/ipvlan no-copy behaviour. |
+| `skip_routes` | all | `false` | upstream; all modes since v0.9.0 | Don't copy non-default static routes from the parent (bridge or NIC) into containers, **and** don't apply DHCP-supplied classless static routes (option 121, see below). v0.9.0 extended parent route-copying from bridge-only to all modes (#102); set `true` to restore the old macvlan/ipvlan no-copy behaviour. The default gateway is unaffected either way. |
 | `propagate_dns` | all | `false` | v0.9.0 | Write the DHCP-supplied DNS server list (option 6 / v6 option 23) into the container's `/etc/resolv.conf` on every bind/renew. Overrides Docker's embedded resolver for this network; the `search` line uses option 119 with fallback to option 15. |
 | `propagate_mtu` | all | `false` | v0.9.0 | Apply DHCP option 26 (Interface MTU) to the container link on bind/renew. For jumbo-frame (9000) and VPN-reduced (~1450) networks. |
 | `client_id` | all | per-endpoint id | v0.9.0 | Override DHCP option 61 (Client Identifier) for every endpoint on this network; sent as RFC 2132 opaque bytes (type `0x00`). The default per-endpoint id is what makes per-container reservations work — a fixed `client_id` makes all containers look like one client to the server. Pair with `vendor_class` for class-based policy. |
 | `vendor_class` | all | `docker-net-dhcp` | v0.9.0 | Override DHCP option 60 (Vendor Class Identifier), for DHCP servers running class-based policy (different gateway/option sets per class). v4 only — the DHCPv6 client sends no vendor-class option. |
 | `validate_dhcp` | macvlan, ipvlan | `false` | v0.9.0 | Pre-flight probe at `docker network create`: one-shot DHCP exchange on the parent with a random locally-administered MAC, rejecting the network if no server answers within 5s. Catches isolated parents / blocked UDP 67-68 / broken VLAN tags at create time. Costs one transient lease per probe. Bridge mode rejects the option. |
 | `audit_log` | all | `false` | v1.0.0 | Append every lease-lifecycle event (`bound` / `renew` / `release` / `release_failed`) to `STATE_DIR/leases.jsonl` — one JSON object per line with timestamp, network, endpoint, container, hostname, IP, MAC. Rotated at 16 MB or 30 days (one rotated generation kept, ≤ ~32 MB total). Append failures bump `ledger_write_failures` on `/Plugin.Health`, never affecting lease handling. Off by default: per-event disk write, and container↔IP correlation on disk is privacy-relevant in some environments. |
+
+### DHCP classless static routes (option 121)
+
+When the DHCP server hands out classless static routes (option 121,
+RFC 3442 — and the identically-formatted Microsoft option 249), the
+plugin applies them inside the container alongside the routes copied
+from the parent. Routes are captured from the initial v4 lease and
+programmed at `Join`. A `0.0.0.0/0` entry in option 121 is treated as
+the default route and **supersedes the option-3 router** per RFC 3442
+(an explicit `gateway=` override still wins over both). `skip_routes=true`
+opts out of option-121 routes as well as parent-copied ones. v4 only —
+IPv6 routes come from Router Advertisements. (Legacy option 33 is not
+honored; modern servers send option 121.)
 
 ## Driver options (per-endpoint)
 

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -604,6 +604,10 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 					if opts.Gateway != "" {
 						hint.Gateway = opts.Gateway
 					}
+					// DHCP option-121 classless static routes (RFC 3442);
+					// the parser already folded any default route into
+					// info.Gateway, so these are non-default routes only.
+					hint.Routes = dhcpStaticRoutes(info.Routes)
 				}
 			})
 
@@ -746,6 +750,24 @@ func (p *Plugin) DeleteEndpoint(ctx context.Context, r DeleteEndpointRequest) er
 	}).Info("Endpoint deleted")
 
 	return nil
+}
+
+// dhcpStaticRoutes converts DHCP option-121 classless static routes
+// (udhcpc.Route, captured at CreateEndpoint) into libnetwork
+// StaticRoute responses. An empty Gateway means the route is on-link
+// (dhcpcd reported the gateway as 0.0.0.0); otherwise it is a next-hop
+// route. Destinations are already canonical CIDRs from the parser.
+func dhcpStaticRoutes(routes []udhcpc.Route) []*StaticRoute {
+	out := make([]*StaticRoute, 0, len(routes))
+	for _, r := range routes {
+		sr := &StaticRoute{Destination: r.Destination, RouteType: RouteTypeOnLink}
+		if r.Gateway != "" {
+			sr.RouteType = RouteTypeNextHop
+			sr.NextHop = r.Gateway
+		}
+		out = append(out, sr)
+	}
+	return out
 }
 
 // addRoutes copies non-default, non-kernel-protocol, non-DHCP-subnet
@@ -983,6 +1005,22 @@ func (p *Plugin) Join(ctx context.Context, r JoinRequest) (JoinResponse, error) 
 		if err := p.addRoutes(&opts, true, routeSrc, r, hint, &res); err != nil {
 			return res, err
 		}
+	}
+
+	// Append DHCP option-121 classless static routes (RFC 3442) captured
+	// from the initial v4 exchange in CreateEndpoint. These ride the hint
+	// alongside the gateway; `skip_routes=true` opts out, matching the
+	// host-link copy in addRoutes (the opt-121 default route, folded into
+	// res.Gateway, is unaffected — skip_routes governs static routes, not
+	// the default gateway).
+	if !opts.SkipRoutes && len(hint.Routes) > 0 {
+		res.StaticRoutes = append(res.StaticRoutes, hint.Routes...)
+		log.WithFields(log.Fields{
+			"network":  shortID(r.NetworkID),
+			"endpoint": shortID(r.EndpointID),
+			"sandbox":  r.SandboxKey,
+			"count":    len(hint.Routes),
+		}).Info("[Join] Adding DHCP classless static routes (option 121)")
 	}
 
 	// Register the manager BEFORE spawning the start goroutine so that a

--- a/pkg/plugin/network_test.go
+++ b/pkg/plugin/network_test.go
@@ -2,10 +2,32 @@ package plugin
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 
+	"github.com/devplayer0/docker-net-dhcp/pkg/udhcpc"
 	"github.com/devplayer0/docker-net-dhcp/pkg/util"
 )
+
+func TestDHCPStaticRoutes(t *testing.T) {
+	got := dhcpStaticRoutes([]udhcpc.Route{
+		{Destination: "10.0.0.0/8", Gateway: "192.168.99.2"}, // next-hop
+		{Destination: "172.16.0.0/12"},                       // on-link (empty gateway)
+	})
+	want := []*StaticRoute{
+		{Destination: "10.0.0.0/8", RouteType: RouteTypeNextHop, NextHop: "192.168.99.2"},
+		{Destination: "172.16.0.0/12", RouteType: RouteTypeOnLink},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("dhcpStaticRoutes mismatch:\ngot:  %+v\nwant: %+v", got, want)
+	}
+}
+
+func TestDHCPStaticRoutes_Empty(t *testing.T) {
+	if got := dhcpStaticRoutes(nil); len(got) != 0 {
+		t.Errorf("dhcpStaticRoutes(nil) = %+v, want empty", got)
+	}
+}
 
 func TestValidateModeOptions(t *testing.T) {
 	cases := []struct {

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -268,6 +268,10 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 					if opts.Gateway != "" {
 						hint.Gateway = opts.Gateway
 					}
+					// DHCP option-121 classless static routes (RFC 3442);
+					// any default route was already folded into
+					// info.Gateway by the parser.
+					hint.Routes = dhcpStaticRoutes(info.Routes)
 				}
 			})
 			return nil

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -238,6 +238,11 @@ type joinHint struct {
 	IPv4    *netlink.Addr
 	IPv6    *netlink.Addr
 	Gateway string
+	// Routes are DHCP option-121 classless static routes (RFC 3442)
+	// captured from the initial v4 DHCP exchange in CreateEndpoint. Like
+	// Gateway, they only arrive in CreateEndpoint, so they ride the hint
+	// to be appended to the Join response's StaticRoutes.
+	Routes []*StaticRoute
 	// MacAddress is set in macvlan mode so the persistent DHCP client can
 	// re-find the (renamed) macvlan link inside the container netns by MAC.
 	MacAddress net.HardwareAddr

--- a/pkg/udhcpc/event_builder.go
+++ b/pkg/udhcpc/event_builder.go
@@ -90,6 +90,54 @@ func v4PrefixLen(getenv Getenv) (string, bool) {
 	return strconv.Itoa(ones), true
 }
 
+// parseClasslessRoutes parses a dhcpcd classless-static-routes value
+// (DHCP option 121, RFC 3442) — a space-separated sequence of
+// "destination/prefix gateway" pairs, e.g.
+// "10.0.0.0/8 192.168.99.1 0.0.0.0/0 192.168.99.254". It returns the
+// non-default routes plus, separately, the gateway of a 0.0.0.0/0
+// default entry ("" when absent) so the caller can apply RFC 3442
+// default-route supersession over option 3.
+//
+// dhcpcd reports an on-link route with the gateway 0.0.0.0; that becomes
+// a Route with an empty Gateway. Malformed entries (unparseable
+// destination or gateway) are skipped best-effort — mirroring the MTU
+// guard, a single bad route must not drop the whole lease event — as is
+// a trailing unpaired token.
+func parseClasslessRoutes(raw string) (routes []Route, defaultGW string) {
+	fields := strings.Fields(raw)
+	for i := 0; i+1 < len(fields); i += 2 {
+		dest, gw := fields[i], fields[i+1]
+		_, ipNet, err := net.ParseCIDR(dest)
+		if err != nil {
+			log.WithField("route", dest).Warn("Skipping classless static route with unparseable destination")
+			continue
+		}
+		if net.ParseIP(gw) == nil {
+			log.WithField("gateway", gw).Warn("Skipping classless static route with unparseable gateway")
+			continue
+		}
+		onlink := gw == "0.0.0.0"
+
+		// A 0.0.0.0/0 destination is the default route: its gateway
+		// supersedes option 3 (RFC 3442) and is returned separately, not
+		// added as a static route. An on-link default (gw 0.0.0.0) is
+		// meaningless, so it is simply dropped.
+		if ones, bits := ipNet.Mask.Size(); ones == 0 && bits == 32 && ipNet.IP.Equal(net.IPv4zero) {
+			if !onlink {
+				defaultGW = gw
+			}
+			continue
+		}
+
+		r := Route{Destination: ipNet.String()}
+		if !onlink {
+			r.Gateway = gw
+		}
+		routes = append(routes, r)
+	}
+	return routes, defaultGW
+}
+
 // BuildEvent assembles an Event from a dhcpcd hook invocation: the
 // `$reason` string plus the `new_*` lease variables dhcpcd exports to
 // its --script. Returns (event, true) when the caller should emit the
@@ -168,10 +216,19 @@ func BuildEvent(reason string, getenv Getenv) (Event, bool) {
 	}
 	event.Data.IP = ipMask
 
-	// Default gateway: dhcpcd exports the routers option as a
-	// space-separated list; the plugin applies a single default route,
+	// Option 121 (classless static routes, RFC 3442). Parsed before the
+	// routers gateway below so an opt-121 default route (0.0.0.0/0) can
+	// supersede option 3, as RFC 3442 requires.
+	routes, classlessDefaultGW := parseClasslessRoutes(getenv("new_classless_static_routes"))
+	event.Data.Routes = routes
+
+	// Default gateway: an opt-121 default route supersedes the routers
+	// option (opt 3) per RFC 3442; otherwise dhcpcd exports routers as a
+	// space-separated list and the plugin applies a single default route,
 	// so take the first.
-	if routers := strings.Fields(getenv("new_routers")); len(routers) > 0 {
+	if classlessDefaultGW != "" {
+		event.Data.Gateway = classlessDefaultGW
+	} else if routers := strings.Fields(getenv("new_routers")); len(routers) > 0 {
 		event.Data.Gateway = routers[0]
 	}
 	event.Data.Domain = getenv("new_domain_name")

--- a/pkg/udhcpc/event_builder_test.go
+++ b/pkg/udhcpc/event_builder_test.go
@@ -367,3 +367,78 @@ func TestBuildEvent_BoundV6_MultipleDNS6Servers(t *testing.T) {
 		t.Errorf("DNSServers = %v, want %v", got.Data.DNSServers, want)
 	}
 }
+
+// Option 121 (classless static routes, RFC 3442).
+
+func TestBuildEvent_ClasslessRoutes_NextHopAndOnLink(t *testing.T) {
+	got, emit := BuildEvent("BOUND", fakeEnv(map[string]string{
+		"new_ip_address":  "192.168.99.10",
+		"new_subnet_cidr": "24",
+		"new_routers":     "192.168.99.1",
+		// next-hop route, then an on-link route (gateway 0.0.0.0).
+		"new_classless_static_routes": "10.0.0.0/8 192.168.99.2 172.16.0.0/12 0.0.0.0",
+	}))
+	if !emit {
+		t.Fatal("emit=false on a well-formed BOUND event")
+	}
+	want := []Route{
+		{Destination: "10.0.0.0/8", Gateway: "192.168.99.2"},
+		{Destination: "172.16.0.0/12"}, // on-link: empty gateway
+	}
+	if !reflect.DeepEqual(got.Data.Routes, want) {
+		t.Errorf("Routes = %+v, want %+v", got.Data.Routes, want)
+	}
+	// No opt-121 default route present, so option 3 still sets the gateway.
+	if got.Data.Gateway != "192.168.99.1" {
+		t.Errorf("Gateway = %q, want the option-3 router", got.Data.Gateway)
+	}
+}
+
+func TestBuildEvent_ClasslessDefaultRoute_SupersedesRouters(t *testing.T) {
+	got, _ := BuildEvent("BOUND", fakeEnv(map[string]string{
+		"new_ip_address":  "192.168.99.10",
+		"new_subnet_cidr": "24",
+		"new_routers":     "192.168.99.1",
+		// A 0.0.0.0/0 entry must win over new_routers per RFC 3442, and
+		// must NOT appear among the static routes.
+		"new_classless_static_routes": "0.0.0.0/0 192.168.99.254 10.0.0.0/8 192.168.99.2",
+	}))
+	if got.Data.Gateway != "192.168.99.254" {
+		t.Errorf("Gateway = %q, want the opt-121 default route to supersede routers", got.Data.Gateway)
+	}
+	want := []Route{{Destination: "10.0.0.0/8", Gateway: "192.168.99.2"}}
+	if !reflect.DeepEqual(got.Data.Routes, want) {
+		t.Errorf("Routes = %+v, want only the non-default route %+v", got.Data.Routes, want)
+	}
+}
+
+func TestBuildEvent_ClasslessRoutes_MalformedEntriesSkippedBestEffort(t *testing.T) {
+	got, emit := BuildEvent("BOUND", fakeEnv(map[string]string{
+		"new_ip_address":  "192.168.99.10",
+		"new_subnet_cidr": "24",
+		// bad destination, bad gateway, then a valid route, then an odd
+		// trailing token — none may drop the event or the valid route.
+		"new_classless_static_routes": "not-a-cidr 192.168.99.2 10.0.0.0/8 not-an-ip 192.168.50.0/24 192.168.99.3 192.168.60.0/24",
+	}))
+	if !emit {
+		t.Fatal("a malformed route must not drop the whole lease event")
+	}
+	want := []Route{{Destination: "192.168.50.0/24", Gateway: "192.168.99.3"}}
+	if !reflect.DeepEqual(got.Data.Routes, want) {
+		t.Errorf("Routes = %+v, want only the one valid route %+v", got.Data.Routes, want)
+	}
+}
+
+func TestBuildEvent_NoClasslessRoutes_LeavesRoutesNilAndKeepsRouters(t *testing.T) {
+	got, _ := BuildEvent("BOUND", fakeEnv(map[string]string{
+		"new_ip_address":  "192.168.99.10",
+		"new_subnet_cidr": "24",
+		"new_routers":     "192.168.99.1",
+	}))
+	if got.Data.Routes != nil {
+		t.Errorf("Routes = %+v, want nil when option 121 is absent", got.Data.Routes)
+	}
+	if got.Data.Gateway != "192.168.99.1" {
+		t.Errorf("Gateway = %q, want the option-3 router unchanged", got.Data.Gateway)
+	}
+}

--- a/pkg/udhcpc/handler.go
+++ b/pkg/udhcpc/handler.go
@@ -43,6 +43,24 @@ type Info struct {
 	// BootFile is the boot file name from DHCP option 67 (dhcpcd env
 	// var `new_bootfile_name`). Same surfacing semantics as TFTPServer.
 	BootFile string `json:",omitempty"`
+
+	// Routes are the classless static routes from DHCP option 121
+	// (RFC 3442, dhcpcd env var `new_classless_static_routes`). v4 only —
+	// DHCPv6 carries no route option (routes come from RAs). Empty when
+	// the server didn't supply the option. A 0.0.0.0/0 entry is NOT
+	// included here: per RFC 3442 its gateway supersedes option 3 and is
+	// folded into Gateway during parsing. Applied at Join as additional
+	// container StaticRoutes; `skip_routes=true` opts out.
+	Routes []Route `json:",omitempty"`
+}
+
+// Route is a single classless static route from DHCP option 121.
+type Route struct {
+	// Destination is the canonical CIDR (e.g. "10.0.0.0/8").
+	Destination string
+	// Gateway is the next hop. Empty means the route is on-link (dhcpcd
+	// reported the gateway as 0.0.0.0).
+	Gateway string `json:",omitempty"`
 }
 
 type Event struct {

--- a/test/integration/classless_routes_test.go
+++ b/test/integration/classless_routes_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+)
+
+// TestClasslessStaticRoutes_AppliedFromDHCP is the integration proof for
+// #260: a DHCP server that hands out a classless static route (option
+// 121, RFC 3442) should have that route applied inside the container.
+//
+// The fixture's dnsmasq pushes TestClasslessRoute via TestClasslessRouteGW
+// only to clients tagged with vendor_class = TestClasslessVendorClass, so
+// a container on a network that opts into that vendor class must end up
+// with the route in its table. This exercises the full path the unit
+// tests can't reach: the one-shot lease's Routes ride the joinHint and
+// are emitted as StaticRoutes in the Join response, which libnetwork then
+// programs into the container netns.
+func TestClasslessStaticRoutes_AppliedFromDHCP(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-csr"
+	ctrName := "dh-itest-csr-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{
+		"vendor_class": harness.TestClasslessVendorClass,
+	})
+	id, _, _ := harness.RunContainer(t, ctx, netName, ctrName)
+
+	out := harness.ExecOutput(t, ctx, id, "ip", "route", "show")
+	if gw := routeGateway(t, out, harness.TestClasslessRoute); gw != harness.TestClasslessRouteGW {
+		t.Errorf("route to %s via %q, want DHCP-pushed gateway %s — option 121 didn't reach the container:\n%s",
+			harness.TestClasslessRoute, gw, harness.TestClasslessRouteGW, out)
+	}
+	t.Logf("classless route applied: %s", strings.TrimSpace(out))
+}
+
+// TestClasslessStaticRoutes_AbsentWithoutOptIn is the negative side: a
+// default-config container (no matching vendor class) is not tagged, so
+// dnsmasq never sends option 121 and the route must be absent. Guards
+// against the fixture leaking the route to every client and against the
+// plugin inventing routes from nowhere.
+func TestClasslessStaticRoutes_AbsentWithoutOptIn(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-csr-none"
+	ctrName := "dh-itest-csr-none-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+	id, _, _ := harness.RunContainer(t, ctx, netName, ctrName)
+
+	out := harness.ExecOutput(t, ctx, id, "ip", "route", "show")
+	if hasRoute(out, harness.TestClasslessRoute) {
+		t.Errorf("route to %s present without the vendor-class opt-in — option 121 leaked:\n%s",
+			harness.TestClasslessRoute, out)
+	}
+}
+
+// routeGateway returns the `via` gateway of the route to dest in
+// `ip route` output, failing the test if the route is absent. Matches on
+// the exact destination field (fields[0]) to avoid the substring
+// false-matches that bit the default-route helper (#130).
+func routeGateway(t *testing.T, out, dest string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[0] == dest && fields[1] == "via" {
+			return fields[2]
+		}
+	}
+	t.Fatalf("no route to %s in ip route output:\n%s", dest, out)
+	return ""
+}
+
+// hasRoute reports whether `ip route` output contains any route whose
+// destination field is exactly dest.
+func hasRoute(out, dest string) bool {
+	for _, line := range strings.Split(out, "\n") {
+		if fields := strings.Fields(line); len(fields) >= 1 && fields[0] == dest {
+			return true
+		}
+	}
+	return false
+}

--- a/test/integration/harness/fixture.go
+++ b/test/integration/harness/fixture.go
@@ -110,6 +110,18 @@ const (
 	TestTaggedGateway  = "192.168.99.250"
 	dnsmasqVCTag       = "dh-itest-vc"
 	defaultGatewayAddr = "192.168.99.1"
+
+	// TestClasslessVendorClass / TestClasslessRoute drive the option-121
+	// classless-static-routes test (#260). dnsmasq sets tag
+	// `dh-itest-csr` for clients sending option 60 =
+	// TestClasslessVendorClass, then pushes a non-default classless route
+	// (TestClasslessRoute via TestClasslessRouteGW) only to tagged
+	// clients — so default-config containers never see option 121 and
+	// existing route assertions are unaffected.
+	TestClasslessVendorClass = "docker-net-dhcp-test-csr"
+	TestClasslessRoute       = "192.168.123.0/24"
+	TestClasslessRouteGW     = "192.168.99.249"
+	dnsmasqCSRTag            = "dh-itest-csr"
 )
 
 // DefaultGateway is the gateway untagged clients receive — dnsmasq's
@@ -263,6 +275,12 @@ func (f *Fixture) startDnsmasq() error {
 		// tests that don't opt-in are unaffected.
 		"--dhcp-vendorclass=set:"+dnsmasqVCTag+","+TestVendorClass,
 		"--dhcp-option=tag:"+dnsmasqVCTag+",3,"+TestTaggedGateway,
+		// Option-121 classless static route, pushed only to clients
+		// tagged via TestClasslessVendorClass (#260). Non-default
+		// destination, so it never alters the default-route assertions
+		// of other suites.
+		"--dhcp-vendorclass=set:"+dnsmasqCSRTag+","+TestClasslessVendorClass,
+		"--dhcp-option=tag:"+dnsmasqCSRTag+",121,"+TestClasslessRoute+","+TestClasslessRouteGW,
 		// NOTE: this fixture deliberately does NOT pass --dhcp-broadcast.
 		// dnsmasq honours the client's BROADCAST flag, so it broadcasts
 		// OFFER/ACK only when the client asks. ipvlan-L2 needs that


### PR DESCRIPTION
Closes #260 *(stays open until the v1.3.0 release PR batch-closes it).*

## What
Honor server-pushed **classless static routes (DHCP option 121, RFC 3442)** on DHCPv4 leases, behind the existing `skip_routes` opt-out.

- **Parser** (`pkg/udhcpc/event_builder.go`): reads dhcpcd's `new_classless_static_routes`, emits `Route{Destination, Gateway}` pairs. On-link routes (gateway `0.0.0.0`) → empty Gateway. A `0.0.0.0/0` entry is treated as the **default route and supersedes option 3** (RFC 3442). Malformed entries are skipped best-effort (one bad route must not drop the whole lease event — mirrors the MTU guard).
- **Apply path** (`network.go`/`parent_attached.go`): installs the routes on the endpoint; respects `skip_routes`.
- **Counters/plumbing** (`plugin.go`, `handler.go`).

## Tests
- Unit: parser (next-hop / on-link / default-route supersession / malformed best-effort / no-opt-121 regression) + the `StaticRoute` conversion.
- Integration (`classless_routes_test.go`): pushes option 121 to a vendor-class-tagged client via the fixture and asserts the route lands in the container — and is absent without the opt-in.

## Docs
`docs/reference.md`: option-121 behaviour + the `skip_routes` interaction.

## Freshness / verification
Branch predates the v1.2.0 dhcpcd work; **rebased onto current dev (clean, no conflicts)** and re-validated: `go build`/`vet ./...` clean, route unit tests pass `-count=1`, integration suite compiles under `-tags integration`, and the option-docs / version / apk pin gates pass locally. Crucially it reads the **dhcpcd** env (`new_classless_static_routes`), consistent with the post-#152 client — not the old busybox path. The wire-level behaviour (option 121 → route in container) is proven by this PR's own integration run.