### PR TITLE
docs: correct stated license to GPL-3.0 (matches LICENSE.md + upstream)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,4 +153,6 @@ few days for a response.
 
 ## License
 
-MIT — see [LICENSE.md](LICENSE.md).
+GPL-3.0 — see [LICENSE.md](LICENSE.md). This is a fork of
+[`devplayer0/docker-net-dhcp`][upstream], which is GPL-3.0; as a
+derivative work it stays under the same license.

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,5 +117,8 @@ gh attestation verify oci://ghcr.io/claymore666/docker-net-dhcp:VERSION --repo c
 
 ## License
 
-MIT — see
+GPL-3.0 — see
 [LICENSE.md](https://github.com/claymore666/docker-net-dhcp/blob/dev/LICENSE.md).
+This is a fork of
+[`devplayer0/docker-net-dhcp`](https://github.com/devplayer0/docker-net-dhcp),
+which is GPL-3.0; as a derivative work it stays under the same license.


### PR DESCRIPTION
## Problem
`README.md` and `docs/index.md` stated **"MIT — see LICENSE.md"**, but:
- `LICENSE.md` is — and always has been — the **GPL-3.0** text (added in `8816992`; no MIT LICENSE ever existed).
- GitHub detects the repo as **GPL-3.0**.
- Upstream [`devplayer0/docker-net-dhcp`](https://github.com/devplayer0/docker-net-dhcp) is **GPL-3.0**, so this fork — a derivative work — **must remain GPL-3.0**; it was never MIT and cannot be relicensed to MIT.

## Root cause
Not a relicensing — a **documentation slip**: the "MIT" line was introduced during the README restructure (`4910e56`), with no accompanying LICENSE change and no MIT/SPDX headers anywhere in source.

## Fix
State **GPL-3.0** in both `README.md` and `docs/index.md`, matching `LICENSE.md` + upstream, and note the upstream inheritance so the confusion doesn't recur. Docs-only; no code change.