### PR TITLE
feat(dhcp): opt-in DHCP FQDN registration (option 81/39) (#261)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -152,6 +152,7 @@ Passed as `-o key=value` on `docker network create`, or under
 | `client_id` | all | per-endpoint id | v0.9.0 | Override DHCP option 61 (Client Identifier) for every endpoint on this network; sent as RFC 2132 opaque bytes (type `0x00`). The default per-endpoint id is what makes per-container reservations work — a fixed `client_id` makes all containers look like one client to the server. Pair with `vendor_class` for class-based policy. |
 | `vendor_class` | all | `docker-net-dhcp` | v0.9.0 | Override DHCP option 60 (Vendor Class Identifier), for DHCP servers running class-based policy (different gateway/option sets per class). v4 only — the DHCPv6 client sends no vendor-class option. |
 | `validate_dhcp` | macvlan, ipvlan | `false` | v0.9.0 | Pre-flight probe at `docker network create`: one-shot DHCP exchange on the parent with a random locally-administered MAC, rejecting the network if no server answers within 5s. Catches isolated parents / blocked UDP 67-68 / broken VLAN tags at create time. Costs one transient lease per probe. Bridge mode rejects the option. |
+| `register_dns` | all | `false` | v1.3.0 | Send the DHCP FQDN option (81 on v4 / 39 on v6, via `dhcpcd fqdn both`) built from the container's hostname, asking the DHCP server to register that name in DNS (forward A/AAAA + reverse PTR). Reuses the same hostname already sent as the option-12 hint. Best-effort and advisory — many consumer routers ignore option 81, so this *requests* registration, it does not guarantee resolution. Off by default: dynamic-DNS registration is a network-policy decision. See below. |
 | `audit_log` | all | `false` | v1.0.0 | Append every lease-lifecycle event (`bound` / `renew` / `release` / `release_failed`) to `STATE_DIR/leases.jsonl` — one JSON object per line with timestamp, network, endpoint, container, hostname, IP, MAC. Rotated at 16 MB or 30 days (one rotated generation kept, ≤ ~32 MB total). Append failures bump `ledger_write_failures` on `/Plugin.Health`, never affecting lease handling. Off by default: per-event disk write, and container↔IP correlation on disk is privacy-relevant in some environments. |
 
 ### DHCP classless static routes (option 121)
@@ -166,6 +167,29 @@ the default route and **supersedes the option-3 router** per RFC 3442
 opts out of option-121 routes as well as parent-copied ones. v4 only —
 IPv6 routes come from Router Advertisements. (Legacy option 33 is not
 honored; modern servers send option 121.)
+
+### Dynamic-DNS registration (`register_dns`, option 81 / 39)
+
+With `-o register_dns=true`, every endpoint on the network sends the DHCP
+**FQDN option** — option 81 on v4 (RFC 4702) and option 39 on v6
+(RFC 4704) — built from the container's hostname, asking the server to
+publish that name in DNS. This pairs with the option-12 hostname hint the
+plugin already sends: the hostname says *who we are*, the FQDN option asks
+the server to *publish it*. One `dhcpcd fqdn both` directive covers both
+families, requesting forward (A/AAAA) **and** reverse (PTR) updates; the
+container runs no DNS updater of its own, so the server does all the work.
+
+The payoff is on-mission: a container becomes resolvable **by name** on
+the LAN, not just reachable by its DHCP-leased IP — with no per-container
+plumbing. The name source is the same one used for the hostname hint and
+tombstone matching (the container's hostname; the server supplies the
+domain).
+
+It is **best-effort and advisory**, like the preferred-address hint: many
+consumer routers ignore option 81 entirely, and registration depends on
+the server being configured for dynamic DNS. The plugin's contract is
+"send the option when asked" — not "the name will resolve." Off by
+default because DDNS registration is a deliberate network-policy choice.
 
 ## Driver options (per-endpoint)
 

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -596,6 +596,7 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 	}
 	client, err := udhcpc.NewDHCPClient(m.ctrLink.Attrs().Name, &udhcpc.DHCPClientOptions{
 		Hostname:  m.hostname,
+		FQDN:      m.opts.fqdnMode(),
 		V6:        v6,
 		Namespace: m.nsPath,
 		// Same MAC the CreateEndpoint one-shot used (this is the same

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -567,6 +567,7 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 			clientOpts := &udhcpc.DHCPClientOptions{
 				V6:          v6,
 				Hostname:    hostname,
+				FQDN:        opts.fqdnMode(),
 				ClientID:    clientID,
 				VendorClass: opts.VendorClass,
 				// Pin the dhcpcd DUID-LL/IAID off the container veth's

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -231,6 +231,7 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 			clientOpts := &udhcpc.DHCPClientOptions{
 				V6:          v6,
 				Hostname:    hostname,
+				FQDN:        opts.fqdnMode(),
 				ClientID:    clientID,
 				VendorClass: opts.VendorClass,
 				Broadcast:   mode == ModeIPvlan,

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -191,6 +191,15 @@ type DHCPNetworkOptions struct {
 	// the lease times out naturally rather than dragging CreateNetwork
 	// on a slow release path.
 	ValidateDHCP bool `mapstructure:"validate_dhcp"`
+	// RegisterDNS, when true, makes every endpoint on this network send
+	// the DHCP FQDN option (81 v4 / 39 v6, dhcpcd `fqdn both`) built from
+	// its resolved hostname, asking the DHCP server to register that name
+	// in DNS (forward + reverse). Default false: dynamic-DNS registration
+	// is a network-policy decision, never silent. Best-effort and advisory
+	// — many consumer routers ignore option 81, so this requests
+	// registration, it does not guarantee resolution. Reuses the same
+	// hostname already sent as the option-12 hint (#261).
+	RegisterDNS bool `mapstructure:"register_dns"`
 	// AuditLog, when true, appends every lease-lifecycle event on
 	// this network (bound / renew / release, plus release_failed when
 	// the DHCPRELEASE didn't complete) to STATE_DIR/leases.jsonl —
@@ -211,6 +220,17 @@ func (o DHCPNetworkOptions) effectiveMode() string {
 		return ModeBridge
 	}
 	return o.Mode
+}
+
+// fqdnMode maps the register_dns opt-in to the dhcpcd `fqdn` directive
+// mode passed to the client. "both" asks the server to update forward
+// (A/AAAA) and reverse (PTR); "" omits the directive (the default). See
+// DHCPNetworkOptions.RegisterDNS (#261).
+func (o DHCPNetworkOptions) fqdnMode() string {
+	if o.RegisterDNS {
+		return "both"
+	}
+	return ""
 }
 
 func decodeOpts(input interface{}) (DHCPNetworkOptions, error) {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -67,6 +67,18 @@ func TestEffectiveMode(t *testing.T) {
 	}
 }
 
+// TestFQDNMode pins the register_dns → dhcpcd directive mapping (#261):
+// opt-in yields "both" (server updates A/AAAA + PTR), default yields ""
+// (no fqdn directive — DDNS is opt-in).
+func TestFQDNMode(t *testing.T) {
+	if got := (DHCPNetworkOptions{RegisterDNS: true}).fqdnMode(); got != "both" {
+		t.Errorf("register_dns=true → fqdnMode()=%q, want \"both\"", got)
+	}
+	if got := (DHCPNetworkOptions{}).fqdnMode(); got != "" {
+		t.Errorf("default → fqdnMode()=%q, want \"\" (omit)", got)
+	}
+}
+
 func TestDecodeOpts(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -123,6 +135,15 @@ func TestDecodeOpts(t *testing.T) {
 				IgnoreConflicts: true,
 				SkipRoutes:      true,
 			},
+		},
+		{
+			name: "register_dns",
+			input: map[string]interface{}{
+				"mode":         "macvlan",
+				"parent":       "eth0",
+				"register_dns": "true",
+			},
+			want: DHCPNetworkOptions{Mode: ModeMacvlan, Parent: "eth0", RegisterDNS: true},
 		},
 		{
 			name: "lease_timeout_invalid",

--- a/pkg/udhcpc/client.go
+++ b/pkg/udhcpc/client.go
@@ -157,6 +157,12 @@ type DHCPClientOptions struct {
 	// and #243.
 	Broadcast bool
 
+	// FQDN, when non-empty, sets dhcpcd's `fqdn` directive mode (e.g.
+	// "both"), making the client send the DHCP FQDN option (81 v4 / 39 v6)
+	// built from Hostname and ask the server to register it in DNS (#261).
+	// Empty omits it (the default — DDNS registration is opt-in).
+	FQDN string
+
 	HandlerScript string
 }
 
@@ -212,6 +218,7 @@ func NewDHCPClient(iface string, opts *DHCPClientOptions) (*DHCPClient, error) {
 		V6:          opts.V6,
 		Once:        opts.Once,
 		Hostname:    opts.Hostname,
+		FQDN:        opts.FQDN,
 		VendorClass: vendor,
 		ClientID:    opts.ClientID,
 		RequestedIP: opts.RequestedIP,

--- a/pkg/udhcpc/dhcpcd.go
+++ b/pkg/udhcpc/dhcpcd.go
@@ -93,6 +93,9 @@ type dhcpcdParams struct {
 	Once  bool // one-shot acquisition (CreateEndpoint) vs persistent daemon
 
 	Hostname    string // hostname directive; "" omits
+	FQDN        string // fqdn directive mode (e.g. "both"); "" omits. Sends
+	//            the DHCP FQDN option (81 v4 / 39 v6) using Hostname, asking
+	//            the server to register it in DNS (#261).
 	VendorClass string // v4 option 60; "" omits (v4 only)
 	ClientID    []byte // v4 option 61 raw payload; nil/empty omits (v4 only)
 	RequestedIP string // v4 preferred address (request directive); "" omits
@@ -204,6 +207,15 @@ func renderConfig(p dhcpcdParams) string {
 
 	if p.Hostname != "" {
 		fmt.Fprintf(&b, "hostname %s\n", p.Hostname)
+	}
+	// FQDN option (81 v4 / 39 v6): opt-in dynamic-DNS registration (#261).
+	// dhcpcd sends the FQDN built from the hostname directive above and,
+	// per RFC 4702, sends it *instead of* option 12 — same name, plus the
+	// server-update request. Applies to both families, so it sits outside
+	// the v4-only block below. "both" asks the server to update forward
+	// (A/AAAA) and reverse (PTR); the client runs no DNS updater of its own.
+	if p.FQDN != "" {
+		fmt.Fprintf(&b, "fqdn %s\n", p.FQDN)
 	}
 	// vendorclassid / clientid are DHCPv4 concepts (option 60 / 61);
 	// the v6 identity is carried entirely by DUID + IAID.

--- a/pkg/udhcpc/dhcpcd_test.go
+++ b/pkg/udhcpc/dhcpcd_test.go
@@ -178,7 +178,7 @@ func TestRenderConfig_V6_NoPreferredOmitsIANaButKeepsIAID(t *testing.T) {
 // identity + nohooks + the interface/iaid block.
 func TestRenderConfig_OmitsAbsentOptionals(t *testing.T) {
 	conf := renderConfig(dhcpcdParams{Iface: "eth0", MAC: mustMAC(t, "de:ad:be:ef:00:01")})
-	for _, banned := range []string{"hostname ", "vendorclassid", "clientid", "request", "ia_na"} {
+	for _, banned := range []string{"hostname ", "fqdn ", "vendorclassid", "clientid", "request", "ia_na"} {
 		if strings.Contains(conf, banned) {
 			t.Errorf("minimal config contains unexpected directive %q:\n%s", banned, conf)
 		}
@@ -262,6 +262,30 @@ func TestRenderConfig_BroadcastOnlyForIPvlanV4(t *testing.T) {
 	v6Bcast := renderConfig(dhcpcdParams{Iface: "eth0", MAC: mac, V6: true, Broadcast: true})
 	if hasLine(v6Bcast, "broadcast") {
 		t.Errorf("v6 client must not emit `broadcast` (v4-only flag):\n%s", v6Bcast)
+	}
+}
+
+// TestRenderConfig_FQDN: the `fqdn` directive (opt-in DDNS, #261) is
+// emitted exactly when FQDN is set, for BOTH families (option 81 v4 /
+// option 39 v6 — one directive covers both), and omitted otherwise.
+func TestRenderConfig_FQDN(t *testing.T) {
+	mac := mustMAC(t, "de:ad:be:ef:00:01")
+
+	for _, v6 := range []bool{false, true} {
+		conf := renderConfig(dhcpcdParams{Iface: "eth0", MAC: mac, V6: v6, Hostname: "web1", FQDN: "both"})
+		if !hasLine(conf, "fqdn both") {
+			t.Errorf("v6=%v: FQDN set but `fqdn both` not emitted:\n%s", v6, conf)
+		}
+		// The name rides the hostname directive — both must be present.
+		if !hasLine(conf, "hostname web1") {
+			t.Errorf("v6=%v: fqdn directive without the hostname it names:\n%s", v6, conf)
+		}
+	}
+
+	// Absent → no fqdn directive (default off).
+	noFQDN := renderConfig(dhcpcdParams{Iface: "eth0", MAC: mac, Hostname: "web1"})
+	if strings.Contains(noFQDN, "fqdn ") {
+		t.Errorf("FQDN unset must not emit a `fqdn` directive:\n%s", noFQDN)
 	}
 }
 

--- a/test/integration/fqdn_test.go
+++ b/test/integration/fqdn_test.go
@@ -1,0 +1,79 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+)
+
+// TestFQDN_RegistersInDNS verifies the opt-in FQDN option (#261): with
+// `-o register_dns=true`, the plugin's dhcpcd sends the DHCP FQDN option
+// (81), the DHCP server registers <hostname>.<domain> in its DNS, and
+// the container becomes resolvable by name to its leased IP.
+//
+// The fixture runs dnsmasq with DNS enabled, a domain, and --dhcp-fqdn
+// (WithDNS). --dhcp-fqdn registers ONLY clients that send the FQDN
+// option, ignoring plain option-12 hostnames — so this resolving is
+// itself the proof that the FQDN option (not the bare hostname hint) is
+// what landed. The default-off case (no `fqdn` directive emitted at all)
+// is pinned by the unit tests (TestRenderConfig_FQDN, TestFQDNMode).
+func TestFQDN_RegistersInDNS(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	const domain = "dh.test"
+	netName := "dh-itest-fqdn"
+	ctrName := "dh-itest-fqdn-ctr"
+
+	ef := harness.NewEphemeralFixture(t, harness.WithDNS(domain))
+	t.Cleanup(func() {
+		if t.Failed() {
+			ef.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{
+		"parent":       harness.EphemeralHostVeth,
+		"register_dns": "true",
+	})
+	id, ip, mac := harness.RunContainer(t, ctx, netName, ctrName)
+	t.Logf("bound: ip=%s mac=%s; expecting %s.%s -> %s", ip, mac, ctrName, domain, ip)
+	_ = id
+
+	// Resolve <hostname>.<domain> against the fixture's own DNS (a custom
+	// resolver dialing the fixture, since it listens on a private veth and
+	// a high port). Poll: registration lands once the client's FQDN-
+	// carrying bind reaches dnsmasq, a beat after the lease.
+	res := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, "udp", ef.DNSAddr())
+		},
+	}
+	fqdn := ctrName + "." + domain
+
+	deadline := time.Now().Add(30 * time.Second)
+	var lastErr error
+	var got []string
+	for time.Now().Before(deadline) {
+		lookupCtx, cancelLk := context.WithTimeout(ctx, 2*time.Second)
+		got, lastErr = res.LookupHost(lookupCtx, fqdn)
+		cancelLk()
+		for _, a := range got {
+			if a == ip {
+				t.Logf("resolved %s -> %s after FQDN registration", fqdn, a)
+				return
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("FQDN %s never resolved to the leased IP %s within 30s (last result=%v err=%v) — "+
+		"the server did not register the container via the DHCP FQDN option", fqdn, ip, got, lastErr)
+}

--- a/test/integration/harness/ephemeral.go
+++ b/test/integration/harness/ephemeral.go
@@ -71,6 +71,16 @@ type EphemeralFixture struct {
 	// means "don't set the option" (dhcpcd then derives T1/T2 from
 	// the lease as usual). See WithRenewTimes (#253).
 	renewT1, renewT2 int
+
+	// dnsDomain, when set, enables dnsmasq's DNS resolver (instead of
+	// the default --port=0) on dnsPort with this domain and --dhcp-fqdn,
+	// so a client that sends the DHCP FQDN option (81) gets its
+	// <hostname>.<domain> registered and resolvable. --dhcp-fqdn makes
+	// registration require the FQDN option, so a plain option-12
+	// hostname is NOT registered — which is exactly what lets the FQDN
+	// test distinguish register_dns on/off. See WithDNS (#261).
+	dnsDomain string
+	dnsPort   int
 }
 
 // EphemeralOption configures an EphemeralFixture before its dnsmasq
@@ -88,6 +98,20 @@ func WithRenewTimes(t1, t2 int) EphemeralOption {
 	return func(ef *EphemeralFixture) {
 		ef.renewT1 = t1
 		ef.renewT2 = t2
+	}
+}
+
+// WithDNS turns on the fixture dnsmasq's DNS resolver (on a dedicated
+// high port, bound to the fixture interface) with the given domain and
+// --dhcp-fqdn. A client that sends the DHCP FQDN option (81/39) then has
+// its <hostname>.<domain> registered in this DNS; query it via DNSAddr.
+// --dhcp-fqdn deliberately ignores plain option-12 hostnames, so a
+// container WITHOUT register_dns does not resolve — the on/off proof for
+// the FQDN test (#261).
+func WithDNS(domain string) EphemeralOption {
+	return func(ef *EphemeralFixture) {
+		ef.dnsDomain = domain
+		ef.dnsPort = 15353
 	}
 }
 
@@ -167,10 +191,12 @@ func (ef *EphemeralFixture) start() {
 	defer logF.Close()
 
 	startMark := ef.logSize()
+	// DNS off by default (--port=0). WithDNS turns the resolver on with a
+	// domain + --dhcp-fqdn so FQDN-option clients become resolvable (#261).
+	portArg := "--port=0"
 	args := []string{
 		"--no-daemon",
 		"--conf-file=/dev/null",
-		"--port=0",
 		"--interface=" + ephemeralDhcpVeth,
 		"--bind-interfaces",
 		"--except-interface=lo",
@@ -196,6 +222,14 @@ func (ef *EphemeralFixture) start() {
 	if ef.renewT2 > 0 {
 		args = append(args, fmt.Sprintf("--dhcp-option=59,%d", ef.renewT2))
 	}
+	if ef.dnsDomain != "" {
+		portArg = fmt.Sprintf("--port=%d", ef.dnsPort)
+		args = append(args,
+			"--domain="+ef.dnsDomain,
+			"--dhcp-fqdn",
+		)
+	}
+	args = append(args, portArg)
 	ef.cmd = exec.Command("/usr/sbin/dnsmasq", args...)
 	ef.cmd.Stdout = logF
 	ef.cmd.Stderr = logF
@@ -329,6 +363,17 @@ func (ef *EphemeralFixture) SeedStolenLease(ip string) {
 func (ef *EphemeralFixture) ServerIP() string {
 	return strings.SplitN(ef.serverCIDR, "/", 2)[0]
 }
+
+// DNSAddr returns the "ip:port" of the fixture's DNS resolver, for use
+// as a custom net.Resolver target. Only meaningful when the fixture was
+// built WithDNS; empty port otherwise (#261).
+func (ef *EphemeralFixture) DNSAddr() string {
+	return fmt.Sprintf("%s:%d", ef.ServerIP(), ef.dnsPort)
+}
+
+// DNSDomain returns the domain the fixture resolver appends to DHCP
+// hostnames (set via WithDNS).
+func (ef *EphemeralFixture) DNSDomain() string { return ef.dnsDomain }
 
 // CountLogLines counts log lines containing every one of the given
 // substrings (case-insensitive), e.g. ("DHCPACK", mac) or


### PR DESCRIPTION
Closes #261 *(stays open until the v1.3.0 release PR batch-closes it).*

## What
A container on a `-o register_dns=true` network asks the DHCP server to register its name in DNS — it becomes resolvable **by name** on the LAN, not just reachable by its leased IP. The on-mission completion of the option-12 hostname hint we already send, with no per-container plumbing.

- **dhcpcd config** (`dhcpcd.go`): new `fqdn` directive, emitted as `fqdn both` (server updates A/AAAA + PTR) when set. Built from the existing `hostname` directive, so it reuses the resolved container hostname; per RFC 4702 dhcpcd sends it *instead of* option 12 — same name, plus the server-update request. **One directive covers both option 81 (v4) and option 39 (v6).**
- **Plumbing**: `DHCPClientOptions.FQDN` → `dhcpcdParams`, populated at all three real client sites (parent one-shot, bridge one-shot, persistent).
- **Option**: `DHCPNetworkOptions.RegisterDNS` (`register_dns`, default **off**) + `fqdnMode()` helper. Best-effort/advisory — many consumer routers ignore opt 81.

## Tests
- **Unit**: `renderConfig` emits `fqdn both` for both families when set, omits by default; `fqdnMode` mapping; `register_dns` decode.
- **Integration** (`fqdn_test.go`): fixture dnsmasq `WithDNS` (domain + `--dhcp-fqdn`, which registers **only** FQDN-option clients) → a `register_dns=true` container resolves `<hostname>.<domain>` to its leased IP. The resolving itself proves option 81 (not the bare hostname hint) landed. Default-off is pinned by the unit tests.

## Docs
`reference.md`: option-table row + a "Dynamic-DNS registration" section.

## Verification
`build`/`vet` clean, unit tests + option-docs/version/apk gates pass locally. Wire-level behaviour proven by this PR's integration run. Design discussed on #261 before implementation.