### PR TITLE
feat(dhcp): surface WPAD + timezone DHCP options (observe-only) (#262)

### DIFF
--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -412,14 +412,20 @@ surfaces them in two ways:
   - Option 66 (TFTP server name, env `tftp`)
   - Option 67 (Boot file name, env `bootfile`)
   - Option 119 (when `propagate_dns=false`)
+  - Option 252 (WPAD proxy-autoconfig URL, log field `wpad`)
+  - Options 100 / 101 (RFC 4833 timezone, log fields `posix_tz` /
+    `tzdb_tz`) and option 2 (legacy time offset in seconds,
+    `time_offset`)
 
 ```text
 level=info msg="DHCP options received" ntp=[192.168.0.123]
   tftp=tftp.example.test bootfile=pxelinux.0
-  search=[corp.example internal.example] ...
+  search=[corp.example internal.example]
+  wpad=http://wpad.example/wpad.dat posix_tz=PST8PDT
+  tzdb_tz=Europe/Berlin time_offset=3600 ...
 ```
 
-Workloads needing NTP / TFTP / boot-file can grep the plugin log
+Workloads needing NTP / TFTP / boot-file / WPAD / timezone can grep the plugin log
 or wire a sidecar to it. The plugin doesn't auto-apply these
 because (a) the consuming application owns the config file, not
 the plugin, and (b) writing into `/etc/ntp.conf` etc. would mean

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -363,7 +363,8 @@ func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
 	// propagating DNS). Operators can grep plugin logs for these
 	// without flipping LOG_LEVEL=trace. Only emits when at least one
 	// is non-empty so plain LANs don't get a noisy line per renewal.
-	if len(info.NTPServers) > 0 || info.TFTPServer != "" || info.BootFile != "" || len(info.SearchList) > 0 {
+	if len(info.NTPServers) > 0 || info.TFTPServer != "" || info.BootFile != "" || len(info.SearchList) > 0 ||
+		info.WPAD != "" || info.PosixTimezone != "" || info.TZDBTimezone != "" || info.TimeOffset != "" {
 		fields := m.logFields(v6)
 		if len(info.NTPServers) > 0 {
 			fields["ntp"] = info.NTPServers
@@ -376,6 +377,20 @@ func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
 		}
 		if len(info.SearchList) > 0 {
 			fields["search"] = info.SearchList
+		}
+		// Observe-only informational extras (#262): WPAD URL (opt 252),
+		// RFC 4833 timezone (opt 100/101), legacy time offset (opt 2).
+		if info.WPAD != "" {
+			fields["wpad"] = info.WPAD
+		}
+		if info.PosixTimezone != "" {
+			fields["posix_tz"] = info.PosixTimezone
+		}
+		if info.TZDBTimezone != "" {
+			fields["tzdb_tz"] = info.TZDBTimezone
+		}
+		if info.TimeOffset != "" {
+			fields["time_offset"] = info.TimeOffset
 		}
 		log.WithFields(fields).Info("DHCP options received")
 	}

--- a/pkg/udhcpc/dhcpcd.go
+++ b/pkg/udhcpc/dhcpcd.go
@@ -92,8 +92,8 @@ type dhcpcdParams struct {
 	V6    bool
 	Once  bool // one-shot acquisition (CreateEndpoint) vs persistent daemon
 
-	Hostname    string // hostname directive; "" omits
-	FQDN        string // fqdn directive mode (e.g. "both"); "" omits. Sends
+	Hostname string // hostname directive; "" omits
+	FQDN     string // fqdn directive mode (e.g. "both"); "" omits. Sends
 	//            the DHCP FQDN option (81 v4 / 39 v6) using Hostname, asking
 	//            the server to register it in DNS (#261).
 	VendorClass string // v4 option 60; "" omits (v4 only)
@@ -162,6 +162,13 @@ func renderConfig(p dhcpcdParams) string {
 		fmt.Fprintf(&b, "nohook %s\n", h)
 	}
 
+	// WPAD (option 252) is non-standard, so dhcpcd has no built-in name
+	// for it — define one (as a string) before requesting it below.
+	// dhcpcd 10.x does not pre-define 252, so this never conflicts
+	// (verified against the image's dhcpcd; bare `option wpad` is rejected
+	// without this). #262.
+	fmt.Fprintf(&b, "define 252 string wpad\n")
+
 	// Explicitly request the options the plugin propagates. Passing
 	// `-f <config>` bypasses the distro /etc/dhcpcd.conf, so dhcpcd would
 	// otherwise fall back to a minimal built-in request set and never
@@ -172,7 +179,10 @@ func renderConfig(p dhcpcdParams) string {
 	// families; options that don't apply to the active protocol are
 	// ignored. Routers/subnet/classless-static-routes are in dhcpcd's
 	// defaults but are listed for explicitness and to be robust to a
-	// default change.
+	// default change. posix_timezone/tzdb_timezone/time_offset/wpad
+	// (options 100/101/2/252) are observe-only informational extras
+	// surfaced in logs (#262) — these are dhcpcd's actual names for
+	// those codes (NOT pcode/tcode, which dhcpcd rejects).
 	fmt.Fprintf(&b, "option %s\n", strings.Join([]string{
 		"subnet_mask",
 		"broadcast_address",
@@ -186,6 +196,10 @@ func renderConfig(p dhcpcdParams) string {
 		"tftp_server_name",
 		"bootfile_name",
 		"classless_static_routes",
+		"time_offset",
+		"posix_timezone",
+		"tzdb_timezone",
+		"wpad",
 	}, ", "))
 
 	// Persistent client only: release the lease on graceful stop (busybox

--- a/pkg/udhcpc/dhcpcd_test.go
+++ b/pkg/udhcpc/dhcpcd_test.go
@@ -305,6 +305,10 @@ func TestRenderConfig_RequestsPropagatedOptions(t *testing.T) {
 		"tftp_server_name",    // option 66
 		"bootfile_name",       // option 67
 		"routers",             // option 3 (gateway)
+		"time_offset",         // option 2 (#262)
+		"posix_timezone",      // option 100 (#262)
+		"tzdb_timezone",       // option 101 (#262)
+		"wpad",                // option 252 (#262, requires the define below)
 	}
 	for _, v6 := range []bool{false, true} {
 		conf := renderConfig(dhcpcdParams{Iface: "eth0", MAC: mac, V6: v6})
@@ -322,6 +326,11 @@ func TestRenderConfig_RequestsPropagatedOptions(t *testing.T) {
 			if !strings.Contains(optLine, o) {
 				t.Errorf("v6=%v: option request line missing %q\n%s", v6, o, optLine)
 			}
+		}
+		// WPAD (252) is non-standard: dhcpcd rejects bare `option wpad`
+		// without an explicit define first (#262).
+		if !hasLine(conf, "define 252 string wpad") {
+			t.Errorf("v6=%v: config requests `wpad` but is missing `define 252 string wpad`:\n%s", v6, conf)
 		}
 	}
 }

--- a/pkg/udhcpc/event_builder.go
+++ b/pkg/udhcpc/event_builder.go
@@ -249,6 +249,16 @@ func BuildEvent(reason string, getenv Getenv) (Event, bool) {
 	event.Data.TFTPServer = getenv("new_tftp_server_name")
 	event.Data.BootFile = getenv("new_bootfile_name")
 
+	// Option 252 (WPAD URL), 100/101 (RFC 4833 timezone PCode/TCode) and
+	// the legacy option 2 (time offset, seconds from UTC) — observe-only,
+	// surfaced via plugin logs like TFTP/bootfile, never pushed into the
+	// container (#262). Raw string values; dhcpcd already validated the
+	// option types, so no parsing/guard is needed here.
+	event.Data.WPAD = getenv("new_wpad")
+	event.Data.PosixTimezone = getenv("new_posix_timezone")
+	event.Data.TZDBTimezone = getenv("new_tzdb_timezone")
+	event.Data.TimeOffset = getenv("new_time_offset")
+
 	// Option 26 (interface MTU). Best-effort: a garbage or non-positive
 	// value must not block IP propagation — the consumer treats 0 as
 	// "no MTU info".

--- a/pkg/udhcpc/event_builder_test.go
+++ b/pkg/udhcpc/event_builder_test.go
@@ -26,6 +26,10 @@ func TestBuildEvent_BoundV4_AllOptions(t *testing.T) {
 		"new_tftp_server_name":    "tftp.example.test",
 		"new_bootfile_name":       "pxelinux.0",
 		"new_interface_mtu":       "1400",
+		"new_wpad":                "http://wpad.corp.example/wpad.dat",
+		"new_posix_timezone":      "CET-1CEST,M3.5.0,M10.5.0/3",
+		"new_tzdb_timezone":       "Europe/Berlin",
+		"new_time_offset":         "3600",
 	})
 
 	got, emit := BuildEvent("BOUND", env)
@@ -35,19 +39,40 @@ func TestBuildEvent_BoundV4_AllOptions(t *testing.T) {
 	want := Event{
 		Type: "bound",
 		Data: Info{
-			IP:         "192.168.99.10/24",
-			Gateway:    "192.168.99.1",
-			Domain:     "corp.example",
-			DNSServers: []string{"192.168.99.53", "192.168.99.54"},
-			MTU:        1400,
-			NTPServers: []string{"192.168.99.123", "192.168.99.124"},
-			SearchList: []string{"corp.example", "internal.example"},
-			TFTPServer: "tftp.example.test",
-			BootFile:   "pxelinux.0",
+			IP:            "192.168.99.10/24",
+			Gateway:       "192.168.99.1",
+			Domain:        "corp.example",
+			DNSServers:    []string{"192.168.99.53", "192.168.99.54"},
+			MTU:           1400,
+			NTPServers:    []string{"192.168.99.123", "192.168.99.124"},
+			SearchList:    []string{"corp.example", "internal.example"},
+			TFTPServer:    "tftp.example.test",
+			BootFile:      "pxelinux.0",
+			WPAD:          "http://wpad.corp.example/wpad.dat",
+			PosixTimezone: "CET-1CEST,M3.5.0,M10.5.0/3",
+			TZDBTimezone:  "Europe/Berlin",
+			TimeOffset:    "3600",
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Event mismatch:\ngot:  %+v\nwant: %+v", got, want)
+	}
+}
+
+// TestBuildEvent_BoundV4_InformationalOptionsAbsent: the WPAD/timezone
+// extras (#262) are observe-only and optional — absent env vars leave
+// them empty, never blocking the event.
+func TestBuildEvent_BoundV4_InformationalOptionsAbsent(t *testing.T) {
+	got, emit := BuildEvent("BOUND", fakeEnv(map[string]string{
+		"new_ip_address":  "192.168.99.10",
+		"new_subnet_cidr": "24",
+		"new_routers":     "192.168.99.1",
+	}))
+	if !emit {
+		t.Fatalf("emit=false on a minimal BOUND event")
+	}
+	if got.Data.WPAD != "" || got.Data.PosixTimezone != "" || got.Data.TZDBTimezone != "" || got.Data.TimeOffset != "" {
+		t.Errorf("informational extras should be empty when unset, got %+v", got.Data)
 	}
 }
 

--- a/pkg/udhcpc/handler.go
+++ b/pkg/udhcpc/handler.go
@@ -44,6 +44,19 @@ type Info struct {
 	// var `new_bootfile_name`). Same surfacing semantics as TFTPServer.
 	BootFile string `json:",omitempty"`
 
+	// WPAD is the Web Proxy Auto-Discovery URL from DHCP option 252
+	// (dhcpcd env var `new_wpad`; option 252 is non-standard, so the
+	// config `define`s it). PosixTimezone / TZDBTimezone come from the
+	// RFC 4833 timezone options 100 (PCode, `new_posix_timezone`) and
+	// 101 (TCode, `new_tzdb_timezone`); TimeOffset is the legacy option 2
+	// (seconds from UTC, `new_time_offset`). All observe-only, like
+	// TFTPServer/BootFile: surfaced to operators via plugin logs, never
+	// pushed into the container (the no-plumbing bar, #262).
+	WPAD          string `json:",omitempty"`
+	PosixTimezone string `json:",omitempty"`
+	TZDBTimezone  string `json:",omitempty"`
+	TimeOffset    string `json:",omitempty"`
+
 	// Routes are the classless static routes from DHCP option 121
 	// (RFC 3442, dhcpcd env var `new_classless_static_routes`). v4 only —
 	// DHCPv6 carries no route option (routes come from RAs). Empty when

--- a/test/integration/extra_options_test.go
+++ b/test/integration/extra_options_test.go
@@ -124,3 +124,54 @@ func TestExtraOptions_NTPAndTFTPLogged(t *testing.T) {
 	t.Errorf("plugin log did not surface NTP=%s / TFTP=%s within 5s",
 		harness.TestNTPServer, harness.TestTFTPServer)
 }
+
+// TestExtraOptions_WPADAndTimezoneLogged is the #262 round-trip: the
+// fixture advertises WPAD (252), RFC 4833 timezone (100/101) and the
+// legacy time offset (2); dhcpcd must request and export them (under
+// its real names posix_timezone/tzdb_timezone — NOT pcode/tcode — and
+// via the `define`d wpad), and the plugin must surface them in the
+// "DHCP options received" log line. Observe-only: nothing is applied to
+// the container. Proves the dhcpcd option names are correct end-to-end.
+func TestExtraOptions_WPADAndTimezoneLogged(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-extra-wpad"
+	ctrName := "dh-itest-extra-wpad-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", nil)
+	harness.RunContainer(t, ctx, netName, ctrName)
+
+	want := []string{harness.TestWPAD, harness.TestPosixTZ, harness.TestTZDBTZ, harness.TestTimeOffset}
+	deadline := time.Now().Add(5 * time.Second)
+	var got string
+	for time.Now().Before(deadline) {
+		got = harness.ReadPluginLog(t, ctx)
+		if strings.Contains(got, "DHCP options received") && containsAll(got, want) {
+			t.Logf("plugin log surfaced WPAD/timezone extras: %v", want)
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("plugin log did not surface %q within 5s", w)
+		}
+	}
+}
+
+func containsAll(haystack string, needles []string) bool {
+	for _, n := range needles {
+		if !strings.Contains(haystack, n) {
+			return false
+		}
+	}
+	return true
+}

--- a/test/integration/harness/fixture.go
+++ b/test/integration/harness/fixture.go
@@ -100,6 +100,24 @@ const (
 	TestTFTPServer = "tftp.example.test"
 	TestBootFile   = "pxelinux.0"
 
+	// TestWPAD / TestPosixTZ / TestTZDBTZ / TestTimeOffset are the
+	// observe-only informational extras the fixture advertises (#262),
+	// surfaced via the plugin log like NTP/TFTP:
+	//   - 252 (WPAD URL)       — Info.WPAD
+	//   - 100 (RFC 4833 PCode) — Info.PosixTimezone (dhcpcd: posix_timezone)
+	//   - 101 (RFC 4833 TCode) — Info.TZDBTimezone  (dhcpcd: tzdb_timezone)
+	//   - 2   (time offset, s) — Info.TimeOffset
+	// Recognisably test-only values.
+	// TestPosixTZ is deliberately comma-free: dnsmasq's --dhcp-option
+	// treats commas as value separators, and a full POSIX TZ with DST
+	// rules (CET-1CEST,M3.5.0,...) would be split. This is a valid
+	// comma-free POSIX TZ; the test exercises option plumbing, not TZ
+	// syntax.
+	TestWPAD       = "http://wpad.corp.example/wpad.dat"
+	TestPosixTZ    = "PST8PDT"
+	TestTZDBTZ     = "Europe/Berlin"
+	TestTimeOffset = "3600"
+
 	// TestVendorClass / TestTaggedGateway drive the v0.9.0 / T2-3
 	// vendor_class round-trip test. dnsmasq is configured to set tag
 	// `dh-itest-vc` for clients sending option 60 = TestVendorClass,
@@ -266,6 +284,13 @@ func (f *Fixture) startDnsmasq() error {
 		"--dhcp-option=66,"+TestTFTPServer,  // option 66: TFTP server name
 		"--dhcp-option=67,"+TestBootFile,    // option 67: boot file
 		"--dhcp-option=119,"+TestSearchList, // option 119: domain search list
+		// Observe-only informational extras (#262): surfaced in the plugin
+		// log, never applied to the container. Sent when the client
+		// requests them (dhcpcd's option list now does).
+		"--dhcp-option=2,"+TestTimeOffset, // option 2: time offset (seconds)
+		"--dhcp-option=100,"+TestPosixTZ,  // option 100: RFC 4833 PCode
+		"--dhcp-option=101,"+TestTZDBTZ,   // option 101: RFC 4833 TCode
+		"--dhcp-option=252,"+TestWPAD,     // option 252: WPAD URL
 		// Vendor-class tagging for the v0.9.0 / T2-3 round-trip test.
 		// dnsmasq sets tag `dh-itest-vc` on any DISCOVER carrying
 		// option 60 = TestVendorClass; the matching tag:... rule then


### PR DESCRIPTION
## What

Surfaces three more server-advertised DHCP options on the bound event and in the plugin's "DHCP options received" info log, **observe-only** — nothing is injected into the container (same posture as the existing NTP/TFTP/boot-file surfacing):

- **WPAD** (option 252) — web-proxy auto-discovery URL
- **RFC 4833 timezone** — POSIX TZ (option 100) and TZDB name (option 101)
- **Legacy time offset** (option 2)

## Why the dhcpcd option names matter

The issue assumed `new_pcode` / `new_tcode`. **Verified against dhcpcd 10.x that those are wrong and would be a fatal config error** — the real exported names are `posix_timezone` (100) and `tzdb_timezone` (101), and WPAD (252) is non-standard so it needs an explicit `define 252 string wpad`. The integration test pins these names end-to-end so a future dhcpcd change can't silently break them.

## Changes

- `pkg/udhcpc/dhcpcd.go` — `define 252 string wpad`; request `time_offset, posix_timezone, tzdb_timezone, wpad`. (Also folds in a gofmt fix for #261's struct-field alignment that had left dev's Test check red.)
- `pkg/udhcpc/handler.go`, `event_builder.go` — carry `WPAD/PosixTimezone/TZDBTimezone/TimeOffset` on the event.
- `pkg/plugin/dhcp_manager.go` — extend the info log line + fields.
- `test/integration/extra_options_test.go` + `harness/fixture.go` — `TestExtraOptions_WPADAndTimezoneLogged` round-trips all four via dnsmasq, proving the dhcpcd names are correct.
- `docs/parent-attached-modes.md` — document the newly observed options.

Observe-only by design — respects the no-container-plumbing bar.

Closes #262