### PR TITLE
refactor: rename pkg/udhcpc → pkg/dhcp, cmd/udhcpc-handler → cmd/dhcp-handler (#245)

### DIFF
--- a/.github/coverage-baseline.txt
+++ b/.github/coverage-baseline.txt
@@ -40,8 +40,14 @@
 #   - pkg/udhcpc / cmd/net-dhcp left at floor: their +0.3/+0.4 this run
 #     is integration run-to-run variance, not earned by this PR (no
 #     udhcpc/cmd code or tests changed) — not ratcheted.
+#
+# v1.3.0 (#245): pkg/udhcpc → pkg/dhcp and cmd/udhcpc-handler →
+#   cmd/dhcp-handler (post-dhcpcd misnomer rename, no code change).
+#   Floors carry over unchanged under the new import paths; the
+#   historical decision notes above keep the names they had at the
+#   time. Same code, same floors.
 github.com/devplayer0/docker-net-dhcp/pkg/util 88.0
 github.com/devplayer0/docker-net-dhcp/pkg/plugin 82.0
-github.com/devplayer0/docker-net-dhcp/pkg/udhcpc 85.5
+github.com/devplayer0/docker-net-dhcp/pkg/dhcp 85.5
 github.com/devplayer0/docker-net-dhcp/cmd/net-dhcp 75.0
-github.com/devplayer0/docker-net-dhcp/cmd/udhcpc-handler 50.0
+github.com/devplayer0/docker-net-dhcp/cmd/dhcp-handler 50.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,7 +61,7 @@ jobs:
         run: |
           for target in FuzzBuildEvent FuzzEventUnmarshal; do
             echo "::group::${target}"
-            go test ./pkg/udhcpc/ -run '^$' -fuzz "^${target}$" -fuzztime 20s
+            go test ./pkg/dhcp/ -run '^$' -fuzz "^${target}$" -fuzztime 20s
             echo "::endgroup::"
           done
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,6 @@ RUN mkdir -p /run/docker/plugins /var/lib/net-dhcp && \
         iproute2=7.0.0-r0
 
 COPY --from=builder /usr/local/src/docker-net-dhcp/bin/net-dhcp /usr/sbin/
-COPY --from=builder /usr/local/src/docker-net-dhcp/bin/udhcpc-handler /usr/lib/net-dhcp/udhcpc-handler
+COPY --from=builder /usr/local/src/docker-net-dhcp/bin/dhcp-handler /usr/lib/net-dhcp/dhcp-handler
 
 ENTRYPOINT ["/usr/sbin/net-dhcp"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,9 +25,9 @@ networking, and the Docker socket mounted. Reports are especially
 welcome for:
 
 - container → host or container → plugin escapes through the netns /
-  mount-ns handling (`pkg/plugin`, `pkg/udhcpc`);
+  mount-ns handling (`pkg/plugin`, `pkg/dhcp`);
 - parsing of untrusted DHCP-server responses (the `dhcpcd` hook-event
-  path: `cmd/udhcpc-handler`, `pkg/udhcpc.BuildEvent`, lease/option
+  path: `cmd/dhcp-handler`, `pkg/dhcp.BuildEvent`, lease/option
   propagation into containers);
 - anything that lets one container influence another container's
   lease, address, or DNS (cross-endpoint identity confusion).
@@ -71,7 +71,7 @@ attacker tampering with distributed images.
 
 **Mitigations and why they suffice.**
 - *Memory safety / injection:* the plugin is written in Go (memory-safe)
-  and the untrusted DHCP-response parsers (`pkg/udhcpc.BuildEvent`, the
+  and the untrusted DHCP-response parsers (`pkg/dhcp.BuildEvent`, the
   handler-pipe JSON decoder) have native fuzz targets plus seed corpora
   run on every PR, so malformed server input is exercised, not assumed
   safe.

--- a/cmd/dhcp-handler/main.go
+++ b/cmd/dhcp-handler/main.go
@@ -6,14 +6,14 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/devplayer0/docker-net-dhcp/pkg/udhcpc"
+	"github.com/devplayer0/docker-net-dhcp/pkg/dhcp"
 )
 
 // main is a thin shim invoked by dhcpcd as its --script hook on every
 // network event. dhcpcd passes the event in the $reason environment
 // variable (not argv) along with the lease as new_*/old_* variables;
 // the env-parsing logic that turns those into a structured Event lives
-// in pkg/udhcpc.BuildEvent so it can be unit-tested without involving
+// in pkg/dhcp.BuildEvent so it can be unit-tested without involving
 // os.Setenv / os.Exit. Anything more than reason lookup, getenv
 // passthrough, FIFO selection, and JSON encoding belongs in the library.
 //
@@ -23,7 +23,7 @@ import (
 // channel (it's /dev/null once dhcpcd daemonises and is interleaved
 // with dhcpcd's own log in foreground), so events go to the FIFO whose
 // path the plugin passes in via the dhcpcd `env` directive
-// (udhcpc.EventFIFOEnv). When that var is unset we fall back to stdout
+// (dhcp.EventFIFOEnv). When that var is unset we fall back to stdout
 // so the handler stays runnable by hand for debugging.
 func main() {
 	reason := os.Getenv("reason")
@@ -32,13 +32,13 @@ func main() {
 		return
 	}
 
-	event, emit := udhcpc.BuildEvent(reason, os.Getenv)
+	event, emit := dhcp.BuildEvent(reason, os.Getenv)
 	if !emit {
 		return
 	}
 
 	out := os.Stdout
-	if fifo := os.Getenv(udhcpc.EventFIFOEnv); fifo != "" {
+	if fifo := os.Getenv(dhcp.EventFIFOEnv); fifo != "" {
 		// The plugin holds the read end open (O_RDWR), so this open
 		// succeeds immediately. One short JSON line per event; close
 		// after writing so the line is flushed and we don't hold the

--- a/pkg/dhcp/client.go
+++ b/pkg/dhcp/client.go
@@ -1,4 +1,4 @@
-package udhcpc
+package dhcp
 
 import (
 	"bufio"
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	DefaultHandler = "/usr/lib/net-dhcp/udhcpc-handler"
+	DefaultHandler = "/usr/lib/net-dhcp/dhcp-handler"
 	VendorID       = "docker-net-dhcp"
 
 	// dhcpcdStateDir is dhcpcd's compile-time database directory (DUID +

--- a/pkg/dhcp/client_test.go
+++ b/pkg/dhcp/client_test.go
@@ -1,4 +1,4 @@
-package udhcpc
+package dhcp
 
 import (
 	"os"

--- a/pkg/dhcp/dhcpcd.go
+++ b/pkg/dhcp/dhcpcd.go
@@ -1,4 +1,4 @@
-package udhcpc
+package dhcp
 
 import (
 	"encoding/binary"
@@ -147,7 +147,7 @@ func renderConfig(p dhcpcdParams) string {
 	}
 
 	// Forward GOCOVERDIR to the hook in the coverage-instrumented build
-	// so cmd/udhcpc-handler's `-cover` counters are written and merged.
+	// so cmd/dhcp-handler's `-cover` counters are written and merged.
 	// dhcpcd scrubs the environment, so — like the FIFO above — it has to
 	// ride the `env` directive; otherwise the handler (a separate process
 	// dhcpcd execs per event) loses GOCOVERDIR and emits nothing, and the

--- a/pkg/dhcp/dhcpcd_test.go
+++ b/pkg/dhcp/dhcpcd_test.go
@@ -1,4 +1,4 @@
-package udhcpc
+package dhcp
 
 import (
 	"net"
@@ -339,12 +339,12 @@ func TestRenderArgs_OneShotV4(t *testing.T) {
 	got := renderArgs(dhcpcdParams{
 		Iface:      "eth0",
 		Once:       true,
-		Handler:    "/usr/lib/net-dhcp/udhcpc-handler",
+		Handler:    "/usr/lib/net-dhcp/dhcp-handler",
 		ConfigPath: "/run/net-dhcp/eth0-v4.conf",
 	})
 	want := []string{
 		"dhcpcd", "-B", "--noconfigure", "-L", "-A",
-		"-c", "/usr/lib/net-dhcp/udhcpc-handler",
+		"-c", "/usr/lib/net-dhcp/dhcp-handler",
 		"-f", "/run/net-dhcp/eth0-v4.conf",
 		"-1", "-p", "-4", "eth0",
 	}

--- a/pkg/dhcp/event_builder.go
+++ b/pkg/dhcp/event_builder.go
@@ -1,4 +1,4 @@
-package udhcpc
+package dhcp
 
 import (
 	"net"

--- a/pkg/dhcp/event_builder_test.go
+++ b/pkg/dhcp/event_builder_test.go
@@ -1,4 +1,4 @@
-package udhcpc
+package dhcp
 
 import (
 	"reflect"

--- a/pkg/dhcp/fuzz_test.go
+++ b/pkg/dhcp/fuzz_test.go
@@ -1,4 +1,4 @@
-package udhcpc
+package dhcp
 
 import (
 	"encoding/json"
@@ -79,7 +79,7 @@ func FuzzBuildEvent(f *testing.F) {
 }
 
 // FuzzEventUnmarshal exercises the other untrusted boundary: the
-// newline-delimited JSON the udhcpc-handler binary writes into the
+// newline-delimited JSON the dhcp-handler binary writes into the
 // event pipe, which DHCPClient.Start decodes one line at a time
 // (client.go: json.Unmarshal(scanner.Bytes(), &event)). The bytes
 // cross a process boundary, so the decoder must tolerate any input

--- a/pkg/dhcp/handler.go
+++ b/pkg/dhcp/handler.go
@@ -1,4 +1,4 @@
-package udhcpc
+package dhcp
 
 type Info struct {
 	IP      string

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -15,7 +15,7 @@ import (
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 
-	"github.com/devplayer0/docker-net-dhcp/pkg/udhcpc"
+	"github.com/devplayer0/docker-net-dhcp/pkg/dhcp"
 	"github.com/devplayer0/docker-net-dhcp/pkg/util"
 )
 
@@ -293,7 +293,7 @@ func (m *dhcpManager) findContainerPID(ctx context.Context) (int, error) {
 	return 0, fmt.Errorf("endpoint %s not found in network %s container list", shortID(m.joinReq.EndpointID), shortID(m.joinReq.NetworkID))
 }
 
-func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
+func (m *dhcpManager) renew(v6 bool, info dhcp.Info) error {
 	v4, v6Last := m.lastIPs()
 	lastIP := v4
 	if v6 {
@@ -318,7 +318,7 @@ func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
 			WithFields(m.logFields(v6)).
 			WithField("old_ip", lastIP).
 			WithField("new_ip", ip).
-			Warn("udhcpc renew with changed IP — Docker's view is now stale")
+			Warn("dhcp renew with changed IP — Docker's view is now stale")
 
 		// Apply the re-acquired lease to the link. Found by
 		// TestFailure_LeaseRefusedOnRenewal (#128): without this the
@@ -431,7 +431,7 @@ func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
 	}
 
 	// Apply DHCP option 26 (Interface MTU) when both opt-in and
-	// non-zero. Skipping zero is mandatory: udhcpc-handler emits 0
+	// non-zero. Skipping zero is mandatory: dhcp-handler emits 0
 	// when the server didn't supply the option, and forcing MTU 0
 	// on a kernel link is undefined / disallowed.
 	if m.opts.PropagateMTU && info.MTU > 0 {
@@ -475,7 +475,7 @@ func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
 			log.
 				WithFields(m.logFields(v6)).
 				WithField("gateway", newGateway).
-				Info("udhcpc renew adding default route")
+				Info("dhcp renew adding default route")
 
 			if err := m.netHandle.RouteAdd(&netlink.Route{
 				LinkIndex: m.ctrLink.Attrs().Index,
@@ -488,7 +488,7 @@ func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
 				WithFields(m.logFields(v6)).
 				WithField("old_gateway", routes[0].Gw).
 				WithField("new_gateway", newGateway).
-				Info("udhcpc renew replacing default route")
+				Info("dhcp renew replacing default route")
 
 			routes[0].Gw = newGateway
 			if err := m.netHandle.RouteReplace(&routes[0]); err != nil {
@@ -518,7 +518,7 @@ func bumpFamily(total, v6Counter *atomic.Int32, v6 bool) {
 	}
 }
 
-func (m *dhcpManager) handleEvent(event udhcpc.Event, v6 bool) {
+func (m *dhcpManager) handleEvent(event dhcp.Event, v6 bool) {
 	switch event.Type {
 	// "deconfig" is intentionally not handled. Deleting the
 	// container's IP from the kernel would also wipe the
@@ -548,7 +548,7 @@ func (m *dhcpManager) handleEvent(event udhcpc.Event, v6 bool) {
 	case "renew":
 		log.
 			WithFields(m.logFields(v6)).
-			Debug("udhcpc renew")
+			Debug("dhcp renew")
 
 		if m.plugin != nil {
 			bumpFamily(&m.plugin.leasesRenewed, &m.plugin.leasesRenewedV6, v6)
@@ -566,12 +566,12 @@ func (m *dhcpManager) handleEvent(event udhcpc.Event, v6 bool) {
 		if m.plugin != nil {
 			bumpFamily(&m.plugin.dhcpTimeouts, &m.plugin.dhcpTimeoutsV6, v6)
 		}
-		log.WithFields(m.logFields(v6)).Warn("udhcpc failed to get a lease")
+		log.WithFields(m.logFields(v6)).Warn("dhcp failed to get a lease")
 	case "nak":
 		if m.plugin != nil {
 			bumpFamily(&m.plugin.naksReceived, &m.plugin.naksReceivedV6, v6)
 		}
-		log.WithFields(m.logFields(v6)).Warn("udhcpc client received NAK")
+		log.WithFields(m.logFields(v6)).Warn("dhcp client received NAK")
 	}
 }
 
@@ -609,7 +609,7 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 			preferredV6 = v6Addr.IP.String()
 		}
 	}
-	client, err := udhcpc.NewDHCPClient(m.ctrLink.Attrs().Name, &udhcpc.DHCPClientOptions{
+	client, err := dhcp.NewDHCPClient(m.ctrLink.Attrs().Name, &dhcp.DHCPClientOptions{
 		Hostname:  m.hostname,
 		FQDN:      m.opts.fqdnMode(),
 		V6:        v6,
@@ -675,14 +675,14 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 				if !ok {
 					// dhcpcd exited on its own (NAK, parent NIC vanished,
 					// container netns torn down out from under us, etc.).
-					// The scanner goroutine in udhcpc.Start closes events
+					// The scanner goroutine in dhcp.Start closes events
 					// when its read pipe hits EOF. Without this branch,
 					// `<-events` on a closed channel returns the zero
 					// Event{} every iteration, the switch matches nothing,
 					// and we burn a CPU thread forever.
 					log.
 						WithFields(m.logFields(v6)).
-						Warn("udhcpc event stream closed; client process exited")
+						Warn("dhcp event stream closed; client process exited")
 
 					// Reap the child so it doesn't linger as a zombie:
 					// cmd.Wait must be called exactly once per process,
@@ -693,7 +693,7 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 						log.
 							WithError(err).
 							WithFields(m.logFields(v6)).
-							Debug("udhcpc reap returned error")
+							Debug("dhcp reap returned error")
 					}
 					reapCancel()
 

--- a/pkg/plugin/dhcp_manager_test.go
+++ b/pkg/plugin/dhcp_manager_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/vishvananda/netlink"
 
-	"github.com/devplayer0/docker-net-dhcp/pkg/udhcpc"
+	"github.com/devplayer0/docker-net-dhcp/pkg/dhcp"
 )
 
 // TestRenew_LeaseChangedCounter pins the v0.9.0 / T1-4 counter
@@ -32,7 +32,7 @@ func TestRenew_LeaseChangedCounter(t *testing.T) {
 		m := &dhcpManager{plugin: p}
 		m.setLastIP(false, addr1)
 
-		if err := m.renew(false, udhcpc.Info{IP: addr2.String()}); err != nil {
+		if err := m.renew(false, dhcp.Info{IP: addr2.String()}); err != nil {
 			t.Fatalf("renew: %v", err)
 		}
 
@@ -46,7 +46,7 @@ func TestRenew_LeaseChangedCounter(t *testing.T) {
 		m := &dhcpManager{plugin: p}
 		m.setLastIP(false, addr1)
 
-		if err := m.renew(false, udhcpc.Info{IP: addr1.String()}); err != nil {
+		if err := m.renew(false, dhcp.Info{IP: addr1.String()}); err != nil {
 			t.Fatalf("renew: %v", err)
 		}
 
@@ -65,7 +65,7 @@ func TestRenew_LeaseChangedCounter(t *testing.T) {
 		m := &dhcpManager{plugin: p}
 		// no setLastIP — lastIP is nil
 
-		if err := m.renew(false, udhcpc.Info{IP: addr1.String()}); err != nil {
+		if err := m.renew(false, dhcp.Info{IP: addr1.String()}); err != nil {
 			t.Fatalf("renew: %v", err)
 		}
 
@@ -79,7 +79,7 @@ func TestRenew_LeaseChangedCounter(t *testing.T) {
 		m := &dhcpManager{plugin: p}
 		m.setLastIP(true, addr1)
 
-		if err := m.renew(true, udhcpc.Info{IP: addr2.String()}); err != nil {
+		if err := m.renew(true, dhcp.Info{IP: addr2.String()}); err != nil {
 			t.Fatalf("renew: %v", err)
 		}
 
@@ -96,7 +96,7 @@ func TestRenew_LeaseChangedCounter(t *testing.T) {
 		m := &dhcpManager{plugin: p}
 		m.setLastIP(false, addr1)
 
-		if err := m.renew(false, udhcpc.Info{IP: addr2.String()}); err != nil {
+		if err := m.renew(false, dhcp.Info{IP: addr2.String()}); err != nil {
 			t.Fatalf("renew: %v", err)
 		}
 
@@ -115,7 +115,7 @@ func TestRenew_LeaseChangedCounter(t *testing.T) {
 		m := &dhcpManager{plugin: nil}
 		m.setLastIP(false, addr1)
 
-		if err := m.renew(false, udhcpc.Info{IP: addr2.String()}); err != nil {
+		if err := m.renew(false, dhcp.Info{IP: addr2.String()}); err != nil {
 			t.Fatalf("renew: %v", err)
 		}
 	})
@@ -156,7 +156,7 @@ func TestHandleEvent_Counters(t *testing.T) {
 				m := &dhcpManager{plugin: p}
 				m.setLastIP(v6, addr)
 
-				m.handleEvent(udhcpc.Event{Type: c.event, Data: udhcpc.Info{IP: addr.String()}}, v6)
+				m.handleEvent(dhcp.Event{Type: c.event, Data: dhcp.Info{IP: addr.String()}}, v6)
 
 				if got := c.aggregate(p); got != 1 {
 					t.Errorf("%s aggregate = %d, want 1", c.event, got)
@@ -176,7 +176,7 @@ func TestHandleEvent_Counters(t *testing.T) {
 		p := &Plugin{}
 		m := &dhcpManager{plugin: p}
 		for _, evt := range []string{"deconfig", "something-new"} {
-			m.handleEvent(udhcpc.Event{Type: evt}, false)
+			m.handleEvent(dhcp.Event{Type: evt}, false)
 		}
 		total := p.leasesObtained.Load() + p.leasesRenewed.Load() +
 			p.dhcpTimeouts.Load() + p.naksReceived.Load()
@@ -189,7 +189,7 @@ func TestHandleEvent_Counters(t *testing.T) {
 		m := &dhcpManager{plugin: nil}
 		m.setLastIP(false, addr)
 		for _, evt := range []string{"bound", "renew", "leasefail", "nak", "deconfig"} {
-			m.handleEvent(udhcpc.Event{Type: evt, Data: udhcpc.Info{IP: addr.String()}}, false)
+			m.handleEvent(dhcp.Event{Type: evt, Data: dhcp.Info{IP: addr.String()}}, false)
 		}
 	})
 }

--- a/pkg/plugin/dhcp_probe.go
+++ b/pkg/plugin/dhcp_probe.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
-	"github.com/devplayer0/docker-net-dhcp/pkg/udhcpc"
+	"github.com/devplayer0/docker-net-dhcp/pkg/dhcp"
 	"github.com/devplayer0/docker-net-dhcp/pkg/util"
 )
 
@@ -39,7 +39,7 @@ const preflightProbeBudget = 5 * time.Second
 //     share the parent MAC, which would clash with the random probe
 //     MAC, and the probe goal (verifying DHCP reachability of the
 //     parent) is mode-agnostic.
-//  3. Bring it up and run udhcpc.GetIP one-shot with the probe budget.
+//  3. Bring it up and run dhcp.GetIP one-shot with the probe budget.
 //     dhcpcd has no DISCOVER-only flag; we accept the full DORA and
 //     let the upstream server briefly hold a lease that times out
 //     naturally (no `release` directive sent). The cost is one
@@ -98,7 +98,7 @@ func runDHCPProbe(ctx context.Context, parent string) error {
 	probeCtx, cancel := context.WithTimeout(ctx, preflightProbeBudget)
 	defer cancel()
 
-	info, err := udhcpc.GetIP(probeCtx, probeName, &udhcpc.DHCPClientOptions{
+	info, err := dhcp.GetIP(probeCtx, probeName, &dhcp.DHCPClientOptions{
 		// MAC is the probe link's (random) address; dhcpcd derives its
 		// DUID-LL from it. Identity-neutral otherwise:
 		// Hostname intentionally empty — the probe shouldn't

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -16,7 +16,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
-	"github.com/devplayer0/docker-net-dhcp/pkg/udhcpc"
+	"github.com/devplayer0/docker-net-dhcp/pkg/dhcp"
 	"github.com/devplayer0/docker-net-dhcp/pkg/util"
 )
 
@@ -564,7 +564,7 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 			timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 			defer cancel()
 
-			clientOpts := &udhcpc.DHCPClientOptions{
+			clientOpts := &dhcp.DHCPClientOptions{
 				V6:          v6,
 				Hostname:    hostname,
 				FQDN:        opts.fqdnMode(),
@@ -584,7 +584,7 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 			} else {
 				clientOpts.RequestedIP = requestedIP
 			}
-			info, err := udhcpc.GetIP(timeoutCtx, ctrName, clientOpts)
+			info, err := dhcp.GetIP(timeoutCtx, ctrName, clientOpts)
 			if err != nil {
 				return fmt.Errorf("failed to get initial IP%v address via DHCP%v: %w", v6str, v6str, err)
 			}
@@ -754,11 +754,11 @@ func (p *Plugin) DeleteEndpoint(ctx context.Context, r DeleteEndpointRequest) er
 }
 
 // dhcpStaticRoutes converts DHCP option-121 classless static routes
-// (udhcpc.Route, captured at CreateEndpoint) into libnetwork
+// (dhcp.Route, captured at CreateEndpoint) into libnetwork
 // StaticRoute responses. An empty Gateway means the route is on-link
 // (dhcpcd reported the gateway as 0.0.0.0); otherwise it is a next-hop
 // route. Destinations are already canonical CIDRs from the parser.
-func dhcpStaticRoutes(routes []udhcpc.Route) []*StaticRoute {
+func dhcpStaticRoutes(routes []dhcp.Route) []*StaticRoute {
 	out := make([]*StaticRoute, 0, len(routes))
 	for _, r := range routes {
 		sr := &StaticRoute{Destination: r.Destination, RouteType: RouteTypeOnLink}

--- a/pkg/plugin/network_test.go
+++ b/pkg/plugin/network_test.go
@@ -5,12 +5,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/devplayer0/docker-net-dhcp/pkg/udhcpc"
+	"github.com/devplayer0/docker-net-dhcp/pkg/dhcp"
 	"github.com/devplayer0/docker-net-dhcp/pkg/util"
 )
 
 func TestDHCPStaticRoutes(t *testing.T) {
-	got := dhcpStaticRoutes([]udhcpc.Route{
+	got := dhcpStaticRoutes([]dhcp.Route{
 		{Destination: "10.0.0.0/8", Gateway: "192.168.99.2"}, // next-hop
 		{Destination: "172.16.0.0/12"},                       // on-link (empty gateway)
 	})

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -23,7 +23,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
-	"github.com/devplayer0/docker-net-dhcp/pkg/udhcpc"
+	"github.com/devplayer0/docker-net-dhcp/pkg/dhcp"
 	"github.com/devplayer0/docker-net-dhcp/pkg/util"
 )
 
@@ -228,7 +228,7 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 			tCtx, cancel := context.WithTimeout(ctx, timeout)
 			defer cancel()
 
-			clientOpts := &udhcpc.DHCPClientOptions{
+			clientOpts := &dhcp.DHCPClientOptions{
 				V6:          v6,
 				Hostname:    hostname,
 				FQDN:        opts.fqdnMode(),
@@ -248,7 +248,7 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 			} else {
 				clientOpts.RequestedIP = requestedIP
 			}
-			info, err := udhcpc.GetIP(tCtx, la.Name, clientOpts)
+			info, err := dhcp.GetIP(tCtx, la.Name, clientOpts)
 			if err != nil {
 				return fmt.Errorf("failed to get initial IP%v address via DHCP%v: %w", v6str, v6str, err)
 			}

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -6,7 +6,7 @@ real parent NIC (one end of a veth pair), a real DHCP server (host
 through libnetwork. These cover the integration surface that `go
 test` can't reach without privileges — `CreateEndpoint`, `Join`,
 `Leave`, `recoverEndpoints`, `dhcpManager.{Start,Stop}`,
-parent-attached link wiring, `udhcpc.{Start,Finish,Wait,GetIP}`.
+parent-attached link wiring, `dhcp.{Start,Finish,Wait,GetIP}`.
 
 ## Running locally
 

--- a/test/integration/failure_test.go
+++ b/test/integration/failure_test.go
@@ -12,7 +12,7 @@
 // minutes — they are split out of the main suite into
 // `make integration-test-failure` (second CI step).
 //
-// dhcpcd timing facts the asserts below lean on (see pkg/udhcpc):
+// dhcpcd timing facts the asserts below lean on (see pkg/dhcp):
 //   - a dead server produces NO event at T1/T2 (dhcpcd retries silently
 //     while re-discovering); the first internal "leasefail" comes from
 //     dhcpcd's EXPIRE when the bound lease finally lapses (at expiry),


### PR DESCRIPTION
## What

Post-#152 (busybox→dhcpcd) the `udhcpc` names are misnomers. Rename to **client-agnostic** names so the package isn't tied to a concrete client again (the whole lesson of `udhcpc`):

- `pkg/udhcpc` → `pkg/dhcp` (package decl, import paths, `udhcpc.` qualifiers)
- `cmd/udhcpc-handler` → `cmd/dhcp-handler` (dir, built binary, image path `/usr/lib/net-dhcp/dhcp-handler`, `DefaultHandler` const, Dockerfile `COPY`)

## Also updated to stay coherent

- **Runtime log strings** (`"udhcpc renew"` → `"dhcp renew"`, etc.) — these were misnomers too. Verified **no test/script greps them**, so this is safe.
- **Functional CI refs** a naive rename would silently break:
  - the fuzz workflow path → `go test ./pkg/dhcp/` (verified both targets resolve)
  - `.github/coverage-baseline.txt` ratchet keys → new import paths (+ a v1.3.0 rename note; floors carry over unchanged)
- Current-state docs: `SECURITY.md`, `test/integration/README.md`.

## Deliberately left as-is

- Historical `busybox udhcpc/udhcpc6` comments — accurate history of the pre-#152 client.
- `RELEASE_NOTES.md` — frozen per-release changelog; its `pkg/udhcpc` names were correct for those releases.

## Impact

Pure internal refactor — no wire, plugin-manifest (`config.json`), state/tombstone, or upgrade impact (the handler path is internal to the image, passed to dhcpcd via `-c`). Verified locally: gofmt clean, `go build ./...`, `go vet` (incl. integration tags), `go test ./...`, fuzz targets, and coverage-ratchet self-test all green.

Closes #245