### PR TITLE
feat(ipvlan): stable DHCP client-id for lease stability across recreate (#219)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -151,6 +151,8 @@ Passed as `-o key=value` on `docker network create`, or under
 | `propagate_mtu` | all | `false` | v0.9.0 | Apply DHCP option 26 (Interface MTU) to the container link on bind/renew. For jumbo-frame (9000) and VPN-reduced (~1450) networks. |
 | `client_id` | all | per-endpoint id | v0.9.0 | Override DHCP option 61 (Client Identifier) for every endpoint on this network; sent as RFC 2132 opaque bytes (type `0x00`). The default per-endpoint id is what makes per-container reservations work — a fixed `client_id` makes all containers look like one client to the server. Pair with `vendor_class` for class-based policy. |
 | `vendor_class` | all | `docker-net-dhcp` | v0.9.0 | Override DHCP option 60 (Vendor Class Identifier), for DHCP servers running class-based policy (different gateway/option sets per class). v4 only — the DHCPv6 client sends no vendor-class option. |
+| `stable_lease` | ipvlan | `false` | v1.3.0 | Derive the DHCP option-61 client-id from the container's **stable identity** instead of the per-recreate endpoint id, so a server that keys leases on the client-id (dnsmasq does by default) hands the same container the same IP across `stop` / `rm` / recreate. ipvlan-only: ipvlan children share the parent's MAC, so the client-id is the only per-container handle — bridge/macvlan reject this option (their lease stability is delivered by the deterministic-MAC work, not yet available). Identity is taken from, most-specific first: `lease_seed`, then Compose `project`+`service`+`container-number`, then the container `--name`. An anonymous container (none of these) falls back to the endpoint-derived id and bumps `stable_lease_no_identity` on `/Plugin.Health`. See below. |
+| `lease_seed` | ipvlan | *(none)* | v1.3.0 | Explicit highest-precedence identity for `stable_lease`: the derived client-id is a hash of the network plus this value, so two containers sharing a `lease_seed` on one network collapse onto one lease, and one container keeps its lease across recreate regardless of name or Compose labels. Only consulted when `stable_lease=true` (inert otherwise). |
 | `validate_dhcp` | macvlan, ipvlan | `false` | v0.9.0 | Pre-flight probe at `docker network create`: one-shot DHCP exchange on the parent with a random locally-administered MAC, rejecting the network if no server answers within 5s. Catches isolated parents / blocked UDP 67-68 / broken VLAN tags at create time. Costs one transient lease per probe. Bridge mode rejects the option. |
 | `register_dns` | all | `false` | v1.3.0 | Send the DHCP FQDN option (81 on v4 / 39 on v6, via `dhcpcd fqdn both`) built from the container's hostname, asking the DHCP server to register that name in DNS (forward A/AAAA + reverse PTR). Reuses the same hostname already sent as the option-12 hint. Best-effort and advisory — many consumer routers ignore option 81, so this *requests* registration, it does not guarantee resolution. Off by default: dynamic-DNS registration is a network-policy decision. See below. |
 | `audit_log` | all | `false` | v1.0.0 | Append every lease-lifecycle event (`bound` / `renew` / `release` / `release_failed`) to `STATE_DIR/leases.jsonl` — one JSON object per line with timestamp, network, endpoint, container, hostname, IP, MAC. Rotated at 16 MB or 30 days (one rotated generation kept, ≤ ~32 MB total). Append failures bump `ledger_write_failures` on `/Plugin.Health`, never affecting lease handling. Off by default: per-event disk write, and container↔IP correlation on disk is privacy-relevant in some environments. |
@@ -190,6 +192,48 @@ consumer routers ignore option 81 entirely, and registration depends on
 the server being configured for dynamic DNS. The plugin's contract is
 "send the option when asked" — not "the name will resolve." Off by
 default because DDNS registration is a deliberate network-policy choice.
+
+### Stable leases across recreate (`stable_lease`, ipvlan)
+
+By default each endpoint's DHCP client-id (option 61) is derived from the
+Docker **endpoint ID**, which is random and minted fresh every time a
+container is created. So a container that is stopped, removed, and
+recreated comes back as a *new* client to the DHCP server and may get a
+different IP. For **bridge** and **macvlan** networks the plugin already
+keeps the IP stable across a *restart* by inheriting the previous MAC
+(tombstones), and the upcoming deterministic-MAC work extends that to
+recreate. **ipvlan** has no such handle: all ipvlan children share the
+parent NIC's MAC on the wire, so the server cannot tell them apart by MAC
+at all.
+
+`-o stable_lease=true` closes that gap for ipvlan by deriving the client-id
+from the container's **stable identity** instead of the endpoint ID. The
+same logical container then presents the same option 61 on every recreate,
+and a server that keys leases on the client-id — dnsmasq does so by default
+(the client-identifier takes precedence over the MAC) — returns the same
+lease. Two *different* containers on the same network still get distinct
+client-ids and therefore distinct IPs, which is exactly the per-container
+distinction the shared parent MAC otherwise destroys.
+
+The identity is resolved most-specific first:
+
+1. `lease_seed=<key>` — an explicit operator-supplied key (full control;
+    share it deliberately to collapse containers onto one lease).
+2. Compose `project` + `service` + `container-number` — survives
+   `compose up -d`, and the per-replica number keeps `--scale` replicas
+   distinct.
+3. The container `--name`.
+4. *(none)* — an anonymous container with no `--name`, no Compose labels,
+   and no `lease_seed`. There is no stable identity to hash, so the
+   endpoint-derived id is used (no crash, lease still acquired) and
+   `stable_lease_no_identity` is incremented on `/Plugin.Health`. A
+   non-zero counter means `stable_lease` isn't doing anything for those
+   containers — give them a name, Compose labels, or a `lease_seed`.
+
+The network ID is folded into the derivation, so the same container on two
+DHCP networks gets a distinct client-id on each. An explicit `client_id`
+still overrides everything. bridge/macvlan reject `stable_lease` at
+`docker network create` rather than silently ignoring it.
 
 ## Driver options (per-endpoint)
 
@@ -260,6 +304,7 @@ curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
 | `lease_release_failures` | no | Teardown DHCPRELEASE didn't complete cleanly — the server may hold a phantom lease until natural expiry. A pattern points at upstream reachability problems mid-teardown. |
 | `naks_received` | no | (v1.0.0+) The server NAKed a renewal/rebind (v4+v6 aggregate). `dhcpcd` recovers by re-acquiring, so each NAK is typically followed by `leases_obtained` — and, if the address moved, `lease_changed` — bumps. Climbing alongside `lease_changed` means containers are being re-addressed mid-life. |
 | `ledger_write_failures` | no | Failed `audit_log` ledger appends — degrades forensics, not networking. Operators using `audit_log` alert on this. |
+| `stable_lease_no_identity` | no | (v1.3.0+) Endpoints created on a `stable_lease` network that had no stable identity to derive a client-id from and fell back to the recreate-unstable endpoint-derived id (#219). Not networking-affecting — the lease is acquired — but a non-zero value means `stable_lease` isn't applying to those containers; give them a `--name`, Compose labels, or a `lease_seed`. |
 | `lease_changed_v6`, `leases_obtained_v6`, `leases_renewed_v6`, `dhcp_timeouts_v6`, `naks_received_v6` | no | (v1.2.0+) The IPv6-only share of the matching aggregate above (#212). Each counts only the v6 client's events; the v4 share is the aggregate minus its `*_v6`. On a dual-stack host this isolates the v6-specific NAK/timeout signal the aggregate hides. `lease_release_failures` and `ledger_write_failures` have no per-family split. |
 
 ### Plugin log

--- a/pkg/plugin/container_identity.go
+++ b/pkg/plugin/container_identity.go
@@ -1,0 +1,72 @@
+package plugin
+
+import (
+	dContainer "github.com/docker/docker/api/types/container"
+)
+
+// Compose label keys. Docker Compose stamps every container it creates
+// with these, and they survive a `compose up -d` recreate (same project
+// + service ⇒ same values), which is exactly the stable identity the
+// stable-lease client-id (#219) and the deterministic MAC (#218) both
+// need. Defined here rather than imported because the plugin otherwise
+// has no Compose dependency.
+const (
+	composeProjectLabel = "com.docker.compose.project"
+	composeServiceLabel = "com.docker.compose.service"
+	// composeNumberLabel is the per-replica index Compose stamps on each
+	// container of a service (1, 2, 3 for `--scale svc=3`). It is the
+	// piece that keeps replicas of one service from hashing to the same
+	// seed: project+service alone are identical across replicas, so the
+	// number is what makes the seed replica-unique while staying stable
+	// across recreate (replica N keeps its number).
+	composeNumberLabel = "com.docker.compose.container-number"
+)
+
+// containerIdentity is the best-effort stable identity of the container
+// an endpoint is being created for, resolved once at create time (see
+// initialContainerIdentity). Every field is best-effort: a non-Compose
+// `docker run` container has empty Compose fields, and an anonymous
+// container (`--rm` with no name) can even have an empty Name. The seed
+// logic (stableLeaseSeed) degrades through these gracefully.
+type containerIdentity struct {
+	// Hostname is the container's configured hostname, consumed by the
+	// option-12 DHCP hint (initialContainerIdentity → DISCOVER). Not used
+	// as a stable seed: it defaults to the short container ID, which is
+	// NOT stable across recreate.
+	Hostname string
+	// Name is the Docker container name (e.g. "/myproj-web-1"). Stable
+	// across recreate for named and Compose-managed containers.
+	Name string
+	// ComposeProject / ComposeService / ComposeNumber come from the
+	// Compose labels above. Project+Service+Number together form a
+	// replica-unique identity that's stable across `compose up -d` even
+	// if the container name changes. Number may be empty on older
+	// Compose releases that don't stamp it; the seed logic falls back to
+	// the container name (which also carries the replica index) in that
+	// case.
+	ComposeProject string
+	ComposeService string
+	ComposeNumber  string
+}
+
+// containerIdentityFromInspect extracts the stable-identity fields from a
+// Docker ContainerInspect result. Shared by initialContainerIdentity (the
+// CreateEndpoint poll) and the persistent dhcpManager (which inspects the
+// same container at Join / recovery), so both derive the identical seed
+// for the same container — the recompute is deterministic, no plumbing of
+// the chosen client-id between stages required.
+func containerIdentityFromInspect(ctr dContainer.InspectResponse) containerIdentity {
+	var id containerIdentity
+	// Name lives on the embedded *ContainerJSONBase, which a real
+	// ContainerInspect always populates but a hand-built fixture may not.
+	if ctr.ContainerJSONBase != nil {
+		id.Name = ctr.Name
+	}
+	if ctr.Config != nil {
+		id.Hostname = ctr.Config.Hostname
+		id.ComposeProject = ctr.Config.Labels[composeProjectLabel]
+		id.ComposeService = ctr.Config.Labels[composeServiceLabel]
+		id.ComposeNumber = ctr.Config.Labels[composeNumberLabel]
+	}
+	return id
+}

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -125,8 +125,13 @@ type dhcpManager struct {
 	// bridge mode.
 	MacAddress net.HardwareAddr
 
-	nsPath    string
+	nsPath string
+	// hostname feeds the option-12 hint; identity carries the full stable
+	// identity (name/Compose labels) so the persistent client re-derives
+	// the same stable_lease client-id the CreateEndpoint one-shot used —
+	// deterministically, from the same container, no cross-stage plumbing.
 	hostname  string
+	identity  containerIdentity
 	nsHandle  netns.NsHandle
 	netHandle *netlink.Handle
 	ctrLink   netlink.Link
@@ -630,9 +635,13 @@ func (m *dhcpManager) setupClient(v6 bool) (chan error, error) {
 		// ipvlan path but currently has no effect.
 		Broadcast: m.opts.effectiveMode() == ModeIPvlan,
 		// Same client-id the initial DISCOVER used in CreateEndpoint,
-		// so renewals are seen as the same client by the server.
+		// so renewals are seen as the same client by the server. Under
+		// stable_lease it re-derives from the same container identity
+		// (deterministic — identical id, no cross-stage plumbing) and on
+		// recovery too; nil onFallback keeps the renewal/recovery path
+		// from re-counting the anonymous fallback the create path logged.
 		// Honours the operator's client_id override when set.
-		ClientID:    resolveClientID(m.opts, m.joinReq.EndpointID),
+		ClientID:    resolveEndpointClientID(m.opts, m.joinReq.NetworkID, m.joinReq.EndpointID, m.identity, nil),
 		VendorClass: m.opts.VendorClass,
 	})
 	if err != nil {
@@ -849,7 +858,8 @@ func (m *dhcpManager) Start(ctx context.Context) (err error) {
 
 	// Using the "sandbox key" directly causes issues on some platforms
 	m.nsPath = fmt.Sprintf("/proc/%v/ns/net", ctr.State.Pid)
-	m.hostname = ctr.Config.Hostname
+	m.identity = containerIdentityFromInspect(ctr)
+	m.hostname = m.identity.Hostname
 
 	m.nsHandle, err = util.AwaitNetNS(ctx, m.nsPath, pollTime)
 	if err != nil {

--- a/pkg/plugin/docker_client_test.go
+++ b/pkg/plugin/docker_client_test.go
@@ -249,7 +249,7 @@ func TestReacquireEndpoint_MACLookupError(t *testing.T) {
 	}
 }
 
-func TestInitialDHCPHostname_Success(t *testing.T) {
+func TestInitialContainerIdentity_HostnameSuccess(t *testing.T) {
 	const netID, epID = "n1", "ep1"
 	f := &fakeDocker{
 		inspectResult: map[string]dNetwork.Inspect{
@@ -263,12 +263,12 @@ func TestInitialDHCPHostname_Success(t *testing.T) {
 	}
 	p := &Plugin{docker: f}
 
-	if got := p.initialDHCPHostname(context.Background(), netID, epID); got != "myhost" {
+	if got := p.initialContainerIdentity(context.Background(), netID, epID).Hostname; got != "myhost" {
 		t.Fatalf("hostname: got %q want myhost", got)
 	}
 }
 
-func TestInitialDHCPHostname_EmptyOnFailure(t *testing.T) {
+func TestInitialContainerIdentity_EmptyOnFailure(t *testing.T) {
 	const netID, epID = "n1", "ep1"
 	cases := []struct {
 		name string
@@ -303,7 +303,7 @@ func TestInitialDHCPHostname_EmptyOnFailure(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 			defer cancel()
 			p := &Plugin{docker: c.f}
-			if got := p.initialDHCPHostname(ctx, netID, epID); got != "" {
+			if got := p.initialContainerIdentity(ctx, netID, epID).Hostname; got != "" {
 				t.Fatalf("hostname: got %q want empty", got)
 			}
 		})

--- a/pkg/plugin/endpoints.go
+++ b/pkg/plugin/endpoints.go
@@ -289,6 +289,14 @@ type HealthResponse struct {
 	// degrades forensics, not networking; operators using audit_log
 	// alert on this directly.
 	LedgerWriteFailures int32 `json:"ledger_write_failures"`
+	// StableLeaseNoIdentity counts endpoints created on a stable_lease
+	// network that had no stable identity to derive a client-id from and
+	// fell back to the endpoint-derived (recreate-unstable) id (#219). Not
+	// Healthy-affecting — the lease is acquired, it just won't survive a
+	// recreate — but an operator who enabled stable_lease should alert on
+	// it: a non-zero value means the flag isn't doing anything for those
+	// containers (give them a --name, Compose labels, or a lease_seed).
+	StableLeaseNoIdentity int32 `json:"stable_lease_no_identity"`
 
 	// Per-family (IPv6) breakdown of the wire counters (#212). Each
 	// counts only the v6 client's events; the un-suffixed fields above
@@ -334,5 +342,6 @@ func (p *Plugin) apiHealth(w http.ResponseWriter, r *http.Request) {
 		LeasesRenewedV6:        p.leasesRenewedV6.Load(),
 		DHCPTimeoutsV6:         p.dhcpTimeoutsV6.Load(),
 		NAKsReceivedV6:         p.naksReceivedV6.Load(),
+		StableLeaseNoIdentity:  p.stableLeaseNoIdentity.Load(),
 	}, http.StatusOK)
 }

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -54,12 +54,23 @@ func validateModeOptions(opts DHCPNetworkOptions) error {
 		if opts.Bridge != "" {
 			return fmt.Errorf("%w: bridge cannot be set in mode=%v", util.ErrModeMismatch, opts.effectiveMode())
 		}
+		// stable_lease derives a stable client-id, which only stabilizes
+		// leases for ipvlan (where children share the parent MAC and the
+		// client-id is the only per-container handle). macvlan lease
+		// stability comes from the deterministic-MAC work, not yet
+		// available — reject loudly rather than accept-but-ignore.
+		if opts.StableLease && opts.effectiveMode() == ModeMacvlan {
+			return fmt.Errorf("%w: got mode=macvlan", util.ErrStableLeaseMode)
+		}
 	case ModeBridge:
 		if opts.Bridge == "" {
 			return util.ErrBridgeRequired
 		}
 		if opts.Parent != "" {
 			return fmt.Errorf("%w: parent cannot be set in mode=bridge", util.ErrModeMismatch)
+		}
+		if opts.StableLease {
+			return fmt.Errorf("%w: got mode=bridge", util.ErrStableLeaseMode)
 		}
 		// validate_dhcp on bridge mode is a v0.9.0 carve-out: the
 		// probe semantics differ (parent is an existing bridge, not
@@ -459,7 +470,9 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 	// to the same container (prevents identity swap during sequential
 	// `compose restart`). Best-effort: if the lookup misses or returns
 	// empty, consumeTombstone falls back to network-only matching.
-	hostname := p.initialDHCPHostname(ctx, r.NetworkID, r.EndpointID)
+	// stable_lease is rejected for bridge at CreateNetwork, so only the
+	// hostname (option-12 hint) is consumed here.
+	hostname := p.initialContainerIdentity(ctx, r.NetworkID, r.EndpointID).Hostname
 
 	// MAC/IP selection priority:
 	//   1. Explicit values from libnetwork (`--mac-address`, `--ip`)

--- a/pkg/plugin/parent_attached.go
+++ b/pkg/plugin/parent_attached.go
@@ -102,11 +102,15 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 	if err != nil {
 		return res, err
 	}
-	// Look up the hostname up front so we can scope tombstone matching
-	// to the same container (prevents identity swap during sequential
-	// `compose restart`). Best-effort: if the lookup misses or returns
-	// empty, consumeTombstone falls back to network-only matching.
-	hostname := p.initialDHCPHostname(ctx, r.NetworkID, r.EndpointID)
+	// Resolve the container's stable identity up front. The hostname
+	// scopes tombstone matching to the same container (prevents identity
+	// swap during sequential `compose restart`) and feeds the option-12
+	// DHCP hint; the name/Compose labels seed the stable_lease client-id
+	// (#219). Best-effort: if the lookup misses, consumeTombstone falls
+	// back to network-only matching and the client-id falls back to the
+	// endpoint-derived id.
+	identity := p.initialContainerIdentity(ctx, r.NetworkID, r.EndpointID)
+	hostname := identity.Hostname
 
 	requestedIP := explicitV4
 	requestedV6 := explicitV6
@@ -211,13 +215,21 @@ func (p *Plugin) createParentAttachedEndpoint(ctx context.Context, r CreateEndpo
 		if opts.LeaseTimeout != 0 {
 			timeout = opts.LeaseTimeout
 		}
-		// Stable client-id derived from the endpoint ID (so reservations
-		// keyed on option 61 survive container recreation, and so ipvlan
-		// children can be told apart even though they all share the
-		// parent's MAC). hostname was resolved earlier for tombstone
-		// matching and is reused for the DHCP option 12 hint here.
-		// Operator-supplied client_id overrides the derived value.
-		clientID := resolveClientID(opts, r.EndpointID)
+		// Client-id for the initial exchange. With stable_lease=true
+		// (ipvlan only) it's derived from the container's stable identity
+		// so reservations keyed on option 61 survive recreate even though
+		// ipvlan children all share the parent's MAC; otherwise it's the
+		// endpoint-derived id (stable across restarts of the same
+		// endpoint). Operator-supplied client_id overrides either. An
+		// anonymous container under stable_lease can't be hashed to a
+		// stable id, so it falls back and bumps the health counter.
+		clientID := resolveEndpointClientID(opts, r.NetworkID, r.EndpointID, identity, func() {
+			p.stableLeaseNoIdentity.Add(1)
+			log.WithFields(log.Fields{
+				"network":  shortID(r.NetworkID),
+				"endpoint": shortID(r.EndpointID),
+			}).Warn("stable_lease is enabled but the container has no stable identity (no lease_seed, Compose labels, or --name); the lease will not survive a recreate")
+		})
 
 		runDHCP := func(v6 bool) error {
 			v6str := ""

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -163,6 +163,35 @@ type DHCPNetworkOptions struct {
 	// VendorClass to drive class-based policy that doesn't depend on
 	// per-client identity.
 	ClientID string `mapstructure:"client_id"`
+	// StableLease, when true, makes every endpoint on this network present
+	// a DHCP client-id (option 61) derived from the container's *stable*
+	// identity instead of the per-endpoint default (which is keyed off the
+	// random Docker endpoint ID and so changes on every recreate). With a
+	// server that keys leases on the client-id (dnsmasq does by default),
+	// this returns the same IP to the same logical container across
+	// stop/remove/recreate. Default false.
+	//
+	// mode=ipvlan only: ipvlan children share the parent's MAC on the
+	// wire, so the client-id is the only L7 handle that lets the server
+	// tell recreated containers apart and hand back the same lease (#219).
+	// bridge/macvlan reject stable_lease at CreateNetwork (their lease
+	// stability is delivered by the deterministic-MAC work, not yet
+	// available) rather than silently no-op'ing. The stable identity is
+	// resolved from, most-specific first: LeaseSeed, then Compose
+	// project+service+container-number, then the container --name; an
+	// anonymous container with none of these falls back to the
+	// endpoint-derived id and bumps stable_lease_no_identity on
+	// /Plugin.Health.
+	StableLease bool `mapstructure:"stable_lease"`
+	// LeaseSeed, when non-empty, is the highest-precedence stable-identity
+	// source for the StableLease client-id: the derived option 61 is a
+	// hash of (scheme-tag ‖ network ‖ LeaseSeed), so two containers sharing
+	// a LeaseSeed on one network present the same client-id and share a
+	// lease, and one container keeps its lease across recreate regardless
+	// of name/Compose labels. Only consulted when StableLease is true
+	// (inert otherwise). Pair distinct values per logical container; a
+	// shared value deliberately collapses them onto one lease.
+	LeaseSeed string `mapstructure:"lease_seed"`
 	// VendorClass, when non-empty, overrides the default DHCP option
 	// 60 (Vendor Class Identifier) value of "docker-net-dhcp" for
 	// every endpoint on this network. Lets DHCP servers using
@@ -382,6 +411,17 @@ type Plugin struct {
 	// audit_log should alert on the counter instead.
 	ledger              *leaseLedger
 	ledgerWriteFailures atomic.Int32
+
+	// stableLeaseNoIdentity counts CreateEndpoint calls on a stable_lease
+	// network where no stable identity could be resolved (an anonymous
+	// container: no lease_seed, no Compose labels, no --name), so the
+	// endpoint fell back to the endpoint-derived client-id — which is NOT
+	// stable across recreate. Surfaced on /Plugin.Health so an operator
+	// who turned on stable_lease can see it silently not applying to some
+	// containers. Not Healthy-affecting: the lease is still acquired, it
+	// just won't survive a recreate. Counted once per create (the renewal
+	// and recovery paths re-derive the same fallback silently).
+	stableLeaseNoIdentity atomic.Int32
 }
 
 // storeJoinHint records the state collected during CreateEndpoint so
@@ -844,17 +884,21 @@ func (p *Plugin) reacquireEndpoint(ctx context.Context, r JoinRequest, opts DHCP
 	return nil
 }
 
-// initialDHCPHostname makes a best-effort attempt to find the hostname
-// of the container we're about to attach an endpoint to, so we can pass
-// it in the initial DHCPDISCOVER. Polls the network's Containers map
-// for up to initialDHCPHostnameLookupTimeout; if the container hasn't
-// been registered yet (it's a race; sometimes Docker calls
-// CreateEndpoint before the container appears in the network's
-// container list), we fall through with an empty hostname. The
-// persistent renewal client populates the hostname later regardless,
-// so the worst case is "first lease appears in the upstream DHCP
-// server's UI without a hostname for a few minutes".
-func (p *Plugin) initialDHCPHostname(ctx context.Context, networkID, endpointID string) string {
+// initialContainerIdentity makes a best-effort attempt to resolve the
+// stable identity of the container we're about to attach an endpoint to,
+// in a single NetworkInspect → ContainerInspect round-trip. The hostname
+// feeds the initial DHCPDISCOVER (option 12); the name and Compose labels
+// feed the stable-lease client-id (#219, and the deterministic MAC #218).
+// Polls the network's Containers map for up to
+// initialDHCPHostnameLookupTimeout; if the container hasn't been
+// registered yet (it's a race; sometimes Docker calls CreateEndpoint
+// before the container appears in the network's container list), we fall
+// through with a zero identity. The persistent renewal client populates
+// the hostname later regardless, so the worst case for the hint is "first
+// lease appears in the upstream DHCP server's UI without a hostname for a
+// few minutes"; for the stable-lease client-id a zero identity simply
+// means we fall back to the endpoint-derived id.
+func (p *Plugin) initialContainerIdentity(ctx context.Context, networkID, endpointID string) containerIdentity {
 	ctx, cancel := context.WithTimeout(ctx, initialDHCPHostnameLookupTimeout)
 	defer cancel()
 
@@ -867,15 +911,15 @@ func (p *Plugin) initialDHCPHostname(ctx context.Context, networkID, endpointID 
 	// retry interval. Cap the inner ctx at the poll interval.
 	const dockerCallTimeout = 200 * time.Millisecond
 
-	var hostname string
+	var id containerIdentity
 	_ = util.AwaitCondition(ctx, func() (bool, error) {
 		inner, innerCancel := context.WithTimeout(ctx, dockerCallTimeout)
 		defer innerCancel()
 		dockerNet, err := p.docker.NetworkInspect(inner, networkID, dNetwork.InspectOptions{})
 		if err != nil {
 			// Don't propagate the error — we want to keep retrying
-			// while the timeout has time. The caller treats an empty
-			// hostname as "not yet known" and lets renewal handle it.
+			// while the timeout has time. The caller treats a zero
+			// identity as "not yet known" and lets renewal handle it.
 			return false, nil
 		}
 		for ctrID, info := range dockerNet.Containers {
@@ -891,12 +935,12 @@ func (p *Plugin) initialDHCPHostname(ctx context.Context, networkID, endpointID 
 			if err != nil {
 				return false, nil
 			}
-			hostname = ctr.Config.Hostname
+			id = containerIdentityFromInspect(ctr)
 			return true, nil
 		}
 		return false, nil
 	}, 100*time.Millisecond)
-	return hostname
+	return id
 }
 
 // NewPlugin creates a new Plugin

--- a/pkg/plugin/stable_lease.go
+++ b/pkg/plugin/stable_lease.go
@@ -1,0 +1,95 @@
+package plugin
+
+import (
+	"crypto/sha256"
+)
+
+// stableLeaseSeedTag versions the seed-construction scheme for the
+// stable-lease client-id and namespaces its hash input. Bumping it
+// deliberately remaps every container's derived client-id (and therefore
+// its lease); keep it fixed so leases stay stable across plugin upgrades.
+// It is distinct from stable-mac/v1 (#218) so a MAC seed and a client-id
+// seed built from the *same* container identity never coincide on the
+// wire.
+const stableLeaseSeedTag = "stable-lease-clientid/v1"
+
+// stableLeaseClientIDLen is the byte width of the derived option-61
+// payload. Matches clientIDFromEndpoint's 8 bytes: long enough to be
+// unique in any realistic deployment, short enough to keep the option
+// well below the 255-byte wire limit.
+const stableLeaseClientIDLen = 8
+
+// stableLeaseSeed picks the stable seed for a container's derived DHCP
+// client-id, or returns "" when no stable identity is available (in which
+// case the caller must fall back to the endpoint-derived id — a "stable"
+// client-id hashed from an unstable identity would just drift on the next
+// recreate, defeating the point). Precedence, most-specific first:
+//
+//  1. explicit `-o lease_seed=<key>` driver-opt — full operator control
+//  2. Compose project + service + container-number — survives
+//     `compose up -d`, and the number keeps service replicas distinct
+//  3. container name — explicit `--name`, or Compose without the
+//     container-number label (the name carries the replica index)
+//  4. none — anonymous container, no stable identity
+//
+// networkID is folded into every seed so the same container attached to
+// two DHCP networks gets a distinct client-id on each. Each tier carries
+// a discriminator string so a name that happens to equal a lease_seed
+// value (or a project) can't hash to the same id.
+func stableLeaseSeed(id containerIdentity, networkID string, opts DHCPNetworkOptions) string {
+	prefix := stableLeaseSeedTag + "\x00" + networkID + "\x00"
+	switch {
+	case opts.LeaseSeed != "":
+		return prefix + "seed\x00" + opts.LeaseSeed
+	case id.ComposeProject != "" && id.ComposeService != "" && id.ComposeNumber != "":
+		return prefix + "compose\x00" + id.ComposeProject + "\x00" + id.ComposeService + "\x00" + id.ComposeNumber
+	case id.Name != "":
+		return prefix + "name\x00" + id.Name
+	default:
+		return ""
+	}
+}
+
+// deriveStableLeaseClientID turns a seed into a deterministic option-61
+// payload: the first stableLeaseClientIDLen bytes of SHA-256(seed). The
+// dhcpcd client wraps these with the type byte 0x00 (RFC 2132 opaque) on
+// the wire, the same as the operator-supplied and endpoint-derived paths.
+//
+// Unlike the deterministic MAC (#218) there is no perturbation/collision
+// avoidance: a MAC must be unique on the L2 segment, but two identical
+// client-ids only matter on a true hash collision of *distinct*
+// identities — negligible at 64 bits — and there is no live "taken" set
+// at the DHCP layer to check against anyway.
+func deriveStableLeaseClientID(seed string) []byte {
+	sum := sha256.Sum256([]byte(seed))
+	out := make([]byte, stableLeaseClientIDLen)
+	copy(out, sum[:stableLeaseClientIDLen])
+	return out
+}
+
+// resolveEndpointClientID picks the option-61 payload for an endpoint's
+// DHCP exchange, honoring stable_lease. Precedence:
+//
+//  1. operator `-o client_id=` — explicit override always wins (unchanged)
+//  2. stable_lease=true with a resolvable stable identity → a client-id
+//     derived from that identity, stable across recreate (#219)
+//  3. otherwise → the endpoint-derived id (today's default)
+//
+// When stable_lease is set but no stable identity is available (an
+// anonymous container), onFallback is invoked once — the CreateEndpoint
+// caller uses it to bump the stable_lease_no_identity health counter and
+// warn. The persistent/renewal and recovery callers pass nil: they
+// re-derive the same id deterministically from the same container and
+// must not double-count (or re-warn about) the one fallback the create
+// path already recorded.
+func resolveEndpointClientID(opts DHCPNetworkOptions, networkID, endpointID string, id containerIdentity, onFallback func()) []byte {
+	if opts.StableLease && opts.ClientID == "" {
+		if seed := stableLeaseSeed(id, networkID, opts); seed != "" {
+			return deriveStableLeaseClientID(seed)
+		}
+		if onFallback != nil {
+			onFallback()
+		}
+	}
+	return resolveClientID(opts, endpointID)
+}

--- a/pkg/plugin/stable_lease_test.go
+++ b/pkg/plugin/stable_lease_test.go
@@ -1,0 +1,191 @@
+package plugin
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/devplayer0/docker-net-dhcp/pkg/util"
+)
+
+// TestStableLeaseSeed_Precedence pins the most-specific-first ordering:
+// lease_seed > Compose project+service+number > container name > none.
+func TestStableLeaseSeed_Precedence(t *testing.T) {
+	const net = "net1"
+	full := containerIdentity{
+		Name:           "/proj-web-1",
+		ComposeProject: "proj",
+		ComposeService: "web",
+		ComposeNumber:  "1",
+	}
+
+	cases := []struct {
+		name   string
+		id     containerIdentity
+		opts   DHCPNetworkOptions
+		expect string // discriminator the chosen seed tier must contain
+		empty  bool
+	}{
+		{"lease_seed wins", full, DHCPNetworkOptions{LeaseSeed: "k"}, "seed\x00k", false},
+		{"compose when no seed", full, DHCPNetworkOptions{}, "compose\x00proj\x00web\x001", false},
+		{
+			"name when compose incomplete",
+			containerIdentity{Name: "/solo", ComposeProject: "proj", ComposeService: "web"}, // no number
+			DHCPNetworkOptions{}, "name\x00/solo", false,
+		},
+		{"name when only name", containerIdentity{Name: "/solo"}, DHCPNetworkOptions{}, "name\x00/solo", false},
+		{"none when anonymous", containerIdentity{}, DHCPNetworkOptions{}, "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := stableLeaseSeed(c.id, net, c.opts)
+			if c.empty {
+				if got != "" {
+					t.Fatalf("want empty seed, got %q", got)
+				}
+				return
+			}
+			if got == "" {
+				t.Fatal("want non-empty seed, got empty")
+			}
+			if !bytes.Contains([]byte(got), []byte(c.expect)) {
+				t.Fatalf("seed %q does not contain discriminator %q", got, c.expect)
+			}
+		})
+	}
+}
+
+// TestStableLeaseSeed_NetworkScoped: the same identity on two networks
+// yields distinct seeds (so the same container gets a distinct client-id
+// per DHCP network it joins).
+func TestStableLeaseSeed_NetworkScoped(t *testing.T) {
+	id := containerIdentity{Name: "/c"}
+	a := stableLeaseSeed(id, "netA", DHCPNetworkOptions{})
+	b := stableLeaseSeed(id, "netB", DHCPNetworkOptions{})
+	if a == b {
+		t.Fatalf("seeds must differ across networks, both = %q", a)
+	}
+}
+
+// TestStableLeaseSeed_TagNamespaced: every seed carries the versioned
+// scheme tag as a prefix, so the hash input is namespaced. The tag value
+// is deliberately distinct from the deterministic-MAC scheme (#218) so a
+// MAC seed and a client-id seed built from the same identity can never
+// coincide once that work lands; this asserts the lease tag here (the MAC
+// tag lives on the #218 branch).
+func TestStableLeaseSeed_TagNamespaced(t *testing.T) {
+	if stableLeaseSeedTag != "stable-lease-clientid/v1" {
+		t.Fatalf("seed tag changed to %q — bumping it remaps every lease; do so deliberately", stableLeaseSeedTag)
+	}
+	seed := stableLeaseSeed(containerIdentity{Name: "/c"}, "n", DHCPNetworkOptions{})
+	if !bytes.HasPrefix([]byte(seed), []byte(stableLeaseSeedTag)) {
+		t.Fatalf("seed %q must be prefixed with the scheme tag", seed)
+	}
+}
+
+// TestDeriveStableLeaseClientID pins determinism, width, and that
+// distinct seeds map to distinct ids.
+func TestDeriveStableLeaseClientID(t *testing.T) {
+	a := deriveStableLeaseClientID("seed-a")
+	if len(a) != stableLeaseClientIDLen {
+		t.Fatalf("width: got %d want %d", len(a), stableLeaseClientIDLen)
+	}
+	if !bytes.Equal(a, deriveStableLeaseClientID("seed-a")) {
+		t.Fatal("derivation must be deterministic")
+	}
+	if bytes.Equal(a, deriveStableLeaseClientID("seed-b")) {
+		t.Fatal("distinct seeds must map to distinct client-ids")
+	}
+}
+
+// TestResolveEndpointClientID covers the full precedence with stable_lease.
+func TestResolveEndpointClientID(t *testing.T) {
+	const eid = "0123456789abcdef0123456789abcdef"
+	const net = "net1"
+	named := containerIdentity{Name: "/web"}
+
+	t.Run("operator client_id wins over stable", func(t *testing.T) {
+		got := resolveEndpointClientID(
+			DHCPNetworkOptions{StableLease: true, ClientID: "op"}, net, eid, named, nil)
+		if string(got) != "op" {
+			t.Fatalf("got %q want op", got)
+		}
+	})
+
+	t.Run("stable off falls back to endpoint-derived", func(t *testing.T) {
+		got := resolveEndpointClientID(DHCPNetworkOptions{}, net, eid, named, nil)
+		if !bytes.Equal(got, clientIDFromEndpoint(eid)) {
+			t.Fatalf("got %x want endpoint-derived %x", got, clientIDFromEndpoint(eid))
+		}
+	})
+
+	t.Run("stable on derives from identity", func(t *testing.T) {
+		opts := DHCPNetworkOptions{StableLease: true}
+		got := resolveEndpointClientID(opts, net, eid, named, nil)
+		want := deriveStableLeaseClientID(stableLeaseSeed(named, net, opts))
+		if !bytes.Equal(got, want) {
+			t.Fatalf("got %x want stable %x", got, want)
+		}
+		if bytes.Equal(got, clientIDFromEndpoint(eid)) {
+			t.Fatal("stable id must not equal the endpoint-derived id")
+		}
+	})
+
+	t.Run("stable id is identical across two endpoint IDs (the recreate guarantee)", func(t *testing.T) {
+		opts := DHCPNetworkOptions{StableLease: true}
+		a := resolveEndpointClientID(opts, net, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", named, nil)
+		b := resolveEndpointClientID(opts, net, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", named, nil)
+		if !bytes.Equal(a, b) {
+			t.Fatalf("same identity, different endpoints must give same client-id: %x vs %x", a, b)
+		}
+	})
+
+	t.Run("anonymous fallback invokes onFallback and uses endpoint-derived", func(t *testing.T) {
+		called := 0
+		got := resolveEndpointClientID(
+			DHCPNetworkOptions{StableLease: true}, net, eid, containerIdentity{}, func() { called++ })
+		if called != 1 {
+			t.Fatalf("onFallback called %d times, want 1", called)
+		}
+		if !bytes.Equal(got, clientIDFromEndpoint(eid)) {
+			t.Fatalf("got %x want endpoint-derived %x", got, clientIDFromEndpoint(eid))
+		}
+	})
+
+	t.Run("nil onFallback is safe on anonymous (renewal/recovery path)", func(t *testing.T) {
+		got := resolveEndpointClientID(
+			DHCPNetworkOptions{StableLease: true}, net, eid, containerIdentity{}, nil)
+		if !bytes.Equal(got, clientIDFromEndpoint(eid)) {
+			t.Fatalf("got %x want endpoint-derived %x", got, clientIDFromEndpoint(eid))
+		}
+	})
+}
+
+// TestValidateModeOptions_StableLease pins the ipvlan-only contract:
+// stable_lease is accepted for ipvlan and rejected (with ErrStableLeaseMode)
+// for bridge and macvlan.
+func TestValidateModeOptions_StableLease(t *testing.T) {
+	cases := []struct {
+		name    string
+		opts    DHCPNetworkOptions
+		wantErr bool
+	}{
+		{"ipvlan accepts", DHCPNetworkOptions{Mode: ModeIPvlan, Parent: "eth0", StableLease: true}, false},
+		{"macvlan rejects", DHCPNetworkOptions{Mode: ModeMacvlan, Parent: "eth0", StableLease: true}, true},
+		{"bridge rejects", DHCPNetworkOptions{Mode: ModeBridge, Bridge: "br0", StableLease: true}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateModeOptions(c.opts)
+			if c.wantErr {
+				if !errors.Is(err, util.ErrStableLeaseMode) {
+					t.Fatalf("got %v, want ErrStableLeaseMode", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -24,6 +24,11 @@ var (
 	ErrParentDown = errors.New("parent interface is down")
 	// ErrModeMismatch indicates an option that doesn't apply to the chosen mode was set
 	ErrModeMismatch = errors.New("option does not apply to selected mode")
+	// ErrStableLeaseMode indicates stable_lease was requested in a mode
+	// that can't yet honor it (only mode=ipvlan derives a stable client-id;
+	// bridge/macvlan lease stability rides the deterministic-MAC work,
+	// which is not yet available).
+	ErrStableLeaseMode = errors.New("stable_lease is only supported in mode=ipvlan")
 	// ErrMACAddress indicates an invalid MAC address
 	ErrMACAddress = errors.New("invalid MAC address")
 	// ErrNoLease indicates a DHCP lease was not obtained from dhcpcd
@@ -55,7 +60,7 @@ func ErrToStatus(err error) int {
 		errors.Is(err, ErrBridgeUsed), errors.Is(err, ErrMACAddress),
 		errors.Is(err, ErrInvalidMode), errors.Is(err, ErrParentRequired),
 		errors.Is(err, ErrParentInvalid), errors.Is(err, ErrParentDown),
-		errors.Is(err, ErrModeMismatch):
+		errors.Is(err, ErrModeMismatch), errors.Is(err, ErrStableLeaseMode):
 		return http.StatusBadRequest
 
 	// Upstream DHCP server didn't respond — not our fault, not the

--- a/test/integration/stable_lease_test.go
+++ b/test/integration/stable_lease_test.go
@@ -1,0 +1,188 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	docker "github.com/docker/docker/client"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+)
+
+// TestStableLease_IPvlanSameIPAcrossRecreate is the #219 headline.
+//
+// ipvlan children share the parent's MAC, so a DHCP server keying on MAC
+// can't tell two of them apart — and the default per-endpoint client-id is
+// minted from the random Docker endpoint ID, which changes on every
+// recreate. With stable_lease=true the client-id is derived from the
+// container's stable identity (here, its --name), so the same logical
+// container presents the same option 61 across stop/rm/recreate and
+// dnsmasq (which keys leases on the client-identifier by default) hands
+// back the same address.
+//
+// The test runs a named container, records its IP, removes it, recreates
+// it under the same name (a fresh random endpoint ID), and asserts the IP
+// is identical. As a control on the mechanism — not just the outcome — it
+// also confirms the derived client-id surfaced in the lease file is stable
+// across the two incarnations.
+func TestStableLease_IPvlanSameIPAcrossRecreate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-stablelease-recreate"
+	ctrName := "dh-itest-stablelease-recreate-ctr"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "ipvlan", map[string]string{
+		"stable_lease": "true",
+	})
+
+	id1, ip1, mac1 := harness.RunContainer(t, ctx, netName, ctrName)
+	t.Logf("incarnation 1: id=%s ip=%s mac=%s", id1[:12], ip1, mac1)
+	cid1 := leaseClientIDForIP(t, ip1)
+
+	// Tear the container down fully (Leave + DeleteEndpoint → DHCPRELEASE),
+	// then recreate under the same name. The endpoint ID is fresh and
+	// random; only the stable identity carries over.
+	removeContainer(t, ctx, id1)
+
+	id2, ip2, mac2 := harness.RunContainer(t, ctx, netName, ctrName)
+	t.Logf("incarnation 2: id=%s ip=%s mac=%s", id2[:12], ip2, mac2)
+
+	if ip2 != ip1 {
+		t.Errorf("stable_lease: recreated %q got IP %s, want the prior lease %s", ctrName, ip2, ip1)
+	}
+	cid2 := leaseClientIDForIP(t, ip2)
+	if cid2 != cid1 {
+		t.Errorf("derived client-id changed across recreate: %q -> %q (the lease only stays put because the id does)", cid1, cid2)
+	} else {
+		t.Logf("stable client-id %q held across recreate; lease stayed at %s", cid1, ip1)
+	}
+}
+
+// TestStableLease_IPvlanDistinctIdentitiesDistinctIPs is the negative
+// control: stable_lease must not collapse different containers onto one
+// lease. Two differently-named containers on the same ipvlan network
+// derive different client-ids and so must get different IPs — exactly the
+// per-container distinction the shared parent MAC otherwise erases (a
+// MAC-keyed server would see one client for both).
+func TestStableLease_IPvlanDistinctIdentitiesDistinctIPs(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-stablelease-distinct"
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			fixture.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "ipvlan", map[string]string{
+		"stable_lease": "true",
+	})
+
+	idA, ipA, _ := harness.RunContainer(t, ctx, netName, "dh-itest-stablelease-distinct-a")
+	idB, ipB, _ := harness.RunContainer(t, ctx, netName, "dh-itest-stablelease-distinct-b")
+	t.Logf("A: id=%s ip=%s | B: id=%s ip=%s", idA[:12], ipA, idB[:12], ipB)
+
+	if ipA == ipB {
+		t.Errorf("distinct containers under stable_lease must get distinct IPs; both got %s", ipA)
+	}
+}
+
+// TestStableLease_RejectedOnBridgeAndMacvlan pins the ipvlan-only
+// contract: stable_lease only stabilizes ipvlan (where the client-id is
+// the sole per-container handle). bridge/macvlan lease stability is the
+// deterministic-MAC work, not yet available, so the option is rejected at
+// CreateNetwork rather than silently ignored.
+func TestStableLease_RejectedOnBridgeAndMacvlan(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	cases := []struct {
+		mode    string
+		options map[string]string
+	}{
+		{"bridge", map[string]string{"mode": "bridge", "bridge": harness.BridgeName, "stable_lease": "true"}},
+		{"macvlan", map[string]string{"mode": "macvlan", "parent": harness.HostVeth, "stable_lease": "true"}},
+	}
+	for _, c := range cases {
+		t.Run(c.mode, func(t *testing.T) {
+			netName := "dh-itest-stablelease-reject-" + c.mode
+			res, err := cli.NetworkCreate(ctx, netName, network.CreateOptions{
+				Driver:  harness.DriverName,
+				IPAM:    &network.IPAM{Driver: "null"},
+				Options: c.options,
+			})
+			if err == nil {
+				_ = cli.NetworkRemove(context.Background(), res.ID)
+				t.Fatalf("NetworkCreate accepted stable_lease=true in mode=%s; should have rejected", c.mode)
+			}
+			if !strings.Contains(err.Error(), "stable_lease") {
+				t.Errorf("rejection message should mention stable_lease; got: %q", err.Error())
+			}
+		})
+	}
+}
+
+// removeContainer stops and removes a container synchronously within a
+// test (RunContainer's own cleanup is best-effort and deferred to teardown;
+// the recreate scenario needs the name freed *now*).
+func removeContainer(t *testing.T, ctx context.Context, id string) {
+	t.Helper()
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+	if err := cli.ContainerStop(ctx, id, container.StopOptions{}); err != nil {
+		t.Fatalf("ContainerStop(%s): %v", id, err)
+	}
+	if err := cli.ContainerRemove(ctx, id, container.RemoveOptions{Force: true}); err != nil {
+		t.Fatalf("ContainerRemove(%s): %v", id, err)
+	}
+}
+
+// leaseClientIDForIP reads dnsmasq's lease file and returns the client-id
+// column (last whitespace field) of the lease line for the given IP. The
+// lease format is `<expiry> <mac> <ip> <hostname> <client-id>`. Fails the
+// test if no line for the IP appears within a short FS-sync window.
+func leaseClientIDForIP(t *testing.T, ip string) string {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(fixture.LeaseFile())
+		if err == nil {
+			for _, line := range strings.Split(string(data), "\n") {
+				fields := strings.Fields(line)
+				if len(fields) >= 5 && fields[2] == ip {
+					return fields[len(fields)-1]
+				}
+			}
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	t.Fatalf("no lease line found for IP %s within 5s (lease file %s)", ip, fixture.LeaseFile())
+	return "" // unreachable
+}


### PR DESCRIPTION
Closes #219.

## What

Adds an opt-in `stable_lease` mode (ipvlan only) that gives ipvlan
containers a stable lease across `stop` / `rm` / recreate — the gap left
open for ipvlan by the MAC-based stability that bridge/macvlan already
have.

ipvlan children share the parent NIC's MAC on the wire, so a DHCP server
keying on MAC can't tell two of them apart, and the default per-endpoint
client-id is derived from the random Docker endpoint ID, which is minted
fresh on every recreate. With `-o stable_lease=true` the DHCP option-61
client-id is derived from the container's **stable identity** instead, so
the same logical container presents the same client-id every time and a
server that keys leases on the client-identifier (dnsmasq does so by
default) hands back the same address.

## How

- **Identity precedence**, most-specific first:
  1. `lease_seed=<key>` driver-opt (explicit operator control)
  2. Compose `project` + `service` + `container-number` (survives
     `compose up -d`; the number keeps `--scale` replicas distinct)
  3. container `--name`
  4. *(none)* — anonymous container: falls back to the endpoint-derived id
     and bumps a new `stable_lease_no_identity` health counter (warn-logged
     once at create). A "stable" id hashed from an unstable identity would
     just drift on the next recreate, so the fallback is honest rather than
     a lie.
- **Derivation:** `clientid = SHA256(scheme-tag ‖ networkID ‖ seed)[:8]`,
  sent as option 61 (type-byte `0x00`, same wire wrapper as the existing
  client-id paths). The network ID is folded in so the same container on
  two DHCP networks gets a distinct id on each. An explicit `client_id`
  still overrides.
- **ipvlan only:** bridge/macvlan reject `stable_lease` at
  `docker network create` (their lease stability is the deterministic-MAC
  work, not yet available) rather than silently no-op'ing.
- **CreateEndpoint ↔ persistent/recovery consistency:** the container
  identity resolver is factored into `container_identity.go` (struct,
  Compose label constants, inspect extractor). The initial one-shot and
  the persistent renewal/recovery client each derive the client-id
  *deterministically from the same identity*, so they agree without any
  cross-stage plumbing — and recovery after a daemon restart re-derives the
  identical id too.

No moby/engine dependency: the `lease_seed` path is synchronous, and the
auto-derived path reuses the best-effort container-identity lookup the
option-12 hostname hint already performs at CreateEndpoint.

## Tests

- **Unit:** seed precedence (`lease_seed` > Compose > name > none),
  network-scoping, scheme-tag prefixing, derivation determinism/width, the
  full `resolveEndpointClientID` precedence (operator override wins, stable
  derivation, anonymous fallback invokes the counter callback, nil-callback
  renewal path is silent), and the bridge/macvlan `CreateNetwork` rejection.
- **Integration:** same-IP-across-recreate with the client-id verified
  stable in the dnsmasq lease file (headline), distinct-names →
  distinct-IPs (negative control — proves stable_lease doesn't collapse
  containers onto one lease), and the bridge/macvlan rejection.

## Docs

`docs/reference.md`: both new options in the table, a dedicated
"Stable leases across recreate" section, and the new health counter.

## Notes / shared machinery

The deterministic-MAC work (#218, draft #221) reuses this same identity
resolver and seed-precedence shape. This PR lands that machinery on `dev`;
#221 will rebase onto it (dropping its duplicate `containerIdentity` +
Compose-label copies) when its upstream engine dependency ships.
