### PR TITLE
Prepare v1.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ like any other machine. Bridge, macvlan, and ipvlan attachment modes.
 Install the plugin:
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.2.0
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.0
 ```
 
 It requests `host` networking, the host PID namespace, the Docker
@@ -43,7 +43,7 @@ already have a host bridge `my-bridge` on your LAN — see
 [bridge mode](docs/bridge-mode.md) for that one-time setup):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.2.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.0 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 
 docker run --rm -ti --network my-dhcp-net alpine ip address show

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,6 +44,57 @@ migration tracked in #178). They are accepted at the advisory level in
 older AuthZ finding (GHSA-x744-4wpc-v9h2 = GO-2026-4887), and will be
 re-evaluated when the module migration lands.
 
+## v1.3.0
+
+A feature release that builds new DHCP capabilities on the dhcpcd client
+shipped in v1.2.0: lease stability for ipvlan, opt-in dynamic-DNS
+registration, classless static routes, and more captured DHCP options.
+The plugin manifest is unchanged; all new behaviour is opt-in except the
+classless-routes default (see the compatibility note below).
+
+What changed:
+
+- **Stable leases for ipvlan** (#219). New `-o stable_lease=true` derives
+  the DHCP option-61 client-id from the container's *stable* identity
+  instead of the per-recreate endpoint id, so a server that keys leases on
+  the client-id (`dnsmasq` by default) hands the same logical container the
+  same IP across `stop` / `rm` / recreate — closing the gap that ipvlan
+  otherwise can't, since ipvlan slaves all share the parent's MAC. Identity
+  is taken, most-specific first, from `-o lease_seed=<key>`, then Compose
+  `project`+`service`+`container-number`, then the container `--name`; an
+  anonymous container with none of these bumps the new
+  `stable_lease_no_identity` counter on `/Plugin.Health`. bridge/macvlan
+  reject the option (their stability is delivered by the not-yet-available
+  deterministic-MAC work).
+- **Opt-in dynamic-DNS registration** (#261). New `-o register_dns=true`
+  sends the DHCP FQDN option (81 on v4 / 39 on v6) built from the container
+  hostname, asking the server to register forward (A/AAAA) + reverse (PTR)
+  DNS. Best-effort and advisory — many consumer routers ignore option 81 —
+  and off by default, since DDNS registration is a network-policy decision.
+- **Classless static routes** (#260). DHCPv4 option 121 (RFC 3442, plus the
+  legacy option 33 and MS option 249 encodings) is now honored: routes the
+  server pushes are programmed into the container at `Join`. `-o
+  skip_routes=true` suppresses them along with parent route-copying.
+- **More captured DHCP options** (#262). The observe-only log line now also
+  surfaces WPAD (option 252) and timezone (options 100/101 and legacy
+  option 2), alongside the existing NTP / TFTP / boot-file fields.
+- **Supply chain**: the image `:latest` tag is now a crane retag of the
+  signed version digest rather than a separate unsigned rebuild (#267), so
+  `:latest` and the matching `vX.Y.Z` share one signed digest. The docs
+  toolchain in the Pages workflow is hash-pinned (#268).
+- **Project**: the internal DHCP packages were renamed off their busybox
+  origins (`pkg/udhcpc` → `pkg/dhcp`, `cmd/udhcpc-handler` →
+  `cmd/dhcp-handler`, #245), and the integration suite gained a per-test
+  timing summary plus several runtime cuts (#253, #254, #255, #276).
+
+Operator-visible compatibility: classless static routes (option 121) are
+honored **by default** (`skip_routes` defaults to `false`). If your DHCP
+server pushes option-121 routes, containers will pick them up after the
+upgrade where previously they were ignored; set `-o skip_routes=true` to
+keep the old behaviour. All other new features (`stable_lease`,
+`lease_seed`, `register_dns`) are off by default — no action is required to
+upgrade from v1.2.x.
+
 ## v1.2.0
 
 A DHCP-client modernization release. The plugin's DHCP client changes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,13 +36,22 @@ The v1.1.0 Dependency Review gate (#193) surfaced two further
 
 Both are `docker cp` / archive-extraction paths in the Moby daemon and
 CLI. The plugin invokes none of them — its only client calls remain the
-three inspect/list APIs above — so neither is reachable; `govulncheck`
-confirms (green). No fix is published on the frozen
+three inspect/list APIs above. No fix is published on the frozen
 `github.com/docker/docker` module path (successor `moby/moby/v2`
 migration tracked in #178). They are accepted at the advisory level in
 `.github/dependency-review-config.yml` with a review date, alongside the
 older AuthZ finding (GHSA-x744-4wpc-v9h2 = GO-2026-4887), and will be
 re-evaluated when the module migration lands.
+
+During the v1.3.0 window (2026-06-28) the Go vulnerability database
+imported these advisories, so `govulncheck` now reports them through
+module-init symbol traces — the assessment above is unchanged, but
+"govulncheck is green" no longer holds. All three (GO-2026-5746 =
+GHSA-x86f-5xw2-fm2r, GO-2026-5617 = GHSA-rg2x-37c3-w2rh, plus the
+newly published GO-2026-5668 = GHSA-vp62-88p7-qqf5, a `docker cp`
+symlink-swap empty-file race, also daemon-side) are accepted with
+justification in `.github/vuln-allowlist.txt` (#291, #292) until a
+fixed release ships on the module path we depend on.
 
 ## v1.3.0
 

--- a/docs/bridge-mode.md
+++ b/docs/bridge-mode.md
@@ -37,7 +37,7 @@ sudo dhcpcd my-bridge
 ## 2. Create the network
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.2.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.0 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 ```
 
@@ -45,7 +45,7 @@ With IPv6 as well (the `docker network create --ipv6` flag does **not**
 work with the null IPAM driver; use the `ipv6` driver option instead):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.2.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.0 \
   --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
 ```
 
@@ -100,7 +100,7 @@ services:
       - dhcp
 networks:
   dhcp:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.2.0
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.0
     driver_opts:
       bridge: my-bridge
       ipv6: 'true'

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ like any other machine. Bridge, macvlan, and ipvlan attachment modes.
 Install the plugin:
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.2.0
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.0
 ```
 
 It requests `host` networking, the host PID namespace, the Docker
@@ -34,7 +34,7 @@ already have a host bridge `my-bridge` on your LAN — see
 [Bridge mode](bridge-mode.md) for that one-time setup):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.2.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.0 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 
 docker run --rm -ti --network my-dhcp-net alpine ip address show

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -94,10 +94,13 @@ The host's NIC config (IP, routes, netplan/`systemd-networkd`,
 | `ipv6`              | all              | no       | Also run stateful DHCPv6 (a second `dhcpcd` with `-6`) in addition to DHCPv4 — see "DHCPv6" below for semantics and DUID/IAID identity. |
 | `lease_timeout`     | both      | no       | Initial-lease timeout for the up-front DHCP exchange (default `10s`). |
 | `ignore_conflicts`  | bridge    | no       | Skip the bridge-already-in-use check. No-op in macvlan mode.  |
-| `skip_routes`       | all       | no       | Don't copy non-default static routes from the parent (bridge / macvlan parent NIC / ipvlan parent NIC) into the container. v0.9.0 extended this from bridge-only to all modes for parity (#102) — set `true` to restore pre-v0.9.0 macvlan/ipvlan no-copy behaviour. |
+| `skip_routes`       | all       | no       | Don't copy non-default static routes from the parent (bridge / macvlan parent NIC / ipvlan parent NIC) into the container. v0.9.0 extended this from bridge-only to all modes for parity (#102) — set `true` to restore pre-v0.9.0 macvlan/ipvlan no-copy behaviour. Since v1.3.0 it also suppresses DHCP-supplied classless static routes (option 121, #260 — see `reference.md`). |
 | `propagate_dns`     | all       | no       | (v0.9.0+) Write DHCP option 6 / 23 (DNS server list) into the container's `/etc/resolv.conf` on bind/renew. Off by default; turning it on overrides Docker's embedded resolver for this network. The `search` line uses option 119 (Domain Search List) when supplied, falling back to option 15 (`Domain`) otherwise. |
 | `propagate_mtu`     | all       | no       | (v0.9.0+) Apply DHCP option 26 (Interface MTU) to the container link on bind/renew. Off by default; useful for jumbo-frame networks (9000) and VPN-reduced ones (~1450). |
 | `client_id`         | all       | no       | (v0.9.0+) Override DHCP option 61 (Client Identifier) for every endpoint on this network. Bytes go on the wire prefixed with type byte `0x00` (RFC 2132 opaque). Default empty keeps the per-endpoint stable id derived from the Docker endpoint ID, which is what makes per-container reservations work upstream. **Caveat:** a static `client_id` across containers means the DHCP server can't differentiate them. Typically only useful when paired with `vendor_class` to drive class-based policy. |
+| `stable_lease`      | ipvlan    | no       | (v1.3.0+) Derive the option-61 client-id from the container's **stable identity** instead of the per-recreate endpoint id, so a server that keys leases on option 61 (`dnsmasq` by default) returns the same IP across `stop` / `rm` / recreate. ipvlan-only — ipvlan slaves share the parent's MAC, so the client-id is the only per-container handle; bridge/macvlan reject the opt (their lease stability comes from the deterministic-MAC work, not yet available). Identity resolves most-specific-first: `lease_seed`, then Compose `project`+`service`+`container-number`, then `--name`; an anonymous container falls back to the endpoint id and bumps `stable_lease_no_identity` on `/Plugin.Health`. See `reference.md` for the full treatment (#219). |
+| `lease_seed`        | ipvlan    | no       | (v1.3.0+) Highest-precedence identity source for `stable_lease`: the client-id is a hash of the network plus this value. Two containers sharing a `lease_seed` collapse onto one lease; one container keeps its lease across recreate regardless of name or Compose labels. Inert unless `stable_lease=true`. |
+| `register_dns`      | all       | no       | (v1.3.0+) Send the DHCP FQDN option (81 on v4 / 39 on v6) built from the container hostname, asking the server to register forward (A/AAAA) + reverse (PTR) DNS. Best-effort and advisory — many consumer routers ignore option 81. Off by default: dynamic-DNS registration is a network-policy decision (#261). |
 | `vendor_class`      | all       | no       | (v0.9.0+) Override DHCP option 60 (Vendor Class Identifier). Default `docker-net-dhcp`. Lets DHCP servers running class-based policy (Cisco / Aruba / etc.) issue different gateways or option sets to containers tagged with a known vendor string. v6 unaffected — the DHCPv6 client sends no vendor-class option. |
 | `validate_dhcp`     | macvlan, ipvlan | no | (v0.9.0+) Pre-flight DHCP probe at `docker network create` time. Creates a temporary macvlan child on the parent NIC with a random locally-administered MAC, runs a one-shot `dhcpcd` with a 5-second budget, and rejects the network with `no DHCP OFFER on <parent> within 5s` if no server answers. Catches misconfigurations (parent isolated, firewall blocking UDP/67-68, broken VLAN tag) at create time rather than the first `docker run`. Cost: one transient lease per probe in the upstream pool. Bridge mode rejects the opt with a clear error. |
 | `audit_log`         | all       | no       | (v1.0.0+) Append every lease-lifecycle event on this network (`bound` / `renew` / `release`, plus `release_failed` when the DHCPRELEASE didn't complete cleanly) to `STATE_DIR/leases.jsonl` — one JSON object per line with timestamp, network, endpoint, container ID, hostname, IP, and MAC. Answers "which IP did this container hold last Tuesday?" without DHCP-server-log archaeology. Rotated at 16 MB or 30 days (whichever first), one rotated generation kept (≤ ~32 MB total). Off by default: it costs a disk write per lease event, and container↔IP correlation on disk is privacy-relevant in some environments. Append failures bump `ledger_write_failures` on `/Plugin.Health` and never affect lease handling. |
@@ -313,7 +316,7 @@ exact create incantation (note: the Docker-level `--ipv6` flag does
 NOT work with the null IPAM driver and is not what you want):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.2.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.0 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 -o ipv6=true \
     lan-dhcp6
@@ -388,9 +391,16 @@ the same identity fields, regardless of attachment mode:
   (rather than MAC) keep handing the same lease back. This is
   the mechanism that makes ipvlan stability work, since every
   ipvlan slave shares the parent's MAC; for macvlan and bridge
-  it's a redundant safety net. Override per-network with
-  `-o client_id=<string>` (v0.9.0+); rarely useful since a static
-  ID across containers means the server can't differentiate them.
+  it's a redundant safety net. The endpoint id survives container
+  *restart* but not *recreate* (`docker rm` + `run` mints a fresh
+  endpoint, hence a fresh id) — so by default an ipvlan container
+  can change IP across a recreate. For ipvlan, `-o stable_lease=true`
+  (v1.3.0+) derives this id from the container's stable identity
+  instead, keeping the same lease across recreate too (see the
+  `stable_lease` / `lease_seed` options above and `reference.md`).
+  Override the id outright per-network with `-o client_id=<string>`
+  (v0.9.0+); rarely useful since a static ID across containers means
+  the server can't differentiate them.
 
 ### Captured DHCP options
 
@@ -575,7 +585,7 @@ endpoint operation everything is back to disk-served.
 Override the location via the `STATE_DIR` env var on the plugin:
 
 ```bash
-docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.2.0 STATE_DIR=/some/other/path
+docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.3.0 STATE_DIR=/some/other/path
 ```
 
 ## Plugin env vars

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,7 +27,7 @@ The plugin publishes to two registries; GHCR is primary:
 for unattended):
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.2.0
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.0
 ```
 
 Privileges requested: `network: host`, host PID namespace, the Docker
@@ -93,7 +93,7 @@ You bring an existing Linux bridge that is L2-connected to the LAN
 (see [`bridge-mode.md`](bridge-mode.md) for the bridge setup itself):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.2.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.0 \
     --ipam-driver null \
     -o bridge=my-bridge \
     my-dhcp-net
@@ -105,7 +105,7 @@ No host changes — containers get per-container kernel-generated MACs
 as macvlan children of a host NIC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.2.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.0 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 \
     lan-dhcp
@@ -119,7 +119,7 @@ security, hostile vSwitches, some Wi-Fi APs). The DHCP server must
 key reservations on DHCP option 61 (client identifier), not MAC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.2.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.0 \
     --ipam-driver null \
     -o mode=ipvlan -o parent=eth0 \
     lan-dhcp
@@ -283,7 +283,7 @@ Set with `docker plugin set <plugin> NAME=value`; take effect after
 JSON liveness + counters on the plugin's UNIX socket:
 
 ```bash
-PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.2.0)
+PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.3.0)
 curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
     http://localhost/Plugin.Health | jq .
 ```
@@ -355,7 +355,7 @@ Compose-managed alternative (network lifecycle tied to the project):
 ```yaml
 networks:
   lan:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.2.0
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.0
     driver_opts:
       mode: macvlan
       parent: eth0


### PR DESCRIPTION
Release-prep branch for v1.3.0 (runbook steps 1–4).

- **Version pins** bumped v1.2.0 → v1.3.0 across README and `docs/` (`check-version-pins.sh` passes).
- **RELEASE_NOTES** `## v1.3.0` section added, including the operator-visible compatibility note that DHCP option-121 classless static routes are now honored by default (`skip_routes` defaults `false`).
- **Documentation reconciliation** against the milestone: `docs/parent-attached-modes.md` now documents `stable_lease` / `lease_seed` / `register_dns`, the `skip_routes` row covers option 121, and the option-61 identity paragraph distinguishes restart vs recreate and points to `stable_lease` (#219). `reference.md` already carried full coverage; `check-option-docs.sh` passes for all options.

Docs/notes only — no code changes. Feeds the `Release v1.3.0` PR (`dev` → `main`).