### PR TITLE
ci(govulncheck): allowlist three daemon-side docker/docker advisories

### DIFF
--- a/.github/vuln-allowlist.txt
+++ b/.github/vuln-allowlist.txt
@@ -17,3 +17,19 @@
 #   vulnerable AuthZ/privilege paths run in dockerd, not in us.
 GO-2026-4887
 GO-2026-4883
+#
+# GO-2026-5617: docker cp race — bind mount redirection to host path.
+# GO-2026-5668: docker cp race — arbitrary empty file creation via
+#   symlink swap.
+# GO-2026-5746: PUT /containers/{id}/archive executes container binary
+#   on the host.
+#   All three live in github.com/docker/docker daemon-side code
+#   (docker cp / container archive handling in dockerd). This plugin
+#   only uses the client API against the local daemon socket; the
+#   vulnerable paths never execute in us. Fixed only in
+#   github.com/moby/moby/v2@v2.0.0-beta.14 — no fixed release exists
+#   for the legacy github.com/docker/docker module line (checked
+#   v28.5.2, 2026-07-03). Added in #292 (issue #291).
+GO-2026-5617
+GO-2026-5668
+GO-2026-5746


### PR DESCRIPTION
Fixes the govulncheck gate failure tracked in #291 (kept open for the release batch-close; the entries themselves are removed once a fixed release ships).

## What

Adds GO-2026-5617, GO-2026-5668 and GO-2026-5746 to `.github/vuln-allowlist.txt` with justification, following the allowlist's own rules.

## Why

Three new advisories against `github.com/docker/docker@v28.5.2+incompatible`, all in **daemon-side** `docker cp` / container-archive code that runs in dockerd — this plugin only uses the client API against the local daemon socket, so the vulnerable paths never execute in us (same situation as the existing GO-2026-4883/4887 entries).

Per the Go vuln DB there is **no fixed release for the legacy `github.com/docker/docker` module line** (the fix exists only in `github.com/moby/moby/v2@v2.0.0-beta.14`, checked 2026-07-03), so no dependency bump is available. The moment one ships, Dependabot surfaces it and these entries come out.

## Verification

- `scripts/test-govulncheck-gate.sh` — all gate self-tests pass.
- Gate simulated locally against the exact five IDs reported by the failing CI run: all five now `ALLOW`, gate passes.

Unblocks the required `govulncheck` check on Dependabot PRs #289/#290 and the upcoming v1.3.0 release checks.