### PR TITLE
docs(ci): reconcile dependency-review config comments with the govulncheck allowlist

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -8,9 +8,17 @@
 #   - Entries are only for findings with no fixed release available on
 #     the module path we depend on. The moment a fix ships, the bump
 #     lands and the entry is removed.
-#   - Reachability is the arbiter: an entry is only acceptable while
-#     govulncheck (scripts/govulncheck-gate.sh) reports the path
-#     unreachable. If govulncheck ever flags it, the acceptance is void.
+#   - The documented call-site review is the arbiter: an entry is only
+#     acceptable while the vulnerable code paths are not invoked by the
+#     plugin (this repo's only docker/docker call-sites are the client
+#     APIs listed below). Once the Go vuln DB imports an advisory,
+#     govulncheck reports it through module-init symbol traces
+#     regardless of actual invocation, so a govulncheck report alone
+#     does not void an acceptance — but it does require a matching,
+#     justified entry in .github/vuln-allowlist.txt. The lists stay in
+#     sync for advisories at or above fail-on-severity; lower-severity
+#     advisories live only in vuln-allowlist.txt (this gate never acts
+#     on them).
 
 fail-on-severity: high
 comment-summary-in-pr: on-failure
@@ -19,18 +27,26 @@ comment-summary-in-pr: on-failure
 # github.com/docker/docker. This plugin uses that module only as a
 # CLIENT library; its sole call-sites are NetworkList, NetworkInspect,
 # and ContainerInspect. It never invokes the AuthZ, archive-PUT, or
-# `docker cp` handlers where these live, so none are reachable from the
-# plugin process — govulncheck confirms (green on the same PRs). No fix
+# `docker cp` handlers where these live. The Go vuln DB imported the
+# `docker cp`/archive advisories on 2026-06-28; govulncheck now reports
+# all of them via init-chain traces, and they are accepted with the
+# same justification in .github/vuln-allowlist.txt (#291/#292). No fix
 # is available: the github.com/docker/docker module is frozen at
 # v28.5.2; the successor github.com/moby/moby/v2 migration is tracked in
 # #178, at which point these acceptances are re-evaluated. Reviewed
-# 2026-06-14 (#193).
+# 2026-06-14 (#193); re-reviewed 2026-07-03 (#291).
+#
+# Not listed (below fail-on-severity, so this gate never acts on them;
+# accepted in vuln-allowlist.txt only): GHSA-pxq6-2prw-chj9
+# (= GO-2026-4883, medium) and GHSA-vp62-88p7-qqf5 (= GO-2026-5668,
+# medium, `docker cp` symlink-swap empty-file race).
 allow-ghsas:
   # AuthZ plugin bypass on oversized request bodies (= GO-2026-4887,
   # also in vuln-allowlist.txt for the govulncheck gate).
   - GHSA-x744-4wpc-v9h2
-  # `PUT /containers/{id}/archive` executes container binary on the host.
+  # `PUT /containers/{id}/archive` executes container binary on the
+  # host (= GO-2026-5746).
   - GHSA-x86f-5xw2-fm2r
   # Race condition in `docker cp` allows bind-mount redirection to a
-  # host path.
+  # host path (= GO-2026-5617).
   - GHSA-rg2x-37c3-w2rh


### PR DESCRIPTION
Follow-up to #292 / part of #291.

## Why

`.github/dependency-review-config.yml` carried two claims that #292 made false:

- "govulncheck confirms (green on the same PRs)" — since the Go vuln DB imported the `docker cp`/archive advisories on 2026-06-28, govulncheck reports them via init-chain symbol traces.
- "If govulncheck ever flags it, the acceptance is void" — taken literally this voids all current acceptances, including GO-2026-4887, which govulncheck has always reported. The traces are module-init reachability, not invocation of the vulnerable handlers.

## What

Comment-only; the `allow-ghsas` list is unchanged:

- Arbiter restated as the documented call-site review (client APIs only: `NetworkList`, `NetworkInspect`, `ContainerInspect`); a govulncheck report now requires a matching justified `vuln-allowlist.txt` entry instead of voiding the acceptance.
- Each GHSA annotated with its GO- ID (GHSA-x86f-5xw2-fm2r = GO-2026-5746, GHSA-rg2x-37c3-w2rh = GO-2026-5617).
- Documented why GHSA-pxq6-2prw-chj9 (= GO-2026-4883) and GHSA-vp62-88p7-qqf5 (= GO-2026-5668) are absent: both medium severity, below `fail-on-severity: high`, so this gate never acts on them; they are accepted in `vuln-allowlist.txt` only.
- Review date extended: re-reviewed 2026-07-03 (#291).