### PR TITLE
ci: serialize privileged self-hosted jobs via shared concurrency group (#296)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,10 +26,14 @@ on:
     branches:
       - main
 
-# No concurrency group (intentional). Each dhcp-ci job runs in its own
-# ephemeral container with an isolated nested daemon, so coverage and
-# integration no longer contend for one bare-metal Docker state — they
-# run in parallel. See integration.yml for the full rationale.
+# Serialize all privileged self-hosted jobs (shared with
+# integration.yml, #296): the ephemeral runners isolate Docker state
+# but share one host's CPU/IO, and parallel privileged runs flaked
+# timing-sensitive tests on the v1.3.0 release PR. See integration.yml
+# for the full rationale and the pending-run-cancellation caveat.
+concurrency:
+  group: selfhosted-privileged
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,8 +12,8 @@ name: Integration
 # The `dhcp-ci` runners are ephemeral: one container = one job, each
 # with its own nested Docker daemon (image ghcr.io/claymore666/
 # dhcp-ci-runner, Docker Engine >= 28). An orchestrator pools 2-4 of
-# them (names dhcp-ci-<n>), so jobs run in PARALLEL and in full
-# isolation — replacing the single serial bare-metal runner.
+# them (names dhcp-ci-<n>) for full isolation — but privileged jobs
+# are serialized via the concurrency group below (#296).
 #
 # SECURITY: this workflow runs as root inside the runner container.
 # Repo Settings → Actions → General → "Fork pull request workflows
@@ -30,14 +30,19 @@ on:
       - main
       - dev
 
-# No concurrency group (intentional — do not re-add). The gpu1-era
-# `selfhosted-docker` group serialized jobs because they shared one
-# bare-metal Docker daemon (the :integration / :golang-cover plugin
-# refs, the dnsmasq fixture's fixed veth names + UDP/67). Each
-# `dhcp-ci` job now runs in its own ephemeral container with an
-# isolated nested daemon, so those collisions can't happen — parallel
-# jobs are safe, and serializing them would throw away the whole point
-# of the move.
+# Serialize all privileged self-hosted jobs (shared with coverage.yml,
+# #296). The ephemeral runners isolate Docker *state* (plugin refs,
+# veth names, UDP/67), so the old bare-metal collisions can't happen —
+# but they still share one host's CPU/IO, and the suite has real-time
+# DHCP timing in it: parallel privileged runs flaked the 5s preflight
+# probe and stalled recreates past lease timing on the v1.3.0 release
+# PR. One group restores the serialization the pool cutover dropped.
+# Caveat: GitHub keeps at most one *pending* run per group — a third
+# concurrent run cancels the queued one, which then needs a manual
+# re-run. Acceptable at this repo's volume.
+concurrency:
+  group: selfhosted-privileged
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Restores serialization of the privileged self-hosted jobs (`integration`, `coverage`) via a shared workflow-level concurrency group `selfhosted-privileged` with `cancel-in-progress: false` — option 1 from #296.

## Why

The ephemeral-runner cutover dropped the old `selfhosted-docker` group because the runners isolate all Docker *state*. They do — but they still share one host's CPU/IO, and the integration suite carries real-time DHCP timing. On the v1.3.0 release PR (#295), `coverage` racing two `integration` runs produced two contention flakes (5s preflight probe; a recreate stalled past lease timing amid docker-API timeouts). Details in #296.

## Changes

- `integration.yml` / `coverage.yml`: replace the "No concurrency group (intentional)" blocks with the shared group; header comment no longer claims jobs run in parallel.
- Documented caveat in the comment: GitHub keeps at most one *pending* run per group, so a third concurrent run cancels the queued one (needs a manual re-run). Acceptable at this repo's volume — same behavior as the pre-cutover group.

## Verification

- `actionlint` v1.7.12 (the CI-pinned version) clean on both files.
- The group's effect (queueing, not cancelling, a second run) is only observable with two live runs; this PR's own runs exercise the syntax, and the next time integration and coverage coincide will exercise the queueing. Flagging per the "merged-but-unexercised" rule.

Refs #296 (batch-closes on release, per convention).
