### PR TITLE
docs(ci): fix stale coverage.yml trigger comments (#207)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,9 +13,9 @@ name: Coverage
 # `integration.yml`.
 #
 # Same ephemeral `dhcp-ci` runners as integration.yml, same security
-# posture (outside-collaborator approval required for forked PRs —
-# though only `workflow_dispatch` is wired here, so forks can't trigger
-# this at all).
+# posture: a forked PR into main would trigger this (the pull_request
+# trigger below, added in #127), so the outside-collaborator approval
+# requirement is what keeps untrusted code off the privileged runners.
 on:
   workflow_dispatch:
   # Release PRs (dev → main) run coverage as a required check: the
@@ -53,8 +53,8 @@ jobs:
       # at one point, so stdlib recompiles failed with the
       # 'compile: version "go1.25.9" does not match go tool version
       # "go1.25.0"' error. setup-go gives us a known-clean toolchain
-      # at the cost of ~30s — fine for a 12-minute workflow that
-      # runs only on manual dispatch.
+      # at the cost of ~30s — fine for a workflow that runs only on
+      # release PRs and manual dispatch, not per feature PR.
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '1.26'


### PR DESCRIPTION
## Summary

Actionable output of the #207 workflow audit (full report: https://github.com/claymore666/docker-net-dhcp/issues/207#issuecomment-4881065218). Verdict there: all 12 workflows earn their place — the only rot found is two stale comments in `coverage.yml`, fixed here.

Both predate #127 wiring the `pull_request → main` trigger:

- The header claimed "only `workflow_dispatch` is wired here, so forks can't trigger this at all". A forked PR into main **does** trigger this workflow; the outside-collaborator approval requirement is the real protection for the privileged runners. The comment now says so — this one mattered, since it misstated the security posture.
- The setup-go rationale claimed the workflow "runs only on manual dispatch" — it also runs on every release PR.

Comment-only, no behavior change. `actionlint` v1.7.12 clean.

Refs #207 (audit complete with this PR; batch-closes on release, per convention).
