### PR TITLE
tests(ci): ratchet coverage floors to post-dhcpcd measured levels (#303)

### DIFF
--- a/.github/coverage-baseline.txt
+++ b/.github/coverage-baseline.txt
@@ -46,8 +46,24 @@
 #   Floors carry over unchanged under the new import paths; the
 #   historical decision notes above keep the names they had at the
 #   time. Same code, same floors.
+#
+# v1.4.0 recorded decision (#303 — reconcile floors with measured):
+#   The pkg/dhcp and cmd/dhcp-handler floors were still the carried-over
+#   udhcpc-era numbers; the dhcpcd migration (#152) and the v1.3.0 test
+#   work earned coverage on top that no PR ratcheted in, leaving up to
+#   25 points of silent-regression headroom. Measured merged coverage
+#   (Coverage runs #22 + #23, identical to 0.1%):
+#   - pkg/dhcp 85.5 -> 89.5: RAISED. Measured 90.0; 0.5 under.
+#   - cmd/dhcp-handler 50.0 -> 74.0: RAISED. Measured 75.0; 1.0 under
+#     because the package is one ~16-statement main() and granularity
+#     is coarse.
+#   - pkg/plugin 82.0 -> 83.5: RAISED. Measured 83.8; 0.3 under, the
+#     same margin the v1.2.0 decision used for this package.
+#   - pkg/util (88.7 meas.) and cmd/net-dhcp (75.4 meas.) left at
+#     floor: their deltas are within the documented variance band,
+#     not earned by any identifiable change.
 github.com/devplayer0/docker-net-dhcp/pkg/util 88.0
-github.com/devplayer0/docker-net-dhcp/pkg/plugin 82.0
-github.com/devplayer0/docker-net-dhcp/pkg/dhcp 85.5
+github.com/devplayer0/docker-net-dhcp/pkg/plugin 83.5
+github.com/devplayer0/docker-net-dhcp/pkg/dhcp 89.5
 github.com/devplayer0/docker-net-dhcp/cmd/net-dhcp 75.0
-github.com/devplayer0/docker-net-dhcp/cmd/dhcp-handler 50.0
+github.com/devplayer0/docker-net-dhcp/cmd/dhcp-handler 74.0


### PR DESCRIPTION
Refs #303.

## What

Raises three coverage-ratchet floors in `.github/coverage-baseline.txt` to the levels the suite actually delivers, with a dated decision note in the file header per its own rules:

| package | floor | new floor | measured |
|---|---|---|---|
| `pkg/dhcp` | 85.5 | **89.5** | 90.0 |
| `cmd/dhcp-handler` | 50.0 | **74.0** | 75.0 |
| `pkg/plugin` | 82.0 | **83.5** | 83.8 |

`pkg/util` (88.7 measured vs 88.0) and `cmd/net-dhcp` (75.4 vs 75.0) are deliberately left alone — their deltas are within the documented variance band, not earned improvements.

## Why

The `pkg/dhcp` / `cmd/dhcp-handler` floors were still the udhcpc-era numbers carried over verbatim by the v1.3.0 rename note. The dhcpcd migration (#152) and the v1.3.0 test work earned real coverage on top that no PR ratcheted in — leaving 4.5 and 25 points of headroom where a regression would pass the required Coverage check green. Evidence in #303: the merged profiles of Coverage runs #22 and #23 agree to 0.1%.

## Verification

- [x] `scripts/coverage-ratchet.sh` run locally against the run-#23 measured numbers and the new baseline: **passes** (all five packages hold or beat their floors).
- [x] Same script against a synthetic `pkg/dhcp` 88.9% (a 1.1-point regression the old 85.5 floor would have passed): **fails** with the expected epsilon message.
- [x] `scripts/test-coverage-ratchet.sh` meta-test suite: green.
- [x] New floors exercised in real CI after all: `workflow_dispatch` of the Coverage workflow on this branch (run #25, serialized behind the integration queue by the new #296 concurrency group) — ratchet step passes, all five packages hold or beat their floors with the intended margins (90.0 vs 89.5, 75.0 vs 74.0, 83.8 vs 83.5). Third independent run reproducing identical numbers.

