### PR TITLE
tests(plugin): cover CreateTemp and Rename error arms of state persistence (#305)

### DIFF
--- a/.github/coverage-baseline.txt
+++ b/.github/coverage-baseline.txt
@@ -62,8 +62,15 @@
 #   - pkg/util (88.7 meas.) and cmd/net-dhcp (75.4 meas.) left at
 #     floor: their deltas are within the documented variance band,
 #     not earned by any identifiable change.
+#
+# v1.4.0 (#305, PR #306): pkg/plugin 83.5 -> 83.8. RAISED, earned by
+#   the state-persistence error-arm tests (saveOptions/saveTombstones
+#   CreateTemp + Rename injection). Measured merged 84.1 on this PR's
+#   coverage dispatch; all other packages identical to the decimal
+#   across four runs now, so the +0.3 is attributable, not variance.
+#   Floor 0.3 under measured, same margin as the prior two decisions.
 github.com/devplayer0/docker-net-dhcp/pkg/util 88.0
-github.com/devplayer0/docker-net-dhcp/pkg/plugin 83.5
+github.com/devplayer0/docker-net-dhcp/pkg/plugin 83.8
 github.com/devplayer0/docker-net-dhcp/pkg/dhcp 89.5
 github.com/devplayer0/docker-net-dhcp/cmd/net-dhcp 75.0
 github.com/devplayer0/docker-net-dhcp/cmd/dhcp-handler 74.0

--- a/pkg/plugin/tombstone_failure_test.go
+++ b/pkg/plugin/tombstone_failure_test.go
@@ -102,3 +102,104 @@ func TestDeleteOptions_PermissionError(t *testing.T) {
 		t.Fatal("expected error when state dir is read-only")
 	}
 }
+
+// TestSaveOptions_CreateTempFailure covers the CreateTemp error arm of
+// the atomic-write pipeline (#305): the state dir exists but is not
+// writable, the operational shape of EROFS / disk-full at temp-file
+// creation time. The Write/Close/Chmod arms downstream share this
+// cause and stay uncovered on purpose — see #305.
+//
+// Skipped under root because chmod 0o555 doesn't prevent writes for
+// privileged users.
+func TestSaveOptions_CreateTempFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("chmod-based DAC tests don't apply to root")
+	}
+	dir := t.TempDir()
+	withStateDir(t, dir)
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	if err := saveOptions("net-tmpfail", DHCPNetworkOptions{Bridge: "br0"}); err == nil {
+		t.Fatal("expected error when state dir is not writable")
+	}
+}
+
+// TestSaveTombstones_CreateTempFailure is the tombstone-writer
+// analogue: same read-only-dir injection, same skip rationale.
+func TestSaveTombstones_CreateTempFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("chmod-based DAC tests don't apply to root")
+	}
+	dir := t.TempDir()
+	withStateDir(t, dir)
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	if err := saveTombstones([]tombstone{{NetworkID: "net-A"}}); err == nil {
+		t.Fatal("expected error when state dir is not writable")
+	}
+}
+
+// TestSaveOptions_RenameFailure covers the final arm of the pipeline:
+// os.Rename onto a path occupied by a non-empty directory fails for
+// any uid (ENOTEMPTY/EISDIR), so unlike the chmod tests this one also
+// runs in the coverage workflow's root unit-test pass. Beyond the
+// error itself it pins the two cleanup contracts of a failed save:
+// no stray temp file left in the state dir, and the occupying path
+// untouched (a crash mid-save must never destroy existing state).
+func TestSaveOptions_RenameFailure(t *testing.T) {
+	dir := t.TempDir()
+	withStateDir(t, dir)
+	// Occupy the final path with a non-empty directory.
+	final := filepath.Join(dir, "net-rename.json")
+	if err := os.MkdirAll(filepath.Join(final, "occupant"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	if err := saveOptions("net-rename", DHCPNetworkOptions{Bridge: "br0"}); err == nil {
+		t.Fatal("expected error when final path is a non-empty directory")
+	}
+
+	leftovers, err := filepath.Glob(filepath.Join(dir, ".state-*.tmp"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(leftovers) != 0 {
+		t.Errorf("failed save must remove its temp file, found %v", leftovers)
+	}
+	if _, err := os.Stat(filepath.Join(final, "occupant")); err != nil {
+		t.Errorf("failed save must leave the occupying path untouched: %v", err)
+	}
+}
+
+// TestSaveTombstones_RenameFailure is the tombstone-writer analogue,
+// asserting the same error-plus-cleanup contract for the shared
+// tombstones.json path.
+func TestSaveTombstones_RenameFailure(t *testing.T) {
+	dir := t.TempDir()
+	withStateDir(t, dir)
+	final := filepath.Join(dir, "tombstones.json")
+	if err := os.MkdirAll(filepath.Join(final, "occupant"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	if err := saveTombstones([]tombstone{{NetworkID: "net-A"}}); err == nil {
+		t.Fatal("expected error when tombstones.json is a non-empty directory")
+	}
+
+	leftovers, err := filepath.Glob(filepath.Join(dir, ".tombstones.*.tmp"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(leftovers) != 0 {
+		t.Errorf("failed save must remove its temp file, found %v", leftovers)
+	}
+	if _, err := os.Stat(filepath.Join(final, "occupant")); err != nil {
+		t.Errorf("failed save must leave the occupying path untouched: %v", err)
+	}
+}


### PR DESCRIPTION
Refs #305.

## What

Four failure-injection unit tests for the atomic-write pipeline in `pkg/plugin/state.go`, per the test design on the issue:

- `TestSaveOptions_CreateTempFailure` / `TestSaveTombstones_CreateTempFailure` — read-only state dir (EROFS/disk-full shape); root-skipped like the existing DAC tests, so they run in the Test workflow and skip in the coverage workflow's root pass.
- `TestSaveOptions_RenameFailure` / `TestSaveTombstones_RenameFailure` — final path occupied by a non-empty directory; fails for any uid, so these run everywhere. Beyond the error they pin the cleanup contract: **no stray temp file after a failed save, and the occupying path untouched**.

Function coverage (unit): `saveTombstones` 54.2% → 66.7%, `saveOptions` 57.7% → 69.2%. The Write/Close/Chmod arms stay uncovered by design — rationale recorded on #305.

## Verification

- [x] All four tests pass; full unit suite green; staticcheck clean.
- [x] Mutation check: removing the rename-arm's `os.Remove(tmpName)` cleanup in `saveOptions` makes `TestSaveOptions_RenameFailure` fail on the leftover assertion — the tests can detect the regression they exist for. Code restored; test passes again.
- [x] Coverage floor: coverage dispatched on this branch (run #26) measured pkg/plugin merged at **84.1%** (was 83.8 in #303’s measurement; all other packages identical to the decimal across four runs, so the +0.3 is attributable to these tests). Floor ratcheted 83.5 → 83.8 in this PR per the baseline’s rules.

