### PR TITLE
Prepare v1.3.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ like any other machine. Bridge, macvlan, and ipvlan attachment modes.
 Install the plugin:
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.0
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.1
 ```
 
 It requests `host` networking, the host PID namespace, the Docker
@@ -43,7 +43,7 @@ already have a host bridge `my-bridge` on your LAN — see
 [bridge mode](docs/bridge-mode.md) for that one-time setup):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.1 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 
 docker run --rm -ti --network my-dhcp-net alpine ip address show

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -53,6 +53,39 @@ symlink-swap empty-file race, also daemon-side) are accepted with
 justification in `.github/vuln-allowlist.txt` (#291, #292) until a
 fixed release ships on the module path we depend on.
 
+## v1.3.1
+
+A patch release: one bug fix in the `validate_dhcp` pre-flight probe,
+plus test-pipeline hardening. No new features, no manifest changes, no
+new options.
+
+What changed:
+
+- **`validate_dhcp` no longer misreports live DHCP servers as
+  unreachable on slow hosts** (#307). The probe's time budget assumed
+  sub-second client startup; on slower or virtualized hosts (SBCs, NAS
+  boxes, nested Docker), dhcpcd startup plus one lost-and-retransmitted
+  DISCOVER could exceed it, failing `docker network create -o
+  validate_dhcp=true` against a perfectly working server. The budget is
+  now sized for that worst case (5s → 8s). Successful probes are
+  unaffected (they return as soon as the lease lands, typically 1–2s);
+  only the genuine-failure path reports ~3s later. The error message now
+  reads `no DHCP OFFER on <parent> within 8s`.
+- **CI: privileged integration and coverage jobs are serialized**
+  (#296). Parallel runs on the shared runner host stretched
+  DHCP-timing-sensitive tests past their budgets; a shared concurrency
+  group restores one-at-a-time execution.
+- **Coverage floors reconciled and ratcheted** (#303, #305). Two
+  per-package coverage floors were stale carry-overs from the pre-dhcpcd
+  client (one 25 points below what the suite delivers), leaving room for
+  silent regressions; floors now match measured reality. New unit tests
+  cover the state-persistence failure paths (temp-file creation and
+  atomic-rename errors), raising and re-pinning the plugin package
+  floor.
+- **CI workflow audit** (#207). All workflows reconfirmed as earning
+  their keep; a stale comment misdescribing the coverage workflow's
+  fork-trigger security posture was corrected.
+
 ## v1.3.0
 
 A feature release that builds new DHCP capabilities on the dhcpcd client

--- a/docs/bridge-mode.md
+++ b/docs/bridge-mode.md
@@ -37,7 +37,7 @@ sudo dhcpcd my-bridge
 ## 2. Create the network
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.1 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 ```
 
@@ -45,7 +45,7 @@ With IPv6 as well (the `docker network create --ipv6` flag does **not**
 work with the null IPAM driver; use the `ipv6` driver option instead):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.1 \
   --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
 ```
 
@@ -100,7 +100,7 @@ services:
       - dhcp
 networks:
   dhcp:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.0
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.1
     driver_opts:
       bridge: my-bridge
       ipv6: 'true'

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ like any other machine. Bridge, macvlan, and ipvlan attachment modes.
 Install the plugin:
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.0
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.1
 ```
 
 It requests `host` networking, the host PID namespace, the Docker
@@ -34,7 +34,7 @@ already have a host bridge `my-bridge` on your LAN — see
 [Bridge mode](bridge-mode.md) for that one-time setup):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.1 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 
 docker run --rm -ti --network my-dhcp-net alpine ip address show

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -314,7 +314,7 @@ exact create incantation (note: the Docker-level `--ipv6` flag does
 NOT work with the null IPAM driver and is not what you want):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.1 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 -o ipv6=true \
     lan-dhcp6
@@ -583,7 +583,7 @@ endpoint operation everything is back to disk-served.
 Override the location via the `STATE_DIR` env var on the plugin:
 
 ```bash
-docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.3.0 STATE_DIR=/some/other/path
+docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.3.1 STATE_DIR=/some/other/path
 ```
 
 ## Plugin env vars

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,7 +27,7 @@ The plugin publishes to two registries; GHCR is primary:
 for unattended):
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.0
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.1
 ```
 
 Privileges requested: `network: host`, host PID namespace, the Docker
@@ -93,7 +93,7 @@ You bring an existing Linux bridge that is L2-connected to the LAN
 (see [`bridge-mode.md`](bridge-mode.md) for the bridge setup itself):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.1 \
     --ipam-driver null \
     -o bridge=my-bridge \
     my-dhcp-net
@@ -105,7 +105,7 @@ No host changes — containers get per-container kernel-generated MACs
 as macvlan children of a host NIC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.1 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 \
     lan-dhcp
@@ -119,7 +119,7 @@ security, hostile vSwitches, some Wi-Fi APs). The DHCP server must
 key reservations on DHCP option 61 (client identifier), not MAC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.0 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.1 \
     --ipam-driver null \
     -o mode=ipvlan -o parent=eth0 \
     lan-dhcp
@@ -239,7 +239,7 @@ Set with `docker plugin set <plugin> NAME=value`; take effect after
 JSON liveness + counters on the plugin's UNIX socket:
 
 ```bash
-PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.3.0)
+PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.3.1)
 curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
     http://localhost/Plugin.Health | jq .
 ```
@@ -310,7 +310,7 @@ Compose-managed alternative (network lifecycle tied to the project):
 ```yaml
 networks:
   lan:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.0
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.1
     driver_opts:
       mode: macvlan
       parent: eth0


### PR DESCRIPTION
Runbook steps 1–4 for v1.3.1: install-pin bump to v1.3.1 (pin gate green locally), RELEASE_NOTES section, and the PR-driven docs review — #308 (probe budget) is the milestone's only user-visible change and its doc deltas shipped in the PR itself; verified in place with no stale 5s references. All other milestone PRs are CI/test-internal with no doc surface.