### PR TITLE
ci: skip the integration suite for docs-only PRs and duplicate post-merge trees (#311, #312)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,6 +46,9 @@ concurrency:
 
 permissions:
   contents: read
+  # actions:read — the gate step below lists this workflow's own past
+  # runs to dedupe identical trees (#312).
+  actions: read
 
 jobs:
   integration:
@@ -59,11 +62,34 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # Decide whether this event needs the suite at all: docs-only PR
+      # diffs (#311) and post-merge pushes whose tree already passed
+      # (#312) exit in seconds instead of holding the serialized pool
+      # slot for ~22 minutes. Deliberately a job STEP, not a workflow
+      # paths filter — `integration` is a required check, and a
+      # workflow that never triggers leaves PRs stuck on "Expected".
+      # The script fails open (any API error → run); its meta-test
+      # runs in test.yaml's gate-script step.
+      - name: Suite-needed gate
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GATE_REPO: ${{ github.repository }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            decision=$(bash scripts/integration-run-gate.sh pr "${{ github.event.pull_request.number }}") || decision=run
+          else
+            decision=$(bash scripts/integration-run-gate.sh push "$(git rev-parse 'HEAD^{tree}')") || decision=run
+          fi
+          echo "decision=${decision}" >> "$GITHUB_OUTPUT"
+          echo "gate decision: ${decision}"
+
       # The Go toolchain (go.mod's version) is baked into the dhcp-ci
       # runner image, so actions/setup-go is skipped. Fail loudly if
       # it's ever missing — that means the runner image drifted from
       # go.mod and needs a rebuild (ci/runner-image/).
       - name: Verify Go toolchain
+        if: steps.gate.outputs.decision == 'run'
         run: |
           if ! command -v go >/dev/null; then
             echo "go not in PATH — dhcp-ci runner image is stale vs go.mod; rebuild ci/runner-image/"
@@ -74,6 +100,7 @@ jobs:
       # Best-effort: clean any orphans from a previous run that
       # panicked mid-setup. Safe to run even on a clean state.
       - name: Cleanup orphans from previous runs
+        if: steps.gate.outputs.decision == 'run'
         run: bash test/integration/cleanup-orphans.sh
 
       # Build + install the plugin from THIS PR's source tree, tagged
@@ -88,6 +115,7 @@ jobs:
       # tests its own plugin code". Same shape as coverage.yml's
       # plugin-cover step, just without the -cover instrumentation.
       - name: Build + install integration plugin
+        if: steps.gate.outputs.decision == 'run'
         run: |
           make PLUGIN_NAME=ghcr.io/claymore666/docker-net-dhcp PLUGIN_TAG=integration plugin
           docker plugin rm -f "${INTEGRATION_PLUGIN_REF}" 2>/dev/null || true
@@ -101,6 +129,7 @@ jobs:
       # default is `bash -e` WITHOUT pipefail, which let tee's exit 0
       # swallow go-test failures and pass the gate green (#297).
       - name: Run integration tests
+        if: steps.gate.outputs.decision == 'run'
         shell: bash
         run: make integration-test 2>&1 | tee /tmp/itest-main.log
 
@@ -109,6 +138,7 @@ jobs:
       # Separate step so a red here is immediately distinguishable
       # from a main-suite regression.
       - name: Run failure-injection tests
+        if: steps.gate.outputs.decision == 'run'
         shell: bash
         run: make integration-test-failure 2>&1 | tee /tmp/itest-failure.log
 
@@ -118,7 +148,7 @@ jobs:
       # owns no pass/fail and tolerates a missing log (e.g. the failure
       # step was skipped because the main suite already failed).
       - name: Test timing summary
-        if: always()
+        if: always() && steps.gate.outputs.decision == 'run'
         run: scripts/integration-timing.sh /tmp/itest-main.log /tmp/itest-failure.log
 
       # Tear down so a follow-up workflow on the same runner doesn't
@@ -126,7 +156,7 @@ jobs:
       # PR's source. Always-run; failure of the test step shouldn't
       # leave global state behind.
       - name: Tear down integration plugin
-        if: always()
+        if: always() && steps.gate.outputs.decision == 'run'
         run: |
           docker plugin disable "${INTEGRATION_PLUGIN_REF}" 2>/dev/null || true
           docker plugin rm -f "${INTEGRATION_PLUGIN_REF}" 2>/dev/null || true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,6 +75,7 @@ jobs:
           bash scripts/test-check-apk-pins.sh
           bash scripts/test-check-version-pins.sh
           bash scripts/test-integration-timing.sh
+          bash scripts/test-integration-run-gate.sh
 
       # Every driver-option key the code parses must be documented in
       # docs/reference.md — an undocumented option turns CI red (#132).

--- a/scripts/integration-run-gate.sh
+++ b/scripts/integration-run-gate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Decide whether the integration suite actually needs to run for this
+# event (#311, #312). Two skippable shapes:
+#
+#   pr <number>     docs-only PR diffs (#311): every changed path is
+#                   *.md — nothing the suite executes. The allowlist is
+#                   deliberately just *.md; comment-only code changes,
+#                   workflow edits, scripts, Dockerfile etc. all run
+#                   the full suite.
+#   push <treesha>  duplicate post-merge trees (#312): a squash merge
+#                   whose tree is byte-identical to a tree that already
+#                   passed integration (the PR's merge-ref run, when the
+#                   base didn't move in between). A tree that differs —
+#                   the semantic-conflict case dev-push runs exist for —
+#                   always runs.
+#
+# Prints exactly one word on stdout: "run" or "skip" (reason on stderr).
+# FAIL-OPEN by design: any API error, unexpected input, or unknown mode
+# prints "run" — the expensive path is always the safe one. This gate is
+# a job step, NOT a workflow paths filter: `integration` is a required
+# check, and a workflow that never triggers leaves PRs stuck on
+# "Expected" forever.
+#
+# Env: GATE_REPO=owner/repo, GH_TOKEN for `gh api`.
+# Test hook: the meta-test (scripts/test-integration-run-gate.sh) stubs
+# `gh` via PATH; `classify` mode exposes the pure path-classifier.
+set -uo pipefail
+
+MODE="${1:-}"
+
+# docs_only: stdin = newline-separated changed paths.
+# Exit 0 only when there is at least one path and every path is *.md.
+docs_only() {
+    local any=0 f
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        any=1
+        case "$f" in
+            *.md) ;;
+            *) return 1 ;;
+        esac
+    done
+    [ "$any" -eq 1 ]
+}
+
+case "$MODE" in
+    classify)
+        # Pure classifier for the meta-test: exit 0 = docs-only.
+        docs_only
+        ;;
+    pr)
+        PR="${2:-}"
+        [ -n "$PR" ] && [ -n "${GATE_REPO:-}" ] || { echo run; exit 0; }
+        files=$(gh api "repos/${GATE_REPO}/pulls/${PR}/files" --paginate -q '.[].filename' 2>/dev/null) \
+            || { echo run; exit 0; }
+        if printf '%s\n' "$files" | docs_only; then
+            echo "docs-only diff (all *.md) — suite adds no signal (#311)" >&2
+            echo skip
+        else
+            echo run
+        fi
+        ;;
+    push)
+        TREE="${2:-}"
+        [ -n "$TREE" ] && [ -n "${GATE_REPO:-}" ] || { echo run; exit 0; }
+        shas=$(gh api "repos/${GATE_REPO}/actions/workflows/integration.yml/runs?status=success&per_page=15" \
+                -q '.workflow_runs[].head_sha' 2>/dev/null) \
+            || { echo run; exit 0; }
+        for sha in $shas; do
+            t=$(gh api "repos/${GATE_REPO}/commits/${sha}" -q '.commit.tree.sha' 2>/dev/null) || continue
+            if [ "$t" = "$TREE" ]; then
+                echo "tree ${TREE} already passed integration at ${sha} — duplicate skipped (#312)" >&2
+                echo skip
+                exit 0
+            fi
+        done
+        echo run
+        ;;
+    *)
+        echo run
+        ;;
+esac

--- a/scripts/test-integration-run-gate.sh
+++ b/scripts/test-integration-run-gate.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Meta-test for integration-run-gate.sh (#311, #312). The failure mode
+# these guard against is the gate going too wide: a skip decision on a
+# diff or tree that actually needs the suite. Every ambiguous case must
+# come out "run" (fail-open).
+set -euo pipefail
+
+GATE="$(dirname "$0")/integration-run-gate.sh"
+fails=0
+
+check() {
+    local desc="$1" want="$2" got="$3"
+    if [ "$got" = "$want" ]; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc — want '$want', got '$got'"
+        fails=1
+    fi
+}
+
+# --- classify mode (pure path classifier, #311) ---
+
+got=$(printf 'README.md\ndocs/reference.md\n' | bash "$GATE" classify && echo docs-only || echo not)
+check "md-only diff classifies docs-only" docs-only "$got"
+
+got=$(printf 'README.md\npkg/plugin/state.go\n' | bash "$GATE" classify && echo docs-only || echo not)
+check "mixed md+go diff is NOT docs-only" not "$got"
+
+got=$(printf 'scripts/coverage-ratchet.sh\n' | bash "$GATE" classify && echo docs-only || echo not)
+check "script-only diff is NOT docs-only" not "$got"
+
+got=$(printf '.github/workflows/integration.yml\n' | bash "$GATE" classify && echo docs-only || echo not)
+check "workflow-only diff is NOT docs-only" not "$got"
+
+got=$(printf '' | bash "$GATE" classify && echo docs-only || echo not)
+check "empty diff is NOT docs-only" not "$got"
+
+got=$(printf 'README.mdx\n' | bash "$GATE" classify && echo docs-only || echo not)
+check ".mdx does not sneak past the .md match" not "$got"
+
+# --- pr / push modes with a stubbed gh ---
+
+STUB_DIR=$(mktemp -d)
+trap 'rm -rf "$STUB_DIR"' EXIT
+export GATE_REPO="owner/repo"
+
+make_gh() { # $1 = stub body
+    printf '#!/usr/bin/env bash\n%s\n' "$1" > "$STUB_DIR/gh"
+    chmod +x "$STUB_DIR/gh"
+}
+
+# pr mode: stub returns only md files -> skip
+make_gh 'printf "README.md\ndocs/index.md\n"'
+got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" pr 99 2>/dev/null)
+check "pr mode skips a docs-only PR" skip "$got"
+
+# pr mode: stub returns a go file among md -> run
+make_gh 'printf "README.md\nmain.go\n"'
+got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" pr 99 2>/dev/null)
+check "pr mode runs a mixed PR" run "$got"
+
+# pr mode: gh fails -> run (fail-open)
+make_gh 'exit 1'
+got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" pr 99 2>/dev/null)
+check "pr mode fails open on API error" run "$got"
+
+# push mode: one prior run whose commit has a MATCHING tree -> skip
+make_gh 'case "$*" in
+  *actions/workflows*) printf "cafe1234\n" ;;
+  *commits/cafe1234*) printf "deadbeeftree\n" ;;
+  *) exit 1 ;;
+esac'
+got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" push deadbeeftree 2>/dev/null)
+check "push mode skips an already-passed tree" skip "$got"
+
+# push mode: prior run tree DIFFERS -> run (the semantic-conflict case)
+got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" push othertree000 2>/dev/null)
+check "push mode runs a novel tree" run "$got"
+
+# push mode: runs list fails -> run (fail-open)
+make_gh 'exit 1'
+got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" push deadbeeftree 2>/dev/null)
+check "push mode fails open on API error" run "$got"
+
+# push mode: per-commit lookup fails for the only candidate -> run
+make_gh 'case "$*" in
+  *actions/workflows*) printf "cafe1234\n" ;;
+  *) exit 1 ;;
+esac'
+got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" push deadbeeftree 2>/dev/null)
+check "push mode fails open when commit lookup fails" run "$got"
+
+# unknown mode / missing args -> run
+got=$(bash "$GATE" bogus 2>/dev/null)
+check "unknown mode falls back to run" run "$got"
+got=$(bash "$GATE" pr 2>/dev/null)
+check "pr mode without number falls back to run" run "$got"
+
+if [ "$fails" -ne 0 ]; then
+    echo "integration-run-gate tests FAILED"
+    exit 1
+fi
+echo "All integration-run-gate tests passed"


### PR DESCRIPTION
Refs #311, #312 (close via the next release PR).

The integration suite holds the serialized privileged-runner slot for ~22 minutes. Two event shapes gain nothing from it:

- **Docs-only PR diffs (#311):** every changed path is `*.md` — nothing the suite executes. The allowlist is deliberately just `*.md`; scripts, workflows, Dockerfile, and comment-only code changes all still run the full suite.
- **Duplicate post-merge trees (#312):** a squash/merge commit whose tree is byte-identical to a tree that already passed integration (the PR's merge-ref run, when the base didn't move). A differing tree — the semantic-conflict case dev-push runs exist for — always runs.

## Design

- `scripts/integration-run-gate.sh` prints exactly `run` or `skip`. **Fail-open everywhere:** any API error, missing arg, or unknown mode → `run`. The expensive path is always the safe one.
- The gate is an in-job **step**, not a workflow `paths` filter: `integration` is a required check, and a workflow that never triggers leaves PRs stuck on "Expected" forever. A skipped run still reports success in seconds.
- Push mode matches the current commit's tree SHA against the last 15 successful integration runs' commit trees via the API (needs the new `actions: read` permission).

## Tests

- `scripts/test-integration-run-gate.sh` (15 cases): docs-only/mixed/empty classification, `.mdx` doesn't sneak past `*.md`, stubbed-`gh` pr/push modes, and every fail-open arm. Wired into test.yaml's gate-script self-test step.
- actionlint clean on both touched workflows.

## Verification status

The meta-test passes locally and in CI; the live skip paths (a real docs-only PR, a real duplicate-tree push) are **not yet exercised** — the first post-merge dev push and the next docs-only PR will demonstrate them, and this PR's own run demonstrates the `run` path.