### PR TITLE
Release v1.3.2

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,6 +46,9 @@ concurrency:
 
 permissions:
   contents: read
+  # actions:read — the gate step below lists this workflow's own past
+  # runs to dedupe identical trees (#312).
+  actions: read
 
 jobs:
   integration:
@@ -59,11 +62,34 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # Decide whether this event needs the suite at all: docs-only PR
+      # diffs (#311) and post-merge pushes whose tree already passed
+      # (#312) exit in seconds instead of holding the serialized pool
+      # slot for ~22 minutes. Deliberately a job STEP, not a workflow
+      # paths filter — `integration` is a required check, and a
+      # workflow that never triggers leaves PRs stuck on "Expected".
+      # The script fails open (any API error → run); its meta-test
+      # runs in test.yaml's gate-script step.
+      - name: Suite-needed gate
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GATE_REPO: ${{ github.repository }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            decision=$(bash scripts/integration-run-gate.sh pr "${{ github.event.pull_request.number }}") || decision=run
+          else
+            decision=$(bash scripts/integration-run-gate.sh push "$(git rev-parse 'HEAD^{tree}')") || decision=run
+          fi
+          echo "decision=${decision}" >> "$GITHUB_OUTPUT"
+          echo "gate decision: ${decision}"
+
       # The Go toolchain (go.mod's version) is baked into the dhcp-ci
       # runner image, so actions/setup-go is skipped. Fail loudly if
       # it's ever missing — that means the runner image drifted from
       # go.mod and needs a rebuild (ci/runner-image/).
       - name: Verify Go toolchain
+        if: steps.gate.outputs.decision == 'run'
         run: |
           if ! command -v go >/dev/null; then
             echo "go not in PATH — dhcp-ci runner image is stale vs go.mod; rebuild ci/runner-image/"
@@ -74,6 +100,7 @@ jobs:
       # Best-effort: clean any orphans from a previous run that
       # panicked mid-setup. Safe to run even on a clean state.
       - name: Cleanup orphans from previous runs
+        if: steps.gate.outputs.decision == 'run'
         run: bash test/integration/cleanup-orphans.sh
 
       # Build + install the plugin from THIS PR's source tree, tagged
@@ -88,6 +115,7 @@ jobs:
       # tests its own plugin code". Same shape as coverage.yml's
       # plugin-cover step, just without the -cover instrumentation.
       - name: Build + install integration plugin
+        if: steps.gate.outputs.decision == 'run'
         run: |
           make PLUGIN_NAME=ghcr.io/claymore666/docker-net-dhcp PLUGIN_TAG=integration plugin
           docker plugin rm -f "${INTEGRATION_PLUGIN_REF}" 2>/dev/null || true
@@ -101,6 +129,7 @@ jobs:
       # default is `bash -e` WITHOUT pipefail, which let tee's exit 0
       # swallow go-test failures and pass the gate green (#297).
       - name: Run integration tests
+        if: steps.gate.outputs.decision == 'run'
         shell: bash
         run: make integration-test 2>&1 | tee /tmp/itest-main.log
 
@@ -109,6 +138,7 @@ jobs:
       # Separate step so a red here is immediately distinguishable
       # from a main-suite regression.
       - name: Run failure-injection tests
+        if: steps.gate.outputs.decision == 'run'
         shell: bash
         run: make integration-test-failure 2>&1 | tee /tmp/itest-failure.log
 
@@ -118,7 +148,7 @@ jobs:
       # owns no pass/fail and tolerates a missing log (e.g. the failure
       # step was skipped because the main suite already failed).
       - name: Test timing summary
-        if: always()
+        if: always() && steps.gate.outputs.decision == 'run'
         run: scripts/integration-timing.sh /tmp/itest-main.log /tmp/itest-failure.log
 
       # Tear down so a follow-up workflow on the same runner doesn't
@@ -126,7 +156,7 @@ jobs:
       # PR's source. Always-run; failure of the test step shouldn't
       # leave global state behind.
       - name: Tear down integration plugin
-        if: always()
+        if: always() && steps.gate.outputs.decision == 'run'
         run: |
           docker plugin disable "${INTEGRATION_PLUGIN_REF}" 2>/dev/null || true
           docker plugin rm -f "${INTEGRATION_PLUGIN_REF}" 2>/dev/null || true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,6 +75,7 @@ jobs:
           bash scripts/test-check-apk-pins.sh
           bash scripts/test-check-version-pins.sh
           bash scripts/test-integration-timing.sh
+          bash scripts/test-integration-run-gate.sh
 
       # Every driver-option key the code parses must be documented in
       # docs/reference.md — an undocumented option turns CI red (#132).

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ like any other machine. Bridge, macvlan, and ipvlan attachment modes.
 Install the plugin:
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.1
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.2
 ```
 
 It requests `host` networking, the host PID namespace, the Docker
@@ -43,7 +43,7 @@ already have a host bridge `my-bridge` on your LAN — see
 [bridge mode](docs/bridge-mode.md) for that one-time setup):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.1 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 
 docker run --rm -ti --network my-dhcp-net alpine ip address show
@@ -139,7 +139,9 @@ Contributions are welcome.
     ratchet enforces this at release time.
   - **Green CI:** every PR must pass the required checks — unit tests,
     `staticcheck`, the live integration suite, `govulncheck`, and `actionlint` —
-    before it can be merged.
+    before it can be merged. (Docs-only PRs — diffs touching nothing but
+    `*.md` — satisfy the integration check via a fast in-job skip; any code,
+    script, or workflow change runs the full suite.)
   - **Hosted cross-check:** a separate, *non-required* workflow runs the
     integration suite on a stock GitHub-hosted runner on a weekly schedule
     (and on demand) to validate the plugin against a vanilla distro's Docker.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -53,6 +53,27 @@ symlink-swap empty-file race, also daemon-side) are accepted with
 justification in `.github/vuln-allowlist.txt` (#291, #292) until a
 fixed release ships on the module path we depend on.
 
+## v1.3.2
+
+A CI-only patch release: the plugin's runtime code is identical to
+v1.3.1 — no functional changes, no new options, no manifest changes.
+Published so the version tag, docs pins, and CI behaviour stay in
+lockstep.
+
+What changed:
+
+- **The integration suite skips runs that add no signal** (#311, #312).
+  Two event shapes previously held the serialized privileged CI slot
+  for ~22 minutes each without exercising anything: PRs whose diff
+  touches nothing but `*.md`, and post-merge pushes whose source tree
+  is byte-identical to a tree that already passed the suite (the PR's
+  own pre-merge run). An in-job gate now detects both and exits in
+  seconds — the required check still reports, so nothing gets stuck
+  waiting on a workflow that never triggers. The gate fails open: any
+  API error or ambiguity runs the full suite. Any code, script,
+  workflow, or Dockerfile change is unaffected and always runs
+  everything.
+
 ## v1.3.1
 
 A patch release: one bug fix in the `validate_dhcp` pre-flight probe,

--- a/docs/bridge-mode.md
+++ b/docs/bridge-mode.md
@@ -37,7 +37,7 @@ sudo dhcpcd my-bridge
 ## 2. Create the network
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.1 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 ```
 
@@ -45,7 +45,7 @@ With IPv6 as well (the `docker network create --ipv6` flag does **not**
 work with the null IPAM driver; use the `ipv6` driver option instead):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.1 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
   --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
 ```
 
@@ -100,7 +100,7 @@ services:
       - dhcp
 networks:
   dhcp:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.1
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.2
     driver_opts:
       bridge: my-bridge
       ipv6: 'true'

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ like any other machine. Bridge, macvlan, and ipvlan attachment modes.
 Install the plugin:
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.1
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.2
 ```
 
 It requests `host` networking, the host PID namespace, the Docker
@@ -34,7 +34,7 @@ already have a host bridge `my-bridge` on your LAN — see
 [Bridge mode](bridge-mode.md) for that one-time setup):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.1 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 
 docker run --rm -ti --network my-dhcp-net alpine ip address show

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -314,7 +314,7 @@ exact create incantation (note: the Docker-level `--ipv6` flag does
 NOT work with the null IPAM driver and is not what you want):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.1 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 -o ipv6=true \
     lan-dhcp6
@@ -583,7 +583,7 @@ endpoint operation everything is back to disk-served.
 Override the location via the `STATE_DIR` env var on the plugin:
 
 ```bash
-docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.3.1 STATE_DIR=/some/other/path
+docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.3.2 STATE_DIR=/some/other/path
 ```
 
 ## Plugin env vars

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,7 +27,7 @@ The plugin publishes to two registries; GHCR is primary:
 for unattended):
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.1
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.2
 ```
 
 Privileges requested: `network: host`, host PID namespace, the Docker
@@ -93,7 +93,7 @@ You bring an existing Linux bridge that is L2-connected to the LAN
 (see [`bridge-mode.md`](bridge-mode.md) for the bridge setup itself):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.1 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
     --ipam-driver null \
     -o bridge=my-bridge \
     my-dhcp-net
@@ -105,7 +105,7 @@ No host changes — containers get per-container kernel-generated MACs
 as macvlan children of a host NIC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.1 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 \
     lan-dhcp
@@ -119,7 +119,7 @@ security, hostile vSwitches, some Wi-Fi APs). The DHCP server must
 key reservations on DHCP option 61 (client identifier), not MAC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.1 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
     --ipam-driver null \
     -o mode=ipvlan -o parent=eth0 \
     lan-dhcp
@@ -239,7 +239,7 @@ Set with `docker plugin set <plugin> NAME=value`; take effect after
 JSON liveness + counters on the plugin's UNIX socket:
 
 ```bash
-PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.3.1)
+PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.3.2)
 curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
     http://localhost/Plugin.Health | jq .
 ```
@@ -310,7 +310,7 @@ Compose-managed alternative (network lifecycle tied to the project):
 ```yaml
 networks:
   lan:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.1
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.2
     driver_opts:
       mode: macvlan
       parent: eth0

--- a/scripts/integration-run-gate.sh
+++ b/scripts/integration-run-gate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Decide whether the integration suite actually needs to run for this
+# event (#311, #312). Two skippable shapes:
+#
+#   pr <number>     docs-only PR diffs (#311): every changed path is
+#                   *.md — nothing the suite executes. The allowlist is
+#                   deliberately just *.md; comment-only code changes,
+#                   workflow edits, scripts, Dockerfile etc. all run
+#                   the full suite.
+#   push <treesha>  duplicate post-merge trees (#312): a squash merge
+#                   whose tree is byte-identical to a tree that already
+#                   passed integration (the PR's merge-ref run, when the
+#                   base didn't move in between). A tree that differs —
+#                   the semantic-conflict case dev-push runs exist for —
+#                   always runs.
+#
+# Prints exactly one word on stdout: "run" or "skip" (reason on stderr).
+# FAIL-OPEN by design: any API error, unexpected input, or unknown mode
+# prints "run" — the expensive path is always the safe one. This gate is
+# a job step, NOT a workflow paths filter: `integration` is a required
+# check, and a workflow that never triggers leaves PRs stuck on
+# "Expected" forever.
+#
+# Env: GATE_REPO=owner/repo, GH_TOKEN for `gh api`.
+# Test hook: the meta-test (scripts/test-integration-run-gate.sh) stubs
+# `gh` via PATH; `classify` mode exposes the pure path-classifier.
+set -uo pipefail
+
+MODE="${1:-}"
+
+# docs_only: stdin = newline-separated changed paths.
+# Exit 0 only when there is at least one path and every path is *.md.
+docs_only() {
+    local any=0 f
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        any=1
+        case "$f" in
+            *.md) ;;
+            *) return 1 ;;
+        esac
+    done
+    [ "$any" -eq 1 ]
+}
+
+case "$MODE" in
+    classify)
+        # Pure classifier for the meta-test: exit 0 = docs-only.
+        docs_only
+        ;;
+    pr)
+        PR="${2:-}"
+        [ -n "$PR" ] && [ -n "${GATE_REPO:-}" ] || { echo run; exit 0; }
+        files=$(gh api "repos/${GATE_REPO}/pulls/${PR}/files" --paginate -q '.[].filename' 2>/dev/null) \
+            || { echo run; exit 0; }
+        if printf '%s\n' "$files" | docs_only; then
+            echo "docs-only diff (all *.md) — suite adds no signal (#311)" >&2
+            echo skip
+        else
+            echo run
+        fi
+        ;;
+    push)
+        TREE="${2:-}"
+        [ -n "$TREE" ] && [ -n "${GATE_REPO:-}" ] || { echo run; exit 0; }
+        shas=$(gh api "repos/${GATE_REPO}/actions/workflows/integration.yml/runs?status=success&per_page=15" \
+                -q '.workflow_runs[].head_sha' 2>/dev/null) \
+            || { echo run; exit 0; }
+        for sha in $shas; do
+            t=$(gh api "repos/${GATE_REPO}/commits/${sha}" -q '.commit.tree.sha' 2>/dev/null) || continue
+            if [ "$t" = "$TREE" ]; then
+                echo "tree ${TREE} already passed integration at ${sha} — duplicate skipped (#312)" >&2
+                echo skip
+                exit 0
+            fi
+        done
+        echo run
+        ;;
+    *)
+        echo run
+        ;;
+esac

--- a/scripts/integration-run-gate.sh
+++ b/scripts/integration-run-gate.sh
@@ -15,18 +15,37 @@
 #                   always runs.
 #
 # Prints exactly one word on stdout: "run" or "skip" (reason on stderr).
-# FAIL-OPEN by design: any API error, unexpected input, or unknown mode
-# prints "run" — the expensive path is always the safe one. This gate is
-# a job step, NOT a workflow paths filter: `integration` is a required
-# check, and a workflow that never triggers leaves PRs stuck on
-# "Expected" forever.
+# FAIL-OPEN by design: any API error, unexpected input, missing tool, or
+# unknown mode prints "run" — the expensive path is always the safe one.
+# This gate is a job step, NOT a workflow paths filter: `integration` is
+# a required check, and a workflow that never triggers leaves PRs stuck
+# on "Expected" forever.
 #
-# Env: GATE_REPO=owner/repo, GH_TOKEN for `gh api`.
+# API access is curl + jq, NOT the gh CLI: the self-hosted runner image
+# doesn't ship gh (learned live — the first post-merge gate silently
+# failed open on `gh: command not found`). curl and jq are baked into
+# the image and verified below; if either goes missing the gate says so
+# on stderr and fails open.
+#
+# Env: GATE_REPO=owner/repo, GH_TOKEN for the API.
 # Test hook: the meta-test (scripts/test-integration-run-gate.sh) stubs
-# `gh` via PATH; `classify` mode exposes the pure path-classifier.
+# `curl` via PATH; `classify` mode exposes the pure path-classifier.
 set -uo pipefail
 
 MODE="${1:-}"
+
+api_get() {
+    curl -sf --max-time 15 \
+        -H "Authorization: Bearer ${GH_TOKEN:-}" \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/$1"
+}
+
+have_deps() {
+    command -v curl >/dev/null && command -v jq >/dev/null && return 0
+    echo "gate: curl or jq missing on this runner — failing open" >&2
+    return 1
+}
 
 # docs_only: stdin = newline-separated changed paths.
 # Exit 0 only when there is at least one path and every path is *.md.
@@ -51,9 +70,22 @@ case "$MODE" in
     pr)
         PR="${2:-}"
         [ -n "$PR" ] && [ -n "${GATE_REPO:-}" ] || { echo run; exit 0; }
-        files=$(gh api "repos/${GATE_REPO}/pulls/${PR}/files" --paginate -q '.[].filename' 2>/dev/null) \
-            || { echo run; exit 0; }
-        if printf '%s\n' "$files" | docs_only; then
+        have_deps || { echo run; exit 0; }
+        # Page through the changed-file list. A page shorter than 100
+        # entries is the last one; a still-full page past the cap means
+        # we can't see the whole diff — fail open rather than judge a
+        # truncated view.
+        files="" page=1
+        while :; do
+            chunk=$(api_get "repos/${GATE_REPO}/pulls/${PR}/files?per_page=100&page=${page}" \
+                    | jq -r '.[].filename') || { echo run; exit 0; }
+            files="${files}${chunk}"$'\n'
+            n=$(printf '%s\n' "$chunk" | grep -c .) || n=0
+            [ "$n" -lt 100 ] && break
+            page=$((page + 1))
+            [ "$page" -gt 10 ] && { echo run; exit 0; }
+        done
+        if printf '%s' "$files" | docs_only; then
             echo "docs-only diff (all *.md) — suite adds no signal (#311)" >&2
             echo skip
         else
@@ -63,11 +95,11 @@ case "$MODE" in
     push)
         TREE="${2:-}"
         [ -n "$TREE" ] && [ -n "${GATE_REPO:-}" ] || { echo run; exit 0; }
-        shas=$(gh api "repos/${GATE_REPO}/actions/workflows/integration.yml/runs?status=success&per_page=15" \
-                -q '.workflow_runs[].head_sha' 2>/dev/null) \
-            || { echo run; exit 0; }
+        have_deps || { echo run; exit 0; }
+        shas=$(api_get "repos/${GATE_REPO}/actions/workflows/integration.yml/runs?status=success&per_page=15" \
+                | jq -r '.workflow_runs[].head_sha') || { echo run; exit 0; }
         for sha in $shas; do
-            t=$(gh api "repos/${GATE_REPO}/commits/${sha}" -q '.commit.tree.sha' 2>/dev/null) || continue
+            t=$(api_get "repos/${GATE_REPO}/commits/${sha}" | jq -r '.commit.tree.sha') || continue
             if [ "$t" = "$TREE" ]; then
                 echo "tree ${TREE} already passed integration at ${sha} — duplicate skipped (#312)" >&2
                 echo skip

--- a/scripts/test-integration-run-gate.sh
+++ b/scripts/test-integration-run-gate.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Meta-test for integration-run-gate.sh (#311, #312). The failure mode
+# these guard against is the gate going too wide: a skip decision on a
+# diff or tree that actually needs the suite. Every ambiguous case must
+# come out "run" (fail-open).
+set -euo pipefail
+
+GATE="$(dirname "$0")/integration-run-gate.sh"
+fails=0
+
+check() {
+    local desc="$1" want="$2" got="$3"
+    if [ "$got" = "$want" ]; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc — want '$want', got '$got'"
+        fails=1
+    fi
+}
+
+# --- classify mode (pure path classifier, #311) ---
+
+got=$(printf 'README.md\ndocs/reference.md\n' | bash "$GATE" classify && echo docs-only || echo not)
+check "md-only diff classifies docs-only" docs-only "$got"
+
+got=$(printf 'README.md\npkg/plugin/state.go\n' | bash "$GATE" classify && echo docs-only || echo not)
+check "mixed md+go diff is NOT docs-only" not "$got"
+
+got=$(printf 'scripts/coverage-ratchet.sh\n' | bash "$GATE" classify && echo docs-only || echo not)
+check "script-only diff is NOT docs-only" not "$got"
+
+got=$(printf '.github/workflows/integration.yml\n' | bash "$GATE" classify && echo docs-only || echo not)
+check "workflow-only diff is NOT docs-only" not "$got"
+
+got=$(printf '' | bash "$GATE" classify && echo docs-only || echo not)
+check "empty diff is NOT docs-only" not "$got"
+
+got=$(printf 'README.mdx\n' | bash "$GATE" classify && echo docs-only || echo not)
+check ".mdx does not sneak past the .md match" not "$got"
+
+# --- pr / push modes with a stubbed gh ---
+
+STUB_DIR=$(mktemp -d)
+trap 'rm -rf "$STUB_DIR"' EXIT
+export GATE_REPO="owner/repo"
+
+make_gh() { # $1 = stub body
+    printf '#!/usr/bin/env bash\n%s\n' "$1" > "$STUB_DIR/gh"
+    chmod +x "$STUB_DIR/gh"
+}
+
+# pr mode: stub returns only md files -> skip
+make_gh 'printf "README.md\ndocs/index.md\n"'
+got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" pr 99 2>/dev/null)
+check "pr mode skips a docs-only PR" skip "$got"
+
+# pr mode: stub returns a go file among md -> run
+make_gh 'printf "README.md\nmain.go\n"'
+got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" pr 99 2>/dev/null)
+check "pr mode runs a mixed PR" run "$got"
+
+# pr mode: gh fails -> run (fail-open)
+make_gh 'exit 1'
+got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" pr 99 2>/dev/null)
+check "pr mode fails open on API error" run "$got"
+
+# push mode: one prior run whose commit has a MATCHING tree -> skip
+make_gh 'case "$*" in
+  *actions/workflows*) printf "cafe1234\n" ;;
+  *commits/cafe1234*) printf "deadbeeftree\n" ;;
+  *) exit 1 ;;
+esac'
+got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" push deadbeeftree 2>/dev/null)
+check "push mode skips an already-passed tree" skip "$got"
+
+# push mode: prior run tree DIFFERS -> run (the semantic-conflict case)
+got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" push othertree000 2>/dev/null)
+check "push mode runs a novel tree" run "$got"
+
+# push mode: runs list fails -> run (fail-open)
+make_gh 'exit 1'
+got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" push deadbeeftree 2>/dev/null)
+check "push mode fails open on API error" run "$got"
+
+# push mode: per-commit lookup fails for the only candidate -> run
+make_gh 'case "$*" in
+  *actions/workflows*) printf "cafe1234\n" ;;
+  *) exit 1 ;;
+esac'
+got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" push deadbeeftree 2>/dev/null)
+check "push mode fails open when commit lookup fails" run "$got"
+
+# unknown mode / missing args -> run
+got=$(bash "$GATE" bogus 2>/dev/null)
+check "unknown mode falls back to run" run "$got"
+got=$(bash "$GATE" pr 2>/dev/null)
+check "pr mode without number falls back to run" run "$got"
+
+if [ "$fails" -ne 0 ]; then
+    echo "integration-run-gate tests FAILED"
+    exit 1
+fi
+echo "All integration-run-gate tests passed"

--- a/scripts/test-integration-run-gate.sh
+++ b/scripts/test-integration-run-gate.sh
@@ -38,37 +38,61 @@ check "empty diff is NOT docs-only" not "$got"
 got=$(printf 'README.mdx\n' | bash "$GATE" classify && echo docs-only || echo not)
 check ".mdx does not sneak past the .md match" not "$got"
 
-# --- pr / push modes with a stubbed gh ---
+# --- pr / push modes with a stubbed curl ---
+# The gate talks to the API with curl + jq (the runner image has no gh
+# CLI). The stub keys off the request URL in "$*"; real jq parses the
+# canned JSON, so the stub output must be valid API-shaped JSON.
 
 STUB_DIR=$(mktemp -d)
 trap 'rm -rf "$STUB_DIR"' EXIT
 export GATE_REPO="owner/repo"
 
-make_gh() { # $1 = stub body
-    printf '#!/usr/bin/env bash\n%s\n' "$1" > "$STUB_DIR/gh"
-    chmod +x "$STUB_DIR/gh"
+make_curl() { # $1 = stub body
+    printf '#!/usr/bin/env bash\n%s\n' "$1" > "$STUB_DIR/curl"
+    chmod +x "$STUB_DIR/curl"
 }
 
 # pr mode: stub returns only md files -> skip
-make_gh 'printf "README.md\ndocs/index.md\n"'
+make_curl 'printf "[{\"filename\":\"README.md\"},{\"filename\":\"docs/index.md\"}]"'
 got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" pr 99 2>/dev/null)
 check "pr mode skips a docs-only PR" skip "$got"
 
 # pr mode: stub returns a go file among md -> run
-make_gh 'printf "README.md\nmain.go\n"'
+make_curl 'printf "[{\"filename\":\"README.md\"},{\"filename\":\"main.go\"}]"'
 got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" pr 99 2>/dev/null)
 check "pr mode runs a mixed PR" run "$got"
 
-# pr mode: gh fails -> run (fail-open)
-make_gh 'exit 1'
+# pr mode: curl fails -> run (fail-open)
+make_curl 'exit 22'
 got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" pr 99 2>/dev/null)
 check "pr mode fails open on API error" run "$got"
 
+# pr mode: a FULL first page (100 md files) must not be judged alone —
+# page 2 carries a go file, so the verdict is run. Guards the
+# truncated-view bug class. (Match on "&page=N" — a bare "page=1" also
+# matches inside "per_page=100".)
+make_curl 'case "$*" in
+  *"&page=1"*) jq -n "[range(100) | {filename: (\"doc\" + tostring + \".md\")}]" ;;
+  *"&page=2"*) printf "[{\"filename\":\"main.go\"}]" ;;
+  *) exit 22 ;;
+esac'
+got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" pr 99 2>/dev/null)
+check "pr mode pages past a full page before judging" run "$got"
+
+# ...and a short second page of md keeps the skip.
+make_curl 'case "$*" in
+  *"&page=1"*) jq -n "[range(100) | {filename: (\"doc\" + tostring + \".md\")}]" ;;
+  *"&page=2"*) printf "[{\"filename\":\"last.md\"}]" ;;
+  *) exit 22 ;;
+esac'
+got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" pr 99 2>/dev/null)
+check "pr mode still skips a paginated all-md diff" skip "$got"
+
 # push mode: one prior run whose commit has a MATCHING tree -> skip
-make_gh 'case "$*" in
-  *actions/workflows*) printf "cafe1234\n" ;;
-  *commits/cafe1234*) printf "deadbeeftree\n" ;;
-  *) exit 1 ;;
+make_curl 'case "$*" in
+  *actions/workflows*) printf "{\"workflow_runs\":[{\"head_sha\":\"cafe1234\"}]}" ;;
+  *commits/cafe1234*) printf "{\"commit\":{\"tree\":{\"sha\":\"deadbeeftree\"}}}" ;;
+  *) exit 22 ;;
 esac'
 got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" push deadbeeftree 2>/dev/null)
 check "push mode skips an already-passed tree" skip "$got"
@@ -78,17 +102,26 @@ got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" push othertree000 2>/dev/null)
 check "push mode runs a novel tree" run "$got"
 
 # push mode: runs list fails -> run (fail-open)
-make_gh 'exit 1'
+make_curl 'exit 22'
 got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" push deadbeeftree 2>/dev/null)
 check "push mode fails open on API error" run "$got"
 
 # push mode: per-commit lookup fails for the only candidate -> run
-make_gh 'case "$*" in
-  *actions/workflows*) printf "cafe1234\n" ;;
-  *) exit 1 ;;
+make_curl 'case "$*" in
+  *actions/workflows*) printf "{\"workflow_runs\":[{\"head_sha\":\"cafe1234\"}]}" ;;
+  *) exit 22 ;;
 esac'
 got=$(PATH="$STUB_DIR:$PATH" bash "$GATE" push deadbeeftree 2>/dev/null)
 check "push mode fails open when commit lookup fails" run "$got"
+
+# missing tools: no curl/jq anywhere on PATH -> run (the gh-CLI lesson:
+# a runner without the dependency must fail open, not fail silent).
+# bash itself is resolved before PATH is emptied.
+BASH_BIN=$(command -v bash)
+got=$(PATH="" "$BASH_BIN" "$GATE" pr 99 2>/dev/null)
+check "pr mode fails open without curl/jq on PATH" run "$got"
+got=$(PATH="" "$BASH_BIN" "$GATE" push deadbeeftree 2>/dev/null)
+check "push mode fails open without curl/jq on PATH" run "$got"
 
 # unknown mode / missing args -> run
 got=$(bash "$GATE" bogus 2>/dev/null)


### PR DESCRIPTION
CI-only patch release: the integration suite now skips events that add no signal. The plugin's runtime code is identical to v1.3.1.

Closes #311
Closes #312

## What's in it

- **Integration-suite gate** (#314, fix in #315): docs-only PR diffs and post-merge pushes whose tree already passed the suite exit in seconds instead of holding the serialized privileged CI slot for ~22 minutes. In-job step (not a paths filter — the required check always reports), fail-open on any API error or missing tool, curl+jq (the runner image ships no gh CLI — the initial gh-based version silently failed open on every event; caught live on its first post-merge push).
- Both skip shapes are **live-verified**: the tree-dedupe skip fired on the post-merge dev push of #315 (suite skipped, check green in seconds); pr-mode ran correctly on mixed diffs. The docs-only skip is meta-tested (19 cases) and will demonstrate live on the first docs-only PR.
- Install pins bumped to v1.3.2; RELEASE_NOTES section added; README notes the docs-only fast-skip.