### PR TITLE
fix(plugin): CAP_SYS_PTRACE for non-root containers' netns + join_start_failures counter (#317)

### DIFF
--- a/config.json
+++ b/config.json
@@ -51,7 +51,8 @@
     "linux": {
         "capabilities": [
             "CAP_NET_ADMIN",
-            "CAP_SYS_ADMIN"
+            "CAP_SYS_ADMIN",
+            "CAP_SYS_PTRACE"
         ]
     }
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -246,12 +246,13 @@ curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
 
 | field | healthy-affecting | meaning |
 | ----- | ----------------- | ------- |
-| `healthy` | — | `false` when `recovery_failed` or `tombstone_write_failures` is non-zero — an operator should look. The plugin keeps serving fresh attaches either way. |
+| `healthy` | — | `false` when `recovery_failed`, `join_start_failures`, or `tombstone_write_failures` is non-zero — an operator should look. The plugin keeps serving fresh attaches either way. |
 | `uptime_seconds` | — | Seconds since the plugin process started. |
 | `active_endpoints` | — | DHCP managers currently registered (post-Join, pre-Leave). |
 | `pending_hints` | — | Join hints awaiting consumption; steady-state ~0. |
 | `recovered_ok` | — | Endpoints successfully rebuilt by plugin-restart recovery. |
 | `recovery_failed` | yes | Endpoints whose post-restart rebuild failed — those containers run without lease renewal and lose their IP at expiry; restart them. |
+| `join_start_failures` | yes | (v1.3.3+) Persistent-client start failures at attach time — the container got its initial lease but runs without renewal, and the lease is never released on disconnect (#317). The plugin log carries the cause; fix it and restart the container. |
 | `tombstone_write_failures` | yes | Failed tombstone saves (disk full, EROFS) — the next restart of some container will pick a fresh MAC/IP instead of inheriting. |
 | `lease_changed` | no | Renewals that returned a different IP than last recorded (v4+v6 aggregate). Docker's `inspect` view does **not** update on lease change (libnetwork has no in-place endpoint-IP swap), so this is the stale-inspect-window signal — alert on it for long-running containers. |
 | `leases_obtained` | no | `dhcpcd` bind events (`BOUND`/`REBOOT`, and the v6 equivalents): initial bind or re-bind after NAK/lease loss. v4+v6 aggregate. |

--- a/pkg/plugin/endpoints.go
+++ b/pkg/plugin/endpoints.go
@@ -256,13 +256,18 @@ func (p *Plugin) apiLeave(w http.ResponseWriter, r *http.Request) {
 // expiry. Operators should restart those containers (which produces a
 // fresh CreateEndpoint and gets them back into the persistent map).
 type HealthResponse struct {
-	Healthy                bool    `json:"healthy"`
-	UptimeSeconds          float64 `json:"uptime_seconds"`
-	ActiveEndpoints        int     `json:"active_endpoints"`
-	PendingHints           int     `json:"pending_hints"`
-	RecoveredOK            int32   `json:"recovered_ok"`
-	RecoveryFailed         int32   `json:"recovery_failed"`
-	TombstoneWriteFailures int32   `json:"tombstone_write_failures"`
+	Healthy         bool    `json:"healthy"`
+	UptimeSeconds   float64 `json:"uptime_seconds"`
+	ActiveEndpoints int     `json:"active_endpoints"`
+	PendingHints    int     `json:"pending_hints"`
+	RecoveredOK     int32   `json:"recovered_ok"`
+	RecoveryFailed  int32   `json:"recovery_failed"`
+	// JoinStartFailures counts persistent-client Start failures at
+	// Join time (#317): a running container with no renewal client.
+	// Healthy-affecting — same operator action as recovery_failed
+	// (find the cause in the plugin log, restart the container).
+	JoinStartFailures      int32 `json:"join_start_failures"`
+	TombstoneWriteFailures int32 `json:"tombstone_write_failures"`
 	// LeaseChanged counts renewals where dhcpcd returned a different
 	// IP than the manager last recorded. Not Healthy-affecting (it
 	// doesn't break Docker's view fatally — see plugin.go for the
@@ -309,18 +314,21 @@ func (p *Plugin) apiHealth(w http.ResponseWriter, r *http.Request) {
 	p.mu.Unlock()
 
 	failed := p.recoveryFailed.Load()
+	joinFails := p.joinStartFailures.Load()
 	tsFails := p.tombstoneWriteFailures.Load()
 	util.JSONResponse(w, HealthResponse{
 		// Healthy is false on any condition that means an operator
-		// should look: a recovery failure means a running container has
-		// no renewal goroutine; a tombstone-write failure means the
-		// next restart of some container will pick a new MAC/IP.
-		Healthy:                failed == 0 && tsFails == 0,
+		// should look: a recovery or join-start failure means a running
+		// container has no renewal goroutine; a tombstone-write failure
+		// means the next restart of some container will pick a new
+		// MAC/IP.
+		Healthy:                failed == 0 && joinFails == 0 && tsFails == 0,
 		UptimeSeconds:          time.Since(p.startTime).Seconds(),
 		ActiveEndpoints:        active,
 		PendingHints:           pending,
 		RecoveredOK:            p.recoveredOK.Load(),
 		RecoveryFailed:         failed,
+		JoinStartFailures:      joinFails,
 		TombstoneWriteFailures: tsFails,
 		LeaseChanged:           p.leaseChanged.Load(),
 		LeasesObtained:         p.leasesObtained.Load(),

--- a/pkg/plugin/endpoints_test.go
+++ b/pkg/plugin/endpoints_test.go
@@ -82,6 +82,35 @@ func TestApiHealth_TombstoneWriteFailureUnhealthy(t *testing.T) {
 	}
 }
 
+// TestApiHealth_JoinStartFailureUnhealthy verifies that a non-zero
+// joinStartFailures counter flips the response to unhealthy and is
+// reported under join_start_failures (#317). The counter is bumped from
+// Join's Start-failure goroutine; as with the tombstone sibling above,
+// the surface under test is what /Plugin.Health reports.
+func TestApiHealth_JoinStartFailureUnhealthy(t *testing.T) {
+	p := &Plugin{
+		startTime:      time.Now(),
+		joinHints:      make(map[string]joinHint),
+		persistentDHCP: make(map[string]*dhcpManager),
+	}
+	p.joinStartFailures.Add(1)
+
+	req := httptest.NewRequest(http.MethodGet, "/Plugin.Health", nil)
+	rec := httptest.NewRecorder()
+	p.apiHealth(rec, req)
+
+	var got HealthResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Healthy {
+		t.Error("join-start failures must mark plugin unhealthy — a running container has no renewal client")
+	}
+	if got.JoinStartFailures != 1 {
+		t.Errorf("expected 1 join-start failure reported, got %d", got.JoinStartFailures)
+	}
+}
+
 // TestApiHealth_PerFamilyCounters pins the #212 contract on the wire:
 // the un-suffixed counters stay v4+v6 aggregates while the *_v6 siblings
 // carry the v6 subset, and both surface under their snake_case keys.

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -1039,6 +1039,7 @@ func (p *Plugin) Join(ctx context.Context, r JoinRequest) (JoinResponse, error) 
 		defer cancel()
 
 		if err := m.Start(ctx); err != nil {
+			p.joinStartFailures.Add(1)
 			log.WithError(err).WithFields(log.Fields{
 				"network":  shortID(r.NetworkID),
 				"endpoint": shortID(r.EndpointID),

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -311,6 +311,18 @@ type Plugin struct {
 	recoveredOK    atomic.Int32
 	recoveryFailed atomic.Int32
 
+	// joinStartFailures counts persistent-DHCP-client Start failures
+	// at Join time (#317). Each bump is a running container that got
+	// its initial lease but has NO renewal client: the lease silently
+	// ages toward expiry and is never released on disconnect. The
+	// canonical cause was the missing CAP_SYS_PTRACE (netns open on a
+	// non-root container's /proc/<pid>/ns/net); the counter exists so
+	// the next cause is visible on /Plugin.Health instead of only in
+	// the plugin log. Healthy-affecting, same operator semantics as
+	// recovery_failed: restart the affected container once the cause
+	// is fixed.
+	joinStartFailures atomic.Int32
+
 	// tombstoneWriteFailures counts saveTombstones failures (disk full,
 	// EROFS) from addTombstone. Reported on /Plugin.Health so operators
 	// can detect a degraded restart-stability window — every failure

--- a/pkg/util/netlink.go
+++ b/pkg/util/netlink.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -12,16 +13,25 @@ import (
 // or interval-paced retries exhaust. Synchronous to avoid leaking a
 // poller goroutine on ctx-cancel (the previous form did, and each leaked
 // goroutine kept hammering netns.GetFromPath forever).
+//
+// On ctx expiry the returned error wraps ctx.Err() (so errors.Is against
+// context.DeadlineExceeded keeps working) and carries the last attempt's
+// underlying error. A bare "context deadline exceeded" hid a persistent
+// EACCES for weeks in production — the netns open needs ptrace access to
+// the target process, and a permission failure retried to the deadline is
+// indistinguishable from a startup race without this (#317).
 func AwaitNetNS(ctx context.Context, path string, interval time.Duration) (netns.NsHandle, error) {
 	var dummy netns.NsHandle
+	var lastErr error
 	for {
 		ns, err := netns.GetFromPath(path)
 		if err == nil {
 			return ns, nil
 		}
+		lastErr = err
 		select {
 		case <-ctx.Done():
-			return dummy, ctx.Err()
+			return dummy, fmt.Errorf("%w (last attempt: %v)", ctx.Err(), lastErr)
 		case <-time.After(interval):
 		}
 	}
@@ -29,16 +39,19 @@ func AwaitNetNS(ctx context.Context, path string, interval time.Duration) (netns
 
 // AwaitLinkByIndex polls for a netlink Link by index until it appears,
 // ctx is cancelled, or interval-paced retries exhaust. Synchronous for
-// the same reason as AwaitNetNS.
+// the same reason as AwaitNetNS; surfaces the last attempt's error for
+// the same reason too.
 func AwaitLinkByIndex(ctx context.Context, handle *netlink.Handle, index int, interval time.Duration) (netlink.Link, error) {
+	var lastErr error
 	for {
 		link, err := handle.LinkByIndex(index)
 		if err == nil {
 			return link, nil
 		}
+		lastErr = err
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, fmt.Errorf("%w (last attempt: %v)", ctx.Err(), lastErr)
 		case <-time.After(interval):
 		}
 	}

--- a/pkg/util/netlink_test.go
+++ b/pkg/util/netlink_test.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vishvananda/netlink"
+)
+
+// TestAwaitNetNS_DeadlineCarriesLastError pins the #317 diagnosability
+// contract: when the await budget expires, the error must still satisfy
+// errors.Is(_, context.DeadlineExceeded) for callers that branch on it,
+// AND carry the last underlying open error. The production incident was
+// a persistent EACCES (missing CAP_SYS_PTRACE) reported as a bare
+// "context deadline exceeded" — indistinguishable from a startup race.
+func TestAwaitNetNS_DeadlineCarriesLastError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := AwaitNetNS(ctx, "/nonexistent/netns/path", 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error for a path that never appears")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error must wrap context.DeadlineExceeded, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "last attempt:") ||
+		!strings.Contains(err.Error(), "no such file") {
+		t.Errorf("error must carry the last underlying cause (ENOENT here), got: %v", err)
+	}
+}
+
+// TestAwaitLinkByIndex_DeadlineCarriesLastError is the link-await
+// sibling of the test above.
+func TestAwaitLinkByIndex_DeadlineCarriesLastError(t *testing.T) {
+	handle, err := netlink.NewHandle()
+	if err != nil {
+		t.Skipf("cannot open netlink handle in this environment: %v", err)
+	}
+	defer handle.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	// An index that cannot exist: kernel ifindexes are small positive
+	// ints; 1<<30 will never appear during the 50ms budget.
+	_, err = AwaitLinkByIndex(ctx, handle, 1<<30, 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error for a link index that never appears")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error must wrap context.DeadlineExceeded, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "last attempt:") {
+		t.Errorf("error must carry the last underlying cause, got: %v", err)
+	}
+}

--- a/test/integration/harness/container.go
+++ b/test/integration/harness/container.go
@@ -85,6 +85,16 @@ func EnsureImage(ctx context.Context) error {
 // different entrypoint shape.
 func RunContainer(t *testing.T, ctx context.Context, networkName, containerName string) (id, ipv4, mac string) {
 	t.Helper()
+	return RunContainerUser(t, ctx, networkName, containerName, "")
+}
+
+// RunContainerUser is RunContainer with an explicit container user
+// (docker run --user). A non-root user changes the kernel's ptrace
+// check on /proc/<pid>/ns/net, which the plugin's persistent client
+// must pass at Join — root test containers can't exercise that path
+// (#317).
+func RunContainerUser(t *testing.T, ctx context.Context, networkName, containerName, user string) (id, ipv4, mac string) {
+	t.Helper()
 	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
 	if err != nil {
 		t.Fatalf("docker client: %v", err)
@@ -97,6 +107,7 @@ func RunContainer(t *testing.T, ctx context.Context, networkName, containerName 
 			Cmd:   []string{"sleep", "infinity"},
 			// Hostname surfaces in the tombstone for restart-stability tests.
 			Hostname: containerName,
+			User:     user,
 		},
 		&container.HostConfig{
 			AutoRemove: false, // we remove explicitly in cleanup

--- a/test/integration/harness/health.go
+++ b/test/integration/harness/health.go
@@ -25,6 +25,7 @@ type HealthResponse struct {
 	PendingHints           int     `json:"pending_hints"`
 	RecoveredOK            int32   `json:"recovered_ok"`
 	RecoveryFailed         int32   `json:"recovery_failed"`
+	JoinStartFailures      int32   `json:"join_start_failures"`
 	TombstoneWriteFailures int32   `json:"tombstone_write_failures"`
 	LeaseChanged           int32   `json:"lease_changed"`
 	LeasesObtained         int32   `json:"leases_obtained"`

--- a/test/integration/nonroot_test.go
+++ b/test/integration/nonroot_test.go
@@ -1,0 +1,110 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	docker "github.com/docker/docker/client"
+)
+
+// TestNonRootContainer_PersistentClientStarts is the regression test
+// for #317: the persistent DHCP client must start for a container whose
+// init process runs as a NON-ROOT user.
+//
+// Opening /proc/<pid>/ns/net is gated by the kernel's PTRACE_MODE_READ
+// check: same uid as the target, or CAP_SYS_PTRACE. Every other test in
+// this suite runs its container as root, so the uid-match arm always
+// passes and the capability is never needed — which is exactly how the
+// missing CAP_SYS_PTRACE in config.json survived every release of this
+// fork. In production (any compose service with a `USER`) the netns
+// open failed with EACCES on every retry, the persistent client never
+// started, and the lease silently went unrenewed and unreleased.
+//
+// The assertion strategy mirrors TestLeaseRenew_HonorsT1: a dedicated
+// ephemeral fixture advertises short T1/T2 (option 58/59, #253), and a
+// renewal DHCPACK within the window proves the persistent client is
+// alive inside the non-root container's netns. On a pre-#317 plugin
+// the client never starts, no renewal ACK arrives, and this test fails
+// — verified against the unfixed manifest. join_start_failures must
+// also stay flat (it's the counter #317 adds for this failure mode).
+func TestNonRootContainer_PersistentClientStarts(t *testing.T) {
+	const (
+		renewT1 = 12 // seconds; dhcpcd renews here, above its floor
+		renewT2 = 25 // seconds; rebind — kept past the wait window
+		waitFor = 18 * time.Second
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-nonroot"
+	ctrName := "dh-itest-nonroot-ctr"
+
+	ef := harness.NewEphemeralFixture(t, harness.WithRenewTimes(renewT1, renewT2))
+	t.Cleanup(func() {
+		if t.Failed() {
+			ef.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	healthBefore, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("PluginHealth (before): %v", err)
+	}
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{
+		"parent": harness.EphemeralHostVeth,
+	})
+	// 65534 = nobody. uid != 0 is the whole point: the plugin (root)
+	// must need CAP_SYS_PTRACE to enter this container's netns.
+	id, ipBefore, mac := harness.RunContainerUser(t, ctx, netName, ctrName, "65534:65534")
+	t.Logf("initial: ip=%s mac=%s user=nobody", ipBefore, mac)
+
+	startACKs := ef.CountLogLines("DHCPACK", mac)
+
+	t.Logf("waiting %s for a renewal from the non-root container (T1=%ds, T2=%ds)...", waitFor, renewT1, renewT2)
+	select {
+	case <-ctx.Done():
+		t.Fatalf("context cancelled before renewal window: %v", ctx.Err())
+	case <-time.After(waitFor):
+	}
+
+	ins, err := cli.ContainerInspect(ctx, id)
+	if err != nil {
+		t.Fatalf("ContainerInspect: %v", err)
+	}
+	var ipAfter string
+	for _, ep := range ins.NetworkSettings.Networks {
+		ipAfter = ep.IPAddress
+	}
+	if ipAfter != ipBefore {
+		t.Errorf("IP changed during renewal window: before=%s after=%s", ipBefore, ipAfter)
+	}
+
+	endACKs := ef.CountLogLines("DHCPACK", mac)
+	t.Logf("DHCPACKs for %s: start=%d, after=%d", mac, startACKs, endACKs)
+	if endACKs-startACKs < 1 {
+		t.Errorf("no renewal DHCPACK for the non-root container within %s — persistent client did not start in its netns (#317: check CAP_SYS_PTRACE in the plugin manifest)", waitFor)
+	}
+
+	// The suite shares one plugin instance, so assert the DELTA of the
+	// failure counter across this test, not its absolute value.
+	healthAfter, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("PluginHealth (after): %v", err)
+	}
+	if d := healthAfter.JoinStartFailures - healthBefore.JoinStartFailures; d != 0 {
+		t.Errorf("join_start_failures grew by %d during this test — persistent client failed to start", d)
+	}
+}


### PR DESCRIPTION
Refs #317 (close via the next release PR).

## The bug

The persistent DHCP client enters the container's netns by opening `/proc/<pid>/ns/net`. The kernel gates that open with a `PTRACE_MODE_READ` check — same uid as the target, or `CAP_SYS_PTRACE`. The plugin manifest granted only `CAP_NET_ADMIN` + `CAP_SYS_ADMIN`, so for **any container running as a non-root `USER`** the open failed `EACCES` until the await budget expired: the container keeps its initial lease and works, but gets **no renewals and no release on disconnect**. Found live on a production host (see #317 for the full forensics: pinned-IP walk, dockerd `Leave: missing joined endpoint state` warnings, unreleased leases piling up server-side).

Every integration test container ran as root, so the uid-match arm always passed in CI — inherited from the upstream capability list, present in every release of this fork.

## The fix

- **`config.json`**: add `CAP_SYS_PTRACE`. Takes effect on plugin (re-)install.
- **`util.AwaitNetNS` / `AwaitLinkByIndex`**: the deadline error now carries the last attempt's underlying error (`context deadline exceeded (last attempt: permission denied)`) while still satisfying `errors.Is(_, context.DeadlineExceeded)`. The bare deadline error masked a persistent EACCES as a startup race.
- **`join_start_failures`** — new Healthy-affecting `/Plugin.Health` counter for persistent-client start failures at Join: a running container without a renewal client was previously visible only in the plugin's log file. Documented in `docs/reference.md`.

## Tests

- `TestNonRootContainer_PersistentClientStarts` (integration): container as `65534:65534` on a plugin macvlan network with short T1 (option 58, #253 fixture); asserts a renewal DHCPACK arrives from the non-root container's netns, the IP is stable, and the `join_start_failures` delta is zero. Harness gains `RunContainerUser` (existing `RunContainer` delegates) and the health-mirror field.
- **Verified failing on the pre-fix manifest and passing post-fix** on the integration runner host: pre-fix reproduces the exact production signature (`failed to get sandbox network namespace: context deadline exceeded`, then Leave 503); post-fix shows bind + 2 renewal ACKs. Test plugins cleaned up after.
- Unit: deadline-carries-last-error contracts for both await helpers; `join_start_failures` health surface + Healthy flip.