### PR TITLE
Prepare v1.3.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ like any other machine. Bridge, macvlan, and ipvlan attachment modes.
 Install the plugin:
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.2
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.3
 ```
 
 It requests `host` networking, the host PID namespace, the Docker
-socket, and `CAP_NET_ADMIN`/`CAP_SYS_ADMIN` — grant them to proceed.
+socket, and `CAP_NET_ADMIN`/`CAP_SYS_ADMIN`/`CAP_SYS_PTRACE` — grant
+them to proceed.
 (If you hit `invalid rootfs in image configuration`, upgrade Docker.)
 
 Create a bridge-mode network and run a container on it (assumes you
@@ -42,7 +43,7 @@ already have a host bridge `my-bridge` on your LAN — see
 [bridge mode](docs/bridge-mode.md) for that one-time setup):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 
 docker run --rm -ti --network my-dhcp-net alpine ip address show

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -53,6 +53,34 @@ symlink-swap empty-file race, also daemon-side) are accepted with
 justification in `.github/vuln-allowlist.txt` (#291, #292) until a
 fixed release ships on the module path we depend on.
 
+## v1.3.3
+
+A patch release fixing a bug as old as the fork: containers running as
+a **non-root user** never got a working renewal client.
+
+What changed:
+
+- **Persistent DHCP client now starts for non-root containers** (#317).
+  The client enters the container's network namespace via
+  `/proc/<pid>/ns/net`, which the kernel guards with a ptrace check:
+  the opener must share the container's uid or hold `CAP_SYS_PTRACE`.
+  The plugin manifest granted neither for non-root containers, so any
+  service with a Dockerfile `USER` (or compose `user:`) kept its
+  initial lease but was silently never renewed and never released —
+  addresses leaked server-side on every recreate, and per-endpoint
+  `ip=` requests for a previous address were declined while its stale
+  lease lived. The manifest now requests `CAP_SYS_PTRACE`; **the fix
+  takes effect on plugin (re-)install** (a `docker plugin upgrade` or
+  the remove-and-recreate flow — see the Upgrade section of the
+  reference).
+- **New `join_start_failures` health counter** (#317). A persistent-
+  client start failure at attach time now flips `/Plugin.Health` to
+  unhealthy instead of hiding in the plugin's log file. The underlying
+  await errors also carry their real cause now (the EACCES above
+  spent weeks disguised as `context deadline exceeded`).
+- Housekeeping: the Go Report Card badge is gone — goreportcard.com is
+  end-of-life; staticcheck/gofmt remain required CI gates (#318).
+
 ## v1.3.2
 
 A CI-only patch release: the plugin's runtime code is identical to

--- a/docs/bridge-mode.md
+++ b/docs/bridge-mode.md
@@ -37,7 +37,7 @@ sudo dhcpcd my-bridge
 ## 2. Create the network
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 ```
 
@@ -45,7 +45,7 @@ With IPv6 as well (the `docker network create --ipv6` flag does **not**
 work with the null IPAM driver; use the `ipv6` driver option instead):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
   --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
 ```
 
@@ -100,7 +100,7 @@ services:
       - dhcp
 networks:
   dhcp:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.2
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.3
     driver_opts:
       bridge: my-bridge
       ipv6: 'true'

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,11 +22,12 @@ like any other machine. Bridge, macvlan, and ipvlan attachment modes.
 Install the plugin:
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.2
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.3
 ```
 
 It requests `host` networking, the host PID namespace, the Docker
-socket, and `CAP_NET_ADMIN`/`CAP_SYS_ADMIN` — grant them to proceed.
+socket, and `CAP_NET_ADMIN`/`CAP_SYS_ADMIN`/`CAP_SYS_PTRACE` — grant
+them to proceed.
 (If you hit `invalid rootfs in image configuration`, upgrade Docker.)
 
 Create a bridge-mode network and run a container on it (assumes you
@@ -34,7 +35,7 @@ already have a host bridge `my-bridge` on your LAN — see
 [Bridge mode](bridge-mode.md) for that one-time setup):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 
 docker run --rm -ti --network my-dhcp-net alpine ip address show

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -314,7 +314,7 @@ exact create incantation (note: the Docker-level `--ipv6` flag does
 NOT work with the null IPAM driver and is not what you want):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 -o ipv6=true \
     lan-dhcp6
@@ -583,7 +583,7 @@ endpoint operation everything is back to disk-served.
 Override the location via the `STATE_DIR` env var on the plugin:
 
 ```bash
-docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.3.2 STATE_DIR=/some/other/path
+docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.3.3 STATE_DIR=/some/other/path
 ```
 
 ## Plugin env vars

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,13 +27,16 @@ The plugin publishes to two registries; GHCR is primary:
 for unattended):
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.2
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.3
 ```
 
 Privileges requested: `network: host`, host PID namespace, the Docker
-socket mount, `CAP_NET_ADMIN` + `CAP_SYS_ADMIN`. All four are inherent
-to what the plugin does (creating links in arbitrary netns, driving
-DHCP on the host's L2 segments, querying the daemon).
+socket mount, `CAP_NET_ADMIN` + `CAP_SYS_ADMIN` + `CAP_SYS_PTRACE`
+(v1.3.3+). All are inherent to what the plugin does: creating links in
+arbitrary netns, driving DHCP on the host's L2 segments, querying the
+daemon — and entering a container's netns via `/proc/<pid>/ns/net`,
+which the kernel ptrace-gates when the container runs as a non-root
+user (#317).
 
 **Verify the signature (v1.1.0+).** The published image is cosign-signed
 (keyless) and carries SLSA build provenance; release artifacts ship a
@@ -93,7 +96,7 @@ You bring an existing Linux bridge that is L2-connected to the LAN
 (see [`bridge-mode.md`](bridge-mode.md) for the bridge setup itself):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
     --ipam-driver null \
     -o bridge=my-bridge \
     my-dhcp-net
@@ -105,7 +108,7 @@ No host changes — containers get per-container kernel-generated MACs
 as macvlan children of a host NIC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 \
     lan-dhcp
@@ -119,7 +122,7 @@ security, hostile vSwitches, some Wi-Fi APs). The DHCP server must
 key reservations on DHCP option 61 (client identifier), not MAC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
     --ipam-driver null \
     -o mode=ipvlan -o parent=eth0 \
     lan-dhcp
@@ -239,7 +242,7 @@ Set with `docker plugin set <plugin> NAME=value`; take effect after
 JSON liveness + counters on the plugin's UNIX socket:
 
 ```bash
-PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.3.2)
+PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.3.3)
 curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
     http://localhost/Plugin.Health | jq .
 ```
@@ -311,7 +314,7 @@ Compose-managed alternative (network lifecycle tied to the project):
 ```yaml
 networks:
   lan:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.2
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.3
     driver_opts:
       mode: macvlan
       parent: eth0


### PR DESCRIPTION
Release-prep for v1.3.3 (#317 CAP_SYS_PTRACE fix + join_start_failures counter, #318 badge removal).

- Pins bumped v1.3.2 → v1.3.3 (gate passes).
- Docs review against the milestone: #320's capability change is now reflected in all three requested-privileges lists (README, docs/index.md, docs/reference.md — these still said NET_ADMIN/SYS_ADMIN only); the counter row and error-transparency landed with #320 itself. #319 has no doc delta beyond itself.
- RELEASE_NOTES v1.3.3 section, including the operator-visible note that the fix needs a plugin (re-)install.