### PR TITLE
Release v1.3.3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,6 +76,7 @@ jobs:
           bash scripts/test-check-version-pins.sh
           bash scripts/test-integration-timing.sh
           bash scripts/test-integration-run-gate.sh
+          bash scripts/test-check-manifest-parity.sh
 
       # Every driver-option key the code parses must be documented in
       # docs/reference.md — an undocumented option turns CI red (#132).
@@ -87,6 +88,13 @@ jobs:
       # scripts/bump-version.sh vX.Y.Z.
       - name: Version-pin consistency check
         run: bash scripts/check-version-pins.sh
+
+      # config.json and config-cover.json must agree on privilege
+      # fields — a capability landing in only one means coverage runs
+      # test a different plugin than the one that ships (#317's
+      # CAP_SYS_PTRACE did exactly that on the v1.3.3 release PR).
+      - name: Plugin-manifest parity check
+        run: bash scripts/check-manifest-parity.sh
 
   staticcheck:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Integration](https://github.com/claymore666/docker-net-dhcp/actions/workflows/integration.yml/badge.svg)](https://github.com/claymore666/docker-net-dhcp/actions/workflows/integration.yml)
 [![Dependencies](https://img.shields.io/badge/dependencies-Dependabot%20%2B%20govulncheck-brightgreen?logo=dependabot)](https://github.com/claymore666/docker-net-dhcp/network/updates)
 [![Release](https://img.shields.io/github/v/release/claymore666/docker-net-dhcp?sort=semver)](https://github.com/claymore666/docker-net-dhcp/releases)
-[![Go Report Card](https://goreportcard.com/badge/github.com/claymore666/docker-net-dhcp)](https://goreportcard.com/report/github.com/claymore666/docker-net-dhcp)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/claymore666/docker-net-dhcp/badge)](https://scorecard.dev/viewer/?uri=github.com/claymore666/docker-net-dhcp)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13229/badge)](https://www.bestpractices.dev/projects/13229)
 [![Docs](https://img.shields.io/badge/docs-claymore666.github.io-blue?logo=materialformkdocs&logoColor=white)](https://claymore666.github.io/docker-net-dhcp/)

--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ like any other machine. Bridge, macvlan, and ipvlan attachment modes.
 Install the plugin:
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.2
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.3
 ```
 
 It requests `host` networking, the host PID namespace, the Docker
-socket, and `CAP_NET_ADMIN`/`CAP_SYS_ADMIN` — grant them to proceed.
+socket, and `CAP_NET_ADMIN`/`CAP_SYS_ADMIN`/`CAP_SYS_PTRACE` — grant
+them to proceed.
 (If you hit `invalid rootfs in image configuration`, upgrade Docker.)
 
 Create a bridge-mode network and run a container on it (assumes you
@@ -42,7 +43,7 @@ already have a host bridge `my-bridge` on your LAN — see
 [bridge mode](docs/bridge-mode.md) for that one-time setup):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 
 docker run --rm -ti --network my-dhcp-net alpine ip address show

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -53,6 +53,34 @@ symlink-swap empty-file race, also daemon-side) are accepted with
 justification in `.github/vuln-allowlist.txt` (#291, #292) until a
 fixed release ships on the module path we depend on.
 
+## v1.3.3
+
+A patch release fixing a bug as old as the fork: containers running as
+a **non-root user** never got a working renewal client.
+
+What changed:
+
+- **Persistent DHCP client now starts for non-root containers** (#317).
+  The client enters the container's network namespace via
+  `/proc/<pid>/ns/net`, which the kernel guards with a ptrace check:
+  the opener must share the container's uid or hold `CAP_SYS_PTRACE`.
+  The plugin manifest granted neither for non-root containers, so any
+  service with a Dockerfile `USER` (or compose `user:`) kept its
+  initial lease but was silently never renewed and never released —
+  addresses leaked server-side on every recreate, and per-endpoint
+  `ip=` requests for a previous address were declined while its stale
+  lease lived. The manifest now requests `CAP_SYS_PTRACE`; **the fix
+  takes effect on plugin (re-)install** (a `docker plugin upgrade` or
+  the remove-and-recreate flow — see the Upgrade section of the
+  reference).
+- **New `join_start_failures` health counter** (#317). A persistent-
+  client start failure at attach time now flips `/Plugin.Health` to
+  unhealthy instead of hiding in the plugin's log file. The underlying
+  await errors also carry their real cause now (the EACCES above
+  spent weeks disguised as `context deadline exceeded`).
+- Housekeeping: the Go Report Card badge is gone — goreportcard.com is
+  end-of-life; staticcheck/gofmt remain required CI gates (#318).
+
 ## v1.3.2
 
 A CI-only patch release: the plugin's runtime code is identical to

--- a/config-cover.json
+++ b/config-cover.json
@@ -68,7 +68,8 @@
     "linux": {
         "capabilities": [
             "CAP_NET_ADMIN",
-            "CAP_SYS_ADMIN"
+            "CAP_SYS_ADMIN",
+            "CAP_SYS_PTRACE"
         ]
     }
 }

--- a/config.json
+++ b/config.json
@@ -51,7 +51,8 @@
     "linux": {
         "capabilities": [
             "CAP_NET_ADMIN",
-            "CAP_SYS_ADMIN"
+            "CAP_SYS_ADMIN",
+            "CAP_SYS_PTRACE"
         ]
     }
 }

--- a/docs/bridge-mode.md
+++ b/docs/bridge-mode.md
@@ -37,7 +37,7 @@ sudo dhcpcd my-bridge
 ## 2. Create the network
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 ```
 
@@ -45,7 +45,7 @@ With IPv6 as well (the `docker network create --ipv6` flag does **not**
 work with the null IPAM driver; use the `ipv6` driver option instead):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
   --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
 ```
 
@@ -100,7 +100,7 @@ services:
       - dhcp
 networks:
   dhcp:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.2
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.3
     driver_opts:
       bridge: my-bridge
       ipv6: 'true'

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,11 +22,12 @@ like any other machine. Bridge, macvlan, and ipvlan attachment modes.
 Install the plugin:
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.2
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.3
 ```
 
 It requests `host` networking, the host PID namespace, the Docker
-socket, and `CAP_NET_ADMIN`/`CAP_SYS_ADMIN` — grant them to proceed.
+socket, and `CAP_NET_ADMIN`/`CAP_SYS_ADMIN`/`CAP_SYS_PTRACE` — grant
+them to proceed.
 (If you hit `invalid rootfs in image configuration`, upgrade Docker.)
 
 Create a bridge-mode network and run a container on it (assumes you
@@ -34,7 +35,7 @@ already have a host bridge `my-bridge` on your LAN — see
 [Bridge mode](bridge-mode.md) for that one-time setup):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 
 docker run --rm -ti --network my-dhcp-net alpine ip address show

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -314,7 +314,7 @@ exact create incantation (note: the Docker-level `--ipv6` flag does
 NOT work with the null IPAM driver and is not what you want):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 -o ipv6=true \
     lan-dhcp6
@@ -583,7 +583,7 @@ endpoint operation everything is back to disk-served.
 Override the location via the `STATE_DIR` env var on the plugin:
 
 ```bash
-docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.3.2 STATE_DIR=/some/other/path
+docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.3.3 STATE_DIR=/some/other/path
 ```
 
 ## Plugin env vars

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -246,12 +246,13 @@ curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
 
 | field | healthy-affecting | meaning |
 | ----- | ----------------- | ------- |
-| `healthy` | — | `false` when `recovery_failed` or `tombstone_write_failures` is non-zero — an operator should look. The plugin keeps serving fresh attaches either way. |
+| `healthy` | — | `false` when `recovery_failed`, `join_start_failures`, or `tombstone_write_failures` is non-zero — an operator should look. The plugin keeps serving fresh attaches either way. |
 | `uptime_seconds` | — | Seconds since the plugin process started. |
 | `active_endpoints` | — | DHCP managers currently registered (post-Join, pre-Leave). |
 | `pending_hints` | — | Join hints awaiting consumption; steady-state ~0. |
 | `recovered_ok` | — | Endpoints successfully rebuilt by plugin-restart recovery. |
 | `recovery_failed` | yes | Endpoints whose post-restart rebuild failed — those containers run without lease renewal and lose their IP at expiry; restart them. |
+| `join_start_failures` | yes | (v1.3.3+) Persistent-client start failures at attach time — the container got its initial lease but runs without renewal, and the lease is never released on disconnect (#317). The plugin log carries the cause; fix it and restart the container. |
 | `tombstone_write_failures` | yes | Failed tombstone saves (disk full, EROFS) — the next restart of some container will pick a fresh MAC/IP instead of inheriting. |
 | `lease_changed` | no | Renewals that returned a different IP than last recorded (v4+v6 aggregate). Docker's `inspect` view does **not** update on lease change (libnetwork has no in-place endpoint-IP swap), so this is the stale-inspect-window signal — alert on it for long-running containers. |
 | `leases_obtained` | no | `dhcpcd` bind events (`BOUND`/`REBOOT`, and the v6 equivalents): initial bind or re-bind after NAK/lease loss. v4+v6 aggregate. |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,13 +27,16 @@ The plugin publishes to two registries; GHCR is primary:
 for unattended):
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.2
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.3
 ```
 
 Privileges requested: `network: host`, host PID namespace, the Docker
-socket mount, `CAP_NET_ADMIN` + `CAP_SYS_ADMIN`. All four are inherent
-to what the plugin does (creating links in arbitrary netns, driving
-DHCP on the host's L2 segments, querying the daemon).
+socket mount, `CAP_NET_ADMIN` + `CAP_SYS_ADMIN` + `CAP_SYS_PTRACE`
+(v1.3.3+). All are inherent to what the plugin does: creating links in
+arbitrary netns, driving DHCP on the host's L2 segments, querying the
+daemon — and entering a container's netns via `/proc/<pid>/ns/net`,
+which the kernel ptrace-gates when the container runs as a non-root
+user (#317).
 
 **Verify the signature (v1.1.0+).** The published image is cosign-signed
 (keyless) and carries SLSA build provenance; release artifacts ship a
@@ -93,7 +96,7 @@ You bring an existing Linux bridge that is L2-connected to the LAN
 (see [`bridge-mode.md`](bridge-mode.md) for the bridge setup itself):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
     --ipam-driver null \
     -o bridge=my-bridge \
     my-dhcp-net
@@ -105,7 +108,7 @@ No host changes — containers get per-container kernel-generated MACs
 as macvlan children of a host NIC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 \
     lan-dhcp
@@ -119,7 +122,7 @@ security, hostile vSwitches, some Wi-Fi APs). The DHCP server must
 key reservations on DHCP option 61 (client identifier), not MAC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.2 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
     --ipam-driver null \
     -o mode=ipvlan -o parent=eth0 \
     lan-dhcp
@@ -239,7 +242,7 @@ Set with `docker plugin set <plugin> NAME=value`; take effect after
 JSON liveness + counters on the plugin's UNIX socket:
 
 ```bash
-PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.3.2)
+PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.3.3)
 curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
     http://localhost/Plugin.Health | jq .
 ```
@@ -311,7 +314,7 @@ Compose-managed alternative (network lifecycle tied to the project):
 ```yaml
 networks:
   lan:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.2
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.3
     driver_opts:
       mode: macvlan
       parent: eth0

--- a/pkg/plugin/endpoints.go
+++ b/pkg/plugin/endpoints.go
@@ -256,13 +256,18 @@ func (p *Plugin) apiLeave(w http.ResponseWriter, r *http.Request) {
 // expiry. Operators should restart those containers (which produces a
 // fresh CreateEndpoint and gets them back into the persistent map).
 type HealthResponse struct {
-	Healthy                bool    `json:"healthy"`
-	UptimeSeconds          float64 `json:"uptime_seconds"`
-	ActiveEndpoints        int     `json:"active_endpoints"`
-	PendingHints           int     `json:"pending_hints"`
-	RecoveredOK            int32   `json:"recovered_ok"`
-	RecoveryFailed         int32   `json:"recovery_failed"`
-	TombstoneWriteFailures int32   `json:"tombstone_write_failures"`
+	Healthy         bool    `json:"healthy"`
+	UptimeSeconds   float64 `json:"uptime_seconds"`
+	ActiveEndpoints int     `json:"active_endpoints"`
+	PendingHints    int     `json:"pending_hints"`
+	RecoveredOK     int32   `json:"recovered_ok"`
+	RecoveryFailed  int32   `json:"recovery_failed"`
+	// JoinStartFailures counts persistent-client Start failures at
+	// Join time (#317): a running container with no renewal client.
+	// Healthy-affecting — same operator action as recovery_failed
+	// (find the cause in the plugin log, restart the container).
+	JoinStartFailures      int32 `json:"join_start_failures"`
+	TombstoneWriteFailures int32 `json:"tombstone_write_failures"`
 	// LeaseChanged counts renewals where dhcpcd returned a different
 	// IP than the manager last recorded. Not Healthy-affecting (it
 	// doesn't break Docker's view fatally — see plugin.go for the
@@ -309,18 +314,21 @@ func (p *Plugin) apiHealth(w http.ResponseWriter, r *http.Request) {
 	p.mu.Unlock()
 
 	failed := p.recoveryFailed.Load()
+	joinFails := p.joinStartFailures.Load()
 	tsFails := p.tombstoneWriteFailures.Load()
 	util.JSONResponse(w, HealthResponse{
 		// Healthy is false on any condition that means an operator
-		// should look: a recovery failure means a running container has
-		// no renewal goroutine; a tombstone-write failure means the
-		// next restart of some container will pick a new MAC/IP.
-		Healthy:                failed == 0 && tsFails == 0,
+		// should look: a recovery or join-start failure means a running
+		// container has no renewal goroutine; a tombstone-write failure
+		// means the next restart of some container will pick a new
+		// MAC/IP.
+		Healthy:                failed == 0 && joinFails == 0 && tsFails == 0,
 		UptimeSeconds:          time.Since(p.startTime).Seconds(),
 		ActiveEndpoints:        active,
 		PendingHints:           pending,
 		RecoveredOK:            p.recoveredOK.Load(),
 		RecoveryFailed:         failed,
+		JoinStartFailures:      joinFails,
 		TombstoneWriteFailures: tsFails,
 		LeaseChanged:           p.leaseChanged.Load(),
 		LeasesObtained:         p.leasesObtained.Load(),

--- a/pkg/plugin/endpoints_test.go
+++ b/pkg/plugin/endpoints_test.go
@@ -82,6 +82,35 @@ func TestApiHealth_TombstoneWriteFailureUnhealthy(t *testing.T) {
 	}
 }
 
+// TestApiHealth_JoinStartFailureUnhealthy verifies that a non-zero
+// joinStartFailures counter flips the response to unhealthy and is
+// reported under join_start_failures (#317). The counter is bumped from
+// Join's Start-failure goroutine; as with the tombstone sibling above,
+// the surface under test is what /Plugin.Health reports.
+func TestApiHealth_JoinStartFailureUnhealthy(t *testing.T) {
+	p := &Plugin{
+		startTime:      time.Now(),
+		joinHints:      make(map[string]joinHint),
+		persistentDHCP: make(map[string]*dhcpManager),
+	}
+	p.joinStartFailures.Add(1)
+
+	req := httptest.NewRequest(http.MethodGet, "/Plugin.Health", nil)
+	rec := httptest.NewRecorder()
+	p.apiHealth(rec, req)
+
+	var got HealthResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Healthy {
+		t.Error("join-start failures must mark plugin unhealthy — a running container has no renewal client")
+	}
+	if got.JoinStartFailures != 1 {
+		t.Errorf("expected 1 join-start failure reported, got %d", got.JoinStartFailures)
+	}
+}
+
 // TestApiHealth_PerFamilyCounters pins the #212 contract on the wire:
 // the un-suffixed counters stay v4+v6 aggregates while the *_v6 siblings
 // carry the v6 subset, and both surface under their snake_case keys.

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -1039,6 +1039,7 @@ func (p *Plugin) Join(ctx context.Context, r JoinRequest) (JoinResponse, error) 
 		defer cancel()
 
 		if err := m.Start(ctx); err != nil {
+			p.joinStartFailures.Add(1)
 			log.WithError(err).WithFields(log.Fields{
 				"network":  shortID(r.NetworkID),
 				"endpoint": shortID(r.EndpointID),

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -311,6 +311,18 @@ type Plugin struct {
 	recoveredOK    atomic.Int32
 	recoveryFailed atomic.Int32
 
+	// joinStartFailures counts persistent-DHCP-client Start failures
+	// at Join time (#317). Each bump is a running container that got
+	// its initial lease but has NO renewal client: the lease silently
+	// ages toward expiry and is never released on disconnect. The
+	// canonical cause was the missing CAP_SYS_PTRACE (netns open on a
+	// non-root container's /proc/<pid>/ns/net); the counter exists so
+	// the next cause is visible on /Plugin.Health instead of only in
+	// the plugin log. Healthy-affecting, same operator semantics as
+	// recovery_failed: restart the affected container once the cause
+	// is fixed.
+	joinStartFailures atomic.Int32
+
 	// tombstoneWriteFailures counts saveTombstones failures (disk full,
 	// EROFS) from addTombstone. Reported on /Plugin.Health so operators
 	// can detect a degraded restart-stability window — every failure

--- a/pkg/util/netlink.go
+++ b/pkg/util/netlink.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -12,16 +13,25 @@ import (
 // or interval-paced retries exhaust. Synchronous to avoid leaking a
 // poller goroutine on ctx-cancel (the previous form did, and each leaked
 // goroutine kept hammering netns.GetFromPath forever).
+//
+// On ctx expiry the returned error wraps ctx.Err() (so errors.Is against
+// context.DeadlineExceeded keeps working) and carries the last attempt's
+// underlying error. A bare "context deadline exceeded" hid a persistent
+// EACCES for weeks in production — the netns open needs ptrace access to
+// the target process, and a permission failure retried to the deadline is
+// indistinguishable from a startup race without this (#317).
 func AwaitNetNS(ctx context.Context, path string, interval time.Duration) (netns.NsHandle, error) {
 	var dummy netns.NsHandle
+	var lastErr error
 	for {
 		ns, err := netns.GetFromPath(path)
 		if err == nil {
 			return ns, nil
 		}
+		lastErr = err
 		select {
 		case <-ctx.Done():
-			return dummy, ctx.Err()
+			return dummy, fmt.Errorf("%w (last attempt: %v)", ctx.Err(), lastErr)
 		case <-time.After(interval):
 		}
 	}
@@ -29,16 +39,19 @@ func AwaitNetNS(ctx context.Context, path string, interval time.Duration) (netns
 
 // AwaitLinkByIndex polls for a netlink Link by index until it appears,
 // ctx is cancelled, or interval-paced retries exhaust. Synchronous for
-// the same reason as AwaitNetNS.
+// the same reason as AwaitNetNS; surfaces the last attempt's error for
+// the same reason too.
 func AwaitLinkByIndex(ctx context.Context, handle *netlink.Handle, index int, interval time.Duration) (netlink.Link, error) {
+	var lastErr error
 	for {
 		link, err := handle.LinkByIndex(index)
 		if err == nil {
 			return link, nil
 		}
+		lastErr = err
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, fmt.Errorf("%w (last attempt: %v)", ctx.Err(), lastErr)
 		case <-time.After(interval):
 		}
 	}

--- a/pkg/util/netlink_test.go
+++ b/pkg/util/netlink_test.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vishvananda/netlink"
+)
+
+// TestAwaitNetNS_DeadlineCarriesLastError pins the #317 diagnosability
+// contract: when the await budget expires, the error must still satisfy
+// errors.Is(_, context.DeadlineExceeded) for callers that branch on it,
+// AND carry the last underlying open error. The production incident was
+// a persistent EACCES (missing CAP_SYS_PTRACE) reported as a bare
+// "context deadline exceeded" — indistinguishable from a startup race.
+func TestAwaitNetNS_DeadlineCarriesLastError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := AwaitNetNS(ctx, "/nonexistent/netns/path", 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error for a path that never appears")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error must wrap context.DeadlineExceeded, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "last attempt:") ||
+		!strings.Contains(err.Error(), "no such file") {
+		t.Errorf("error must carry the last underlying cause (ENOENT here), got: %v", err)
+	}
+}
+
+// TestAwaitLinkByIndex_DeadlineCarriesLastError is the link-await
+// sibling of the test above.
+func TestAwaitLinkByIndex_DeadlineCarriesLastError(t *testing.T) {
+	handle, err := netlink.NewHandle()
+	if err != nil {
+		t.Skipf("cannot open netlink handle in this environment: %v", err)
+	}
+	defer handle.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	// An index that cannot exist: kernel ifindexes are small positive
+	// ints; 1<<30 will never appear during the 50ms budget.
+	_, err = AwaitLinkByIndex(ctx, handle, 1<<30, 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error for a link index that never appears")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error must wrap context.DeadlineExceeded, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "last attempt:") {
+		t.Errorf("error must carry the last underlying cause, got: %v", err)
+	}
+}

--- a/scripts/check-manifest-parity.sh
+++ b/scripts/check-manifest-parity.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Guard against drift between the production plugin manifest
+# (config.json) and the coverage-instrumented one (config-cover.json).
+# The two must agree on every privilege-relevant field — the cover
+# plugin exists to run the SAME suite with instrumentation, so a
+# privilege mismatch makes coverage runs test a different plugin than
+# the one that ships. Learned the hard way: #317's CAP_SYS_PTRACE fix
+# landed in config.json only, and the release-PR coverage run failed
+# the new non-root test against the unfixed cover manifest.
+#
+# Cover-specific additions (env like GOCOVERDIR, extra mounts) are
+# expected and NOT compared. Usage:
+#   scripts/check-manifest-parity.sh [config.json] [config-cover.json]
+set -euo pipefail
+
+MAIN="${1:-config.json}"
+COVER="${2:-config-cover.json}"
+
+fails=0
+for field in '.linux.capabilities' '.network.type' '.pidhost' '.interface.types'; do
+    a=$(jq -cS "$field" "$MAIN")
+    b=$(jq -cS "$field" "$COVER")
+    if [ "$a" != "$b" ]; then
+        echo "FAIL  $field differs: $MAIN=$a $COVER=$b"
+        fails=1
+    else
+        echo "ok    $field $a"
+    fi
+done
+
+if [ "$fails" -ne 0 ]; then
+    echo "manifest parity check FAILED — align $COVER with $MAIN"
+    exit 1
+fi
+echo "PASS  plugin manifests agree on privilege-relevant fields"

--- a/scripts/test-check-manifest-parity.sh
+++ b/scripts/test-check-manifest-parity.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Meta-test for check-manifest-parity.sh: the failure mode it guards is
+# a privilege field silently differing between the two plugin manifests.
+set -euo pipefail
+
+CHECK="$(dirname "$0")/check-manifest-parity.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+fails=0
+
+check() {
+    local desc="$1" want="$2" got="$3"
+    if [ "$got" = "$want" ]; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc — want '$want', got '$got'"
+        fails=1
+    fi
+}
+
+base='{"interface":{"types":["docker.networkdriver/1.0"]},"network":{"type":"host"},"pidhost":true,"linux":{"capabilities":["CAP_NET_ADMIN","CAP_SYS_ADMIN","CAP_SYS_PTRACE"]}}'
+
+# identical privilege fields -> pass (cover-side extras are ignored)
+echo "$base" > "$TMP/a.json"
+echo "$base" | jq '. + {env:[{name:"GOCOVERDIR",value:"/x"}]}' > "$TMP/b.json"
+got=$(bash "$CHECK" "$TMP/a.json" "$TMP/b.json" >/dev/null 2>&1 && echo pass || echo fail)
+check "identical privileges (with cover-only extras) pass" pass "$got"
+
+# missing capability -> fail (the #317 regression shape)
+echo "$base" | jq '.linux.capabilities -= ["CAP_SYS_PTRACE"]' > "$TMP/b.json"
+got=$(bash "$CHECK" "$TMP/a.json" "$TMP/b.json" >/dev/null 2>&1 && echo pass || echo fail)
+check "capability drift fails" fail "$got"
+
+# pidhost drift -> fail
+echo "$base" | jq '.pidhost = false' > "$TMP/b.json"
+got=$(bash "$CHECK" "$TMP/a.json" "$TMP/b.json" >/dev/null 2>&1 && echo pass || echo fail)
+check "pidhost drift fails" fail "$got"
+
+# the real repo manifests must currently agree
+got=$(bash "$CHECK" >/dev/null 2>&1 && echo pass || echo fail)
+check "repo config.json and config-cover.json agree" pass "$got"
+
+if [ "$fails" -ne 0 ]; then
+    echo "check-manifest-parity tests FAILED"
+    exit 1
+fi
+echo "All check-manifest-parity tests passed"

--- a/test/integration/harness/container.go
+++ b/test/integration/harness/container.go
@@ -85,6 +85,16 @@ func EnsureImage(ctx context.Context) error {
 // different entrypoint shape.
 func RunContainer(t *testing.T, ctx context.Context, networkName, containerName string) (id, ipv4, mac string) {
 	t.Helper()
+	return RunContainerUser(t, ctx, networkName, containerName, "")
+}
+
+// RunContainerUser is RunContainer with an explicit container user
+// (docker run --user). A non-root user changes the kernel's ptrace
+// check on /proc/<pid>/ns/net, which the plugin's persistent client
+// must pass at Join — root test containers can't exercise that path
+// (#317).
+func RunContainerUser(t *testing.T, ctx context.Context, networkName, containerName, user string) (id, ipv4, mac string) {
+	t.Helper()
 	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
 	if err != nil {
 		t.Fatalf("docker client: %v", err)
@@ -97,6 +107,7 @@ func RunContainer(t *testing.T, ctx context.Context, networkName, containerName 
 			Cmd:   []string{"sleep", "infinity"},
 			// Hostname surfaces in the tombstone for restart-stability tests.
 			Hostname: containerName,
+			User:     user,
 		},
 		&container.HostConfig{
 			AutoRemove: false, // we remove explicitly in cleanup

--- a/test/integration/harness/health.go
+++ b/test/integration/harness/health.go
@@ -25,6 +25,7 @@ type HealthResponse struct {
 	PendingHints           int     `json:"pending_hints"`
 	RecoveredOK            int32   `json:"recovered_ok"`
 	RecoveryFailed         int32   `json:"recovery_failed"`
+	JoinStartFailures      int32   `json:"join_start_failures"`
 	TombstoneWriteFailures int32   `json:"tombstone_write_failures"`
 	LeaseChanged           int32   `json:"lease_changed"`
 	LeasesObtained         int32   `json:"leases_obtained"`

--- a/test/integration/nonroot_test.go
+++ b/test/integration/nonroot_test.go
@@ -1,0 +1,110 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	docker "github.com/docker/docker/client"
+)
+
+// TestNonRootContainer_PersistentClientStarts is the regression test
+// for #317: the persistent DHCP client must start for a container whose
+// init process runs as a NON-ROOT user.
+//
+// Opening /proc/<pid>/ns/net is gated by the kernel's PTRACE_MODE_READ
+// check: same uid as the target, or CAP_SYS_PTRACE. Every other test in
+// this suite runs its container as root, so the uid-match arm always
+// passes and the capability is never needed — which is exactly how the
+// missing CAP_SYS_PTRACE in config.json survived every release of this
+// fork. In production (any compose service with a `USER`) the netns
+// open failed with EACCES on every retry, the persistent client never
+// started, and the lease silently went unrenewed and unreleased.
+//
+// The assertion strategy mirrors TestLeaseRenew_HonorsT1: a dedicated
+// ephemeral fixture advertises short T1/T2 (option 58/59, #253), and a
+// renewal DHCPACK within the window proves the persistent client is
+// alive inside the non-root container's netns. On a pre-#317 plugin
+// the client never starts, no renewal ACK arrives, and this test fails
+// — verified against the unfixed manifest. join_start_failures must
+// also stay flat (it's the counter #317 adds for this failure mode).
+func TestNonRootContainer_PersistentClientStarts(t *testing.T) {
+	const (
+		renewT1 = 12 // seconds; dhcpcd renews here, above its floor
+		renewT2 = 25 // seconds; rebind — kept past the wait window
+		waitFor = 18 * time.Second
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-nonroot"
+	ctrName := "dh-itest-nonroot-ctr"
+
+	ef := harness.NewEphemeralFixture(t, harness.WithRenewTimes(renewT1, renewT2))
+	t.Cleanup(func() {
+		if t.Failed() {
+			ef.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	healthBefore, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("PluginHealth (before): %v", err)
+	}
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{
+		"parent": harness.EphemeralHostVeth,
+	})
+	// 65534 = nobody. uid != 0 is the whole point: the plugin (root)
+	// must need CAP_SYS_PTRACE to enter this container's netns.
+	id, ipBefore, mac := harness.RunContainerUser(t, ctx, netName, ctrName, "65534:65534")
+	t.Logf("initial: ip=%s mac=%s user=nobody", ipBefore, mac)
+
+	startACKs := ef.CountLogLines("DHCPACK", mac)
+
+	t.Logf("waiting %s for a renewal from the non-root container (T1=%ds, T2=%ds)...", waitFor, renewT1, renewT2)
+	select {
+	case <-ctx.Done():
+		t.Fatalf("context cancelled before renewal window: %v", ctx.Err())
+	case <-time.After(waitFor):
+	}
+
+	ins, err := cli.ContainerInspect(ctx, id)
+	if err != nil {
+		t.Fatalf("ContainerInspect: %v", err)
+	}
+	var ipAfter string
+	for _, ep := range ins.NetworkSettings.Networks {
+		ipAfter = ep.IPAddress
+	}
+	if ipAfter != ipBefore {
+		t.Errorf("IP changed during renewal window: before=%s after=%s", ipBefore, ipAfter)
+	}
+
+	endACKs := ef.CountLogLines("DHCPACK", mac)
+	t.Logf("DHCPACKs for %s: start=%d, after=%d", mac, startACKs, endACKs)
+	if endACKs-startACKs < 1 {
+		t.Errorf("no renewal DHCPACK for the non-root container within %s — persistent client did not start in its netns (#317: check CAP_SYS_PTRACE in the plugin manifest)", waitFor)
+	}
+
+	// The suite shares one plugin instance, so assert the DELTA of the
+	// failure counter across this test, not its absolute value.
+	healthAfter, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("PluginHealth (after): %v", err)
+	}
+	if d := healthAfter.JoinStartFailures - healthBefore.JoinStartFailures; d != 0 {
+		t.Errorf("join_start_failures grew by %d during this test — persistent client failed to start", d)
+	}
+}


### PR DESCRIPTION
Patch release fixing a fork-lifetime bug: the persistent DHCP client never started for containers running as a non-root user.

Closes #317
Closes #318

## What's in it

- **CAP_SYS_PTRACE in the plugin manifest** (#320, completed by #323): the persistent client enters the container's netns via `/proc/<pid>/ns/net`, which the kernel ptrace-gates when the container runs as a non-root `USER`. Without the capability the client silently never started — no renewals, no lease release. Found in production; regression test verified failing pre-fix and passing post-fix. Takes effect on plugin (re-)install.
- **Manifest parity gate** (#323): the coverage workflow builds its instrumented plugin from `config-cover.json`, which #320 missed — this release PR's own coverage run caught it (the new non-root test failing against the unfixed cover manifest). Both manifests now carry the capability, and a new CI gate (`scripts/check-manifest-parity.sh` + meta-test) fails the build if privilege-relevant fields ever drift between them again.
- **`join_start_failures` health counter** + real causes inside await deadline errors (#320) — this failure mode is now visible on `/Plugin.Health` instead of only in the plugin's log file.
- **Non-root integration coverage** (#320): `TestNonRootContainer_PersistentClientStarts` closes the suite-wide gap where every test container ran as root.
- Go Report Card badge removed — goreportcard.com is EOL (#319).
- Docs: requested-privileges lists updated, counter documented, pins → v1.3.3.
