### PR TITLE
fix(ci): CAP_SYS_PTRACE in config-cover.json + manifest parity gate (#317)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,6 +76,7 @@ jobs:
           bash scripts/test-check-version-pins.sh
           bash scripts/test-integration-timing.sh
           bash scripts/test-integration-run-gate.sh
+          bash scripts/test-check-manifest-parity.sh
 
       # Every driver-option key the code parses must be documented in
       # docs/reference.md — an undocumented option turns CI red (#132).
@@ -87,6 +88,13 @@ jobs:
       # scripts/bump-version.sh vX.Y.Z.
       - name: Version-pin consistency check
         run: bash scripts/check-version-pins.sh
+
+      # config.json and config-cover.json must agree on privilege
+      # fields — a capability landing in only one means coverage runs
+      # test a different plugin than the one that ships (#317's
+      # CAP_SYS_PTRACE did exactly that on the v1.3.3 release PR).
+      - name: Plugin-manifest parity check
+        run: bash scripts/check-manifest-parity.sh
 
   staticcheck:
     runs-on: ubuntu-latest

--- a/config-cover.json
+++ b/config-cover.json
@@ -68,7 +68,8 @@
     "linux": {
         "capabilities": [
             "CAP_NET_ADMIN",
-            "CAP_SYS_ADMIN"
+            "CAP_SYS_ADMIN",
+            "CAP_SYS_PTRACE"
         ]
     }
 }

--- a/scripts/check-manifest-parity.sh
+++ b/scripts/check-manifest-parity.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Guard against drift between the production plugin manifest
+# (config.json) and the coverage-instrumented one (config-cover.json).
+# The two must agree on every privilege-relevant field — the cover
+# plugin exists to run the SAME suite with instrumentation, so a
+# privilege mismatch makes coverage runs test a different plugin than
+# the one that ships. Learned the hard way: #317's CAP_SYS_PTRACE fix
+# landed in config.json only, and the release-PR coverage run failed
+# the new non-root test against the unfixed cover manifest.
+#
+# Cover-specific additions (env like GOCOVERDIR, extra mounts) are
+# expected and NOT compared. Usage:
+#   scripts/check-manifest-parity.sh [config.json] [config-cover.json]
+set -euo pipefail
+
+MAIN="${1:-config.json}"
+COVER="${2:-config-cover.json}"
+
+fails=0
+for field in '.linux.capabilities' '.network.type' '.pidhost' '.interface.types'; do
+    a=$(jq -cS "$field" "$MAIN")
+    b=$(jq -cS "$field" "$COVER")
+    if [ "$a" != "$b" ]; then
+        echo "FAIL  $field differs: $MAIN=$a $COVER=$b"
+        fails=1
+    else
+        echo "ok    $field $a"
+    fi
+done
+
+if [ "$fails" -ne 0 ]; then
+    echo "manifest parity check FAILED — align $COVER with $MAIN"
+    exit 1
+fi
+echo "PASS  plugin manifests agree on privilege-relevant fields"

--- a/scripts/test-check-manifest-parity.sh
+++ b/scripts/test-check-manifest-parity.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Meta-test for check-manifest-parity.sh: the failure mode it guards is
+# a privilege field silently differing between the two plugin manifests.
+set -euo pipefail
+
+CHECK="$(dirname "$0")/check-manifest-parity.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+fails=0
+
+check() {
+    local desc="$1" want="$2" got="$3"
+    if [ "$got" = "$want" ]; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc — want '$want', got '$got'"
+        fails=1
+    fi
+}
+
+base='{"interface":{"types":["docker.networkdriver/1.0"]},"network":{"type":"host"},"pidhost":true,"linux":{"capabilities":["CAP_NET_ADMIN","CAP_SYS_ADMIN","CAP_SYS_PTRACE"]}}'
+
+# identical privilege fields -> pass (cover-side extras are ignored)
+echo "$base" > "$TMP/a.json"
+echo "$base" | jq '. + {env:[{name:"GOCOVERDIR",value:"/x"}]}' > "$TMP/b.json"
+got=$(bash "$CHECK" "$TMP/a.json" "$TMP/b.json" >/dev/null 2>&1 && echo pass || echo fail)
+check "identical privileges (with cover-only extras) pass" pass "$got"
+
+# missing capability -> fail (the #317 regression shape)
+echo "$base" | jq '.linux.capabilities -= ["CAP_SYS_PTRACE"]' > "$TMP/b.json"
+got=$(bash "$CHECK" "$TMP/a.json" "$TMP/b.json" >/dev/null 2>&1 && echo pass || echo fail)
+check "capability drift fails" fail "$got"
+
+# pidhost drift -> fail
+echo "$base" | jq '.pidhost = false' > "$TMP/b.json"
+got=$(bash "$CHECK" "$TMP/a.json" "$TMP/b.json" >/dev/null 2>&1 && echo pass || echo fail)
+check "pidhost drift fails" fail "$got"
+
+# the real repo manifests must currently agree
+got=$(bash "$CHECK" >/dev/null 2>&1 && echo pass || echo fail)
+check "repo config.json and config-cover.json agree" pass "$got"
+
+if [ "$fails" -ne 0 ]; then
+    echo "check-manifest-parity tests FAILED"
+    exit 1
+fi
+echo "All check-manifest-parity tests passed"


### PR DESCRIPTION
Refs #317. PR #320 fixed `config.json` only — the coverage workflow's instrumented plugin builds from `config-cover.json`, which still lacked the capability, so release PR #322's coverage run failed the new non-root regression test (correctly: the cover plugin WAS still broken, and the improved await error showed the real cause — `last attempt: permission denied`).

- `config-cover.json`: adds `CAP_SYS_PTRACE`.
- New `scripts/check-manifest-parity.sh` + meta-test, wired into test.yaml: the two manifests must agree on privilege-relevant fields (capabilities, network type, pidhost, interface types) so this class of drift turns CI red instead of surfacing on a release PR. Cover-only extras (env, mounts) are deliberately not compared.

After this merges, #322's coverage run reruns against the fixed cover manifest.