### PR TITLE
Retry dhcpd requests until timeout

### DIFF
--- a/pkg/dhcp/client.go
+++ b/pkg/dhcp/client.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netns"
@@ -52,6 +53,12 @@ const (
 	// non-zero exit error — enough for the operative diagnostic line(s)
 	// without unbounded growth from a chatty trace.
 	stderrTailMax = 4 << 10
+)
+
+// Indirection over the internal lease acquisition call so unit tests can mock
+// results without running a real dhcpcd process.
+var (
+	attemptGetIPFunc = attemptGetIP
 )
 
 // mountPrep is the shell run inside the `unshare -m` mount namespace
@@ -420,16 +427,9 @@ func (c *DHCPClient) await(ctx context.Context) error {
 	}
 }
 
-// GetIP runs dhcpcd once and returns the lease info obtained. The
-// caller's opts is not mutated — we work on a local copy so a caller
-// that reuses the options struct between persistent and one-shot calls
-// doesn't get its Once flag flipped on.
-func GetIP(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, error) {
+func attemptGetIP(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, error) {
 	dummy := Info{}
-
-	optsCopy := *opts
-	optsCopy.Once = true
-	client, err := NewDHCPClient(iface, &optsCopy)
+	client, err := NewDHCPClient(iface, opts)
 	if err != nil {
 		return dummy, fmt.Errorf("failed to create DHCP client: %w", err)
 	}
@@ -469,5 +469,42 @@ func GetIP(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, er
 		return info, nil
 	case <-ctx.Done():
 		return dummy, ctx.Err()
+	}
+}
+
+// GetIP runs dhcpcd and returns the lease info obtained. It retries
+// automatically if the lease acquisition fails, up to the deadline
+// of the passed context.
+// The caller's opts is not mutated — we work on a local copy so a caller
+// that reuses the options struct between persistent and one-shot calls
+// doesn't get its Once flag flipped on.
+func GetIP(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, error) {
+	dummy := Info{}
+
+	optsCopy := *opts
+	optsCopy.Once = true
+
+	var lastErr error
+	for {
+		if err := ctx.Err(); err != nil {
+			if lastErr != nil {
+				return dummy, fmt.Errorf("%w (last attempt error: %v)", err, lastErr)
+			}
+			return dummy, err
+		}
+
+		info, err := attemptGetIPFunc(ctx, iface, &optsCopy)
+		if err == nil {
+			return info, nil
+		}
+
+		lastErr = err
+		log.WithError(err).WithField("iface", iface).Warn("DHCP lease acquisition attempt failed...")
+
+		select {
+		case <-time.After(500 * time.Millisecond):
+		case <-ctx.Done():
+			return dummy, fmt.Errorf("%w (last attempt error: %v)", ctx.Err(), lastErr)
+		}
 	}
 }

--- a/pkg/dhcp/client_test.go
+++ b/pkg/dhcp/client_test.go
@@ -1,10 +1,13 @@
 package dhcp
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // hasArg returns whether args contains exactly target.
@@ -238,5 +241,82 @@ func TestTailWriter_CapsAndCondenses(t *testing.T) {
 	}
 	if (&tailWriter{max: stderrTailMax}).condense() != "" {
 		t.Errorf("empty tail should condense to empty string")
+	}
+}
+
+// stubAttemptGetIP swaps attemptGetIPFunc for the test's duration.
+func stubAttemptGetIP(t *testing.T, fn func(context.Context, string, *DHCPClientOptions) (Info, error)) {
+	t.Helper()
+	prev := attemptGetIPFunc
+	attemptGetIPFunc = fn
+	t.Cleanup(func() { attemptGetIPFunc = prev })
+}
+
+func TestGetIP_RetriesAndSucceeds(t *testing.T) {
+	attempts := 0
+	expectedIP := "192.168.1.100/24"
+	expectedGateway := "192.168.1.1"
+
+	stubAttemptGetIP(t, func(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, error) {
+		attempts++
+		if attempts < 3 {
+			// First two attempts fail.
+			return Info{}, errors.New("lease request failed")
+		}
+		// Third attempt succeeds.
+		return Info{
+			IP:      expectedIP,
+			Gateway: expectedGateway,
+		}, nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	opts := &DHCPClientOptions{
+		MAC: mustMAC(t, "de:ad:be:ef:00:01"),
+	}
+
+	info, err := GetIP(ctx, "eth0", opts)
+	if err != nil {
+		t.Fatalf("GetIP failed: %v", err)
+	}
+
+	if attempts != 3 {
+		t.Errorf("Expected 3 attempts, got %d", attempts)
+	}
+
+	if info.IP != expectedIP || info.Gateway != expectedGateway {
+		t.Errorf("Expected IP %q and Gateway %q, got IP %q and Gateway %q", expectedIP, expectedGateway, info.IP, info.Gateway)
+	}
+}
+
+func TestGetIP_ContextCancelledStopRetries(t *testing.T) {
+	attempts := 0
+	ctx, cancel := context.WithCancel(context.Background())
+
+	stubAttemptGetIP(t, func(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, error) {
+		attempts++
+		if attempts == 2 {
+			cancel()
+		}
+		return Info{}, errors.New("lease request failed")
+	})
+
+	opts := &DHCPClientOptions{
+		MAC: mustMAC(t, "de:ad:be:ef:00:01"),
+	}
+
+	_, err := GetIP(ctx, "eth0", opts)
+	if err == nil {
+		t.Fatal("Expected GetIP to fail with context cancelled, but got no error")
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Expected error to be context.Canceled, got %v", err)
+	}
+
+	if attempts != 2 {
+		t.Errorf("Expected 2 attempts before cancellation, got %d", attempts)
 	}
 }


### PR DESCRIPTION
## What this changes

For whatever reason, I'm getting frequent `did not output a lease` errors before the 10s timeout. Worse, this failure stops docker from booting the container, and I have to retry `docker-compose up` until it succeeds.

With this change, I'm attempting to catch any quick errors from the server and retry (as long as we're still within our timeout limit). Hopefully this'll make the bootup process more resilient.

## Related issue


## Checklist

- [ ] Branched off and targets `dev` (not `main`)
- [ ] Tests added/updated for the change (the coverage ratchet is enforced at release)
- [ ] Unit tests, `staticcheck`, and the integration suite pass
- [ ] Docs (README / `docs/`) updated if behaviour or options changed
- [ ] No secrets, credentials, or internal host details in the diff
