### PR TITLE
ci(govulncheck): drop the stale allowlist entry, reject inconclusive scans, restore a misplaced comment (#333)

### DIFF
--- a/.github/vuln-allowlist.txt
+++ b/.github/vuln-allowlist.txt
@@ -21,15 +21,18 @@ GO-2026-4883
 # GO-2026-5617: docker cp race — bind mount redirection to host path.
 # GO-2026-5668: docker cp race — arbitrary empty file creation via
 #   symlink swap.
-# GO-2026-5746: PUT /containers/{id}/archive executes container binary
-#   on the host.
-#   All three live in github.com/docker/docker daemon-side code
-#   (docker cp / container archive handling in dockerd). This plugin
-#   only uses the client API against the local daemon socket; the
-#   vulnerable paths never execute in us. Fixed only in
-#   github.com/moby/moby/v2@v2.0.0-beta.14 — no fixed release exists
-#   for the legacy github.com/docker/docker module line (checked
-#   v28.5.2, 2026-07-03). Added in #292 (issue #291).
+#   Both live in github.com/docker/docker daemon-side code (docker cp
+#   handling in dockerd). This plugin only uses the client API against
+#   the local daemon socket; the vulnerable paths never execute in us.
+#   Fixed only in github.com/moby/moby/v2@v2.0.0-beta.14 — no fixed
+#   release exists for the legacy github.com/docker/docker module line
+#   (checked v28.5.2, 2026-07-03). Added in #292 (issue #291).
+#
+#   GO-2026-5746 (PUT /containers/{id}/archive executes container
+#   binary on the host) was accepted here by the same #292 review, and
+#   removed on 2026-07-28: govulncheck stopped reporting it as
+#   reachable from our call graph, which is the documented trigger for
+#   dropping an entry. Should it become reachable again the gate fails
+#   loudly rather than silently re-accepting it.
 GO-2026-5617
 GO-2026-5668
-GO-2026-5746

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -197,11 +197,8 @@ jobs:
         run: |
           govulncheck ./... > vulns.txt || true
           cat vulns.txt
-          # A crashed scan must not pass as "no findings": assert the
-          # report actually concluded one way or the other.
-          if ! grep -qE 'No vulnerabilities found|Your code is affected' vulns.txt; then
-            echo "govulncheck did not produce a conclusive report"
-            exit 1
-          fi
+          # No conclusiveness check here on purpose: the gate below owns
+          # that invariant, so it holds for every caller of the script
+          # rather than only for this workflow.
       - name: Gate against allowlist
         run: bash scripts/govulncheck-gate.sh vulns.txt .github/vuln-allowlist.txt

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -146,10 +146,6 @@ jobs:
       - name: Verify actionlint catches known-bad patterns
         run: bash scripts/test-actionlint.sh actionlint
 
-  # Reachable-vulnerability scan. Known-and-reviewed findings without a
-  # published fix live in .github/vuln-allowlist.txt; anything else
-  # fails. The gate also warns when an allowlist entry stops being
-  # reported, so stale acceptances get removed (#127).
   # This fork is published as the maintainer's own work, so no commit
   # or PR may credit an AI assistant. The rule predates the repo's CI
   # and still reached a public branch twice — enforcing it mechanically
@@ -179,6 +175,10 @@ jobs:
           bash scripts/check-no-ai-attribution.sh \
             "$BASE_SHA..$HEAD_SHA" "$RUNNER_TEMP/pr-body.md"
 
+  # Reachable-vulnerability scan. Known-and-reviewed findings without a
+  # published fix live in .github/vuln-allowlist.txt; anything else
+  # fails. The gate also warns when an allowlist entry stops being
+  # reported, so stale acceptances get removed (#127).
   govulncheck:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/scripts/govulncheck-gate.sh
+++ b/scripts/govulncheck-gate.sh
@@ -7,8 +7,12 @@
 # Usage: govulncheck-gate.sh <govulncheck-text-output> <allowlist-file>
 #   <govulncheck-text-output>: captured stdout of `govulncheck ./...`
 #       (exit 3 from govulncheck means "findings exist" — capture the
-#       output and let this gate decide).
+#       output and let this gate decide). Must carry a govulncheck
+#       verdict line; see the conclusiveness check below.
 #   <allowlist-file>: one GO-XXXX-XXXX ID per line, '#' comments ok.
+#
+# Exit: 0 gate passed, 1 unaccepted vulnerability reported, 2 cannot
+# gate (bad usage, or a report the scan never concluded).
 set -u
 
 if [ "$#" -ne 2 ]; then
@@ -19,6 +23,19 @@ fi
 REPORT="$1"
 ALLOWLIST="$2"
 fail=0
+
+# A scan that never concluded must not gate as "nothing found". Every
+# finding this script acts on is a *positive* match in the report, so
+# an empty or error-only report — govulncheck refusing to load packages
+# on a toolchain skew is the realistic case, and callers capture its
+# output with `|| true` — would sail through as a clean pass and turn a
+# required check green while scanning nothing. Demand the verdict line
+# govulncheck emits either way, and exit 2 (cannot gate) rather than 1
+# (found something unaccepted) so the two are distinguishable.
+if ! grep -qE 'No vulnerabilities found|Your code is affected' "$REPORT"; then
+    echo "FAIL  $REPORT holds no govulncheck verdict — the scan did not conclude, so there is nothing to gate" >&2
+    exit 2
+fi
 
 # IDs govulncheck reports as affecting our code (default text output
 # lists only reachable findings as "Vulnerability #N: GO-...").

--- a/scripts/test-govulncheck-gate.sh
+++ b/scripts/test-govulncheck-gate.sh
@@ -67,6 +67,30 @@ else
     failures=$((failures + 1))
 fi
 
+# A scan that never concluded must not gate as "clean". Callers capture
+# govulncheck's output with `|| true`, so a crashed scan reaches the
+# gate as a report with no verdict line — historically a silent pass.
+: > "$TMP/empty.txt"
+check "empty report cannot gate" 2 "$TMP/empty.txt"
+
+cat > "$TMP/crashed.txt" <<'EOF'
+govulncheck: loading packages:
+There are errors with the provided package patterns:
+
+/src/pkg/plugin/plugin.go:1:1: package requires newer Go version go1.26 (application built with go1.25)
+EOF
+check "errored scan cannot gate" 2 "$TMP/crashed.txt"
+grep -q 'did not conclude' "$TMP/out" || { echo "FAIL: missing inconclusive-scan diagnostic"; failures=$((failures + 1)); }
+
+# The conclusiveness check must not shadow a real finding: a report that
+# concluded AND lists an unaccepted vulnerability still exits 1, not 2.
+cat > "$TMP/conclusive-new.txt" <<'EOF'
+Vulnerability #1: GO-2099-0003
+    Something new and scary
+Your code is affected by 1 vulnerability from 1 module.
+EOF
+check "conclusive report with new finding still exits 1" 1 "$TMP/conclusive-new.txt"
+
 if [ "$failures" -ne 0 ]; then
     echo "$failures gate test(s) failed"
     exit 1


### PR DESCRIPTION
## What this changes

Three pieces of govulncheck-gate hygiene, surfaced while triaging the dependabot PRs on this milestone.

**1. Drop `GO-2026-5746` (`34f6f94`)** — the gate has been warning that this entry is allowlisted but no longer reported, which is the documented trigger for removing it. The other four accepted IDs are still reported and stay. The rationale for its original acceptance is kept in the comment block rather than deleted, so the audit trail survives; if it becomes reachable again the gate fails loudly instead of silently re-accepting it.

**2. The gate rejects an inconclusive scan (`e65de46`)** — `govulncheck-gate.sh` acts only on positive `^Vulnerability #` matches, so an empty or error-only report produced `govulncheck gate passed` and exit 0. Callers capture the scan with `govulncheck ./... > vulns.txt || true`, so a scan that dies (a setup-go/`go.mod` toolchain skew is the realistic case) arrives as a verdict-less file.

The `Scan` step in `test.yaml` already asserted a conclusive report, so **CI was never exposed** — but that put the invariant in the workflow, protecting exactly one caller. It now lives in the script, so it holds for every caller, and the duplicate in the workflow is gone. Exits 2 (cannot gate) rather than 1 (found something unaccepted) so the outcomes stay distinguishable; 2 is already this script's "cannot gate" code.

**3. Restore the govulncheck job's comment (`ccec544`)** — #336 inserted the `attribution` job in a way that left the explanatory comment block for `govulncheck` sitting above `attribution:` instead of its own job. Pure comment relocation, no behaviour change; fixing it here rather than leaving the drift on `dev`.

## Related issue

Closes #333.

## Checklist

- [x] Branched off and targets `dev` (not `main`)
- [x] Tests added/updated for the change (the coverage ratchet is enforced at release) — three cases added to `scripts/test-govulncheck-gate.sh`: empty report and package-loading-error report both exit 2 with the diagnostic, and a conclusive report carrying an unaccepted finding still exits 1 so the new check can't shadow a real one
- [x] Unit tests, `staticcheck`, and the integration suite pass — all gate self-tests pass locally plus `actionlint`; no Go code changed
- [x] Docs (README / `docs/`) updated if behaviour or options changed — no operator-visible behaviour; the script's usage header now documents its exit codes
- [x] No secrets, credentials, or internal host details in the diff
