### PR TITLE
ci: enforce the no-AI-attribution rule mechanically — commits, identities, PR body (#335)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,6 +77,7 @@ jobs:
           bash scripts/test-integration-timing.sh
           bash scripts/test-integration-run-gate.sh
           bash scripts/test-check-manifest-parity.sh
+          bash scripts/test-check-no-ai-attribution.sh
 
       # Every driver-option key the code parses must be documented in
       # docs/reference.md — an undocumented option turns CI red (#132).
@@ -149,6 +150,35 @@ jobs:
   # published fix live in .github/vuln-allowlist.txt; anything else
   # fails. The gate also warns when an allowlist entry stops being
   # reported, so stale acceptances get removed (#127).
+  # This fork is published as the maintainer's own work, so no commit
+  # or PR may credit an AI assistant. The rule predates the repo's CI
+  # and still reached a public branch twice — enforcing it mechanically
+  # is the only version that holds on a bad day.
+  #
+  # pull_request only: the gate needs a base..head range and the PR
+  # description, neither of which a push event supplies.
+  attribution:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # The gate walks base..head; a shallow clone cannot resolve it.
+          fetch-depth: 0
+      - name: Check commits and PR body for AI attribution
+        env:
+          # Through env, never inlined into run: — a PR description is
+          # attacker-controlled text, and interpolating it directly
+          # would paste it into the shell.
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr-body.md"
+          bash scripts/check-no-ai-attribution.sh \
+            "$BASE_SHA..$HEAD_SHA" "$RUNNER_TEMP/pr-body.md"
+
   govulncheck:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/scripts/check-no-ai-attribution.sh
+++ b/scripts/check-no-ai-attribution.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# AI-attribution gate: this fork is published as the maintainer's own
+# work, so no commit or PR may credit an AI assistant. The rule has
+# been in CLAUDE.md from the start and still reached a public branch
+# twice, which is why it is enforced mechanically here instead of
+# remembered.
+#
+# Usage: check-no-ai-attribution.sh <commit-range> [pr-body-file]
+#   <commit-range>: any git range, e.g. origin/dev..HEAD
+#   [pr-body-file]: optional file holding the PR description
+#
+# Exit: 0 clean, 1 attribution found, 2 cannot check (bad usage/range).
+#
+# Four surfaces get checked, because all four have been hit:
+#   1. message trailers crediting an assistant as co-author
+#   2. assistant session-link trailers and footers
+#   3. "generated with/by <assistant>" marketing lines
+#   4. the commit author/committer IDENTITY itself — cherry-pick and
+#      rebase PRESERVE authorship, so a rewrite that strips trailers
+#      silently keeps a bad author. This is the one that got missed.
+#
+# Identity is matched by pattern, NOT against an allowlist of the
+# maintainer: external contributors and dependabot author commits here
+# too, and they are legitimate.
+set -u
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+    echo "usage: $0 <commit-range> [pr-body-file]" >&2
+    exit 2
+fi
+
+RANGE="$1"
+BODY="${2-}"
+fail=0
+
+if ! git rev-list "$RANGE" >/dev/null 2>&1; then
+    echo "FAIL  cannot resolve commit range '$RANGE'" >&2
+    exit 2
+fi
+
+# Vendor-agnostic on purpose: the rule is "no AI assistant credit", not
+# "no one specific product". Adding a vendor here is cheaper than
+# discovering the gap after a leak.
+VENDORS='claude|anthropic|copilot|chatgpt|openai|gemini|codex|cursor'
+
+# Attribution in free text, as <label>|<pattern> pairs — the label is
+# what gets reported, because a raw vendor alternation is unreadable in
+# CI output. Each pattern targets a real artifact rather than any
+# mention of a vendor, so prose may still discuss these tools without
+# tripping the gate.
+text_patterns=(
+    "assistant co-author trailer|co-authored-by:[[:space:]]*[^<]*($VENDORS)"
+    "assistant co-author trailer|co-authored-by:.*@(anthropic|openai)\.com"
+    "assistant session trailer|^[[:space:]]*($VENDORS)-session:"
+    "\"generated with/by\" line|generated (with|by) [^[:space:]]*[[:space:]]*($VENDORS)"
+    "assistant session link|($VENDORS)\.ai/code/session"
+    "robot-emoji generated line|🤖[[:space:]]*generated"
+)
+
+scan_text() {
+    # $1 = what is being scanned (for the message), $2 = the text.
+    # Reports each distinct kind of attribution once, not once per
+    # pattern that happens to match it.
+    local what="$1" text="$2" entry label pat
+    local -a seen=()
+    for entry in "${text_patterns[@]}"; do
+        label="${entry%%|*}"
+        pat="${entry#*|}"
+        printf '%s\n' "$text" | grep -qiE "$pat" || continue
+        case " ${seen[*]-} " in *" $label "*) continue ;; esac
+        seen+=("$label")
+        echo "FAIL  $what: contains attribution — $label"
+        fail=1
+    done
+}
+
+for sha in $(git rev-list "$RANGE"); do
+    short="${sha:0:8}"
+
+    # Identity: name and email of both author and committer.
+    while IFS= read -r ident; do
+        role="${ident%%$'\t'*}"
+        who="${ident#*$'\t'}"
+        if printf '%s\n' "$who" | grep -qiE "($VENDORS)"; then
+            echo "FAIL  commit $short: $role identity is '$who' — commits must not be authored by an AI assistant"
+            fail=1
+        fi
+    done < <(git log -1 --format="author	%an <%ae>
+committer	%cn <%ce>" "$sha")
+
+    scan_text "commit $short message" "$(git log -1 --format='%B' "$sha")"
+done
+
+if [ -n "$BODY" ]; then
+    if [ ! -f "$BODY" ]; then
+        echo "FAIL  PR body file '$BODY' does not exist" >&2
+        exit 2
+    fi
+    # Strip fenced blocks and inline code spans first: a PR that
+    # documents these patterns (this gate's own, for one) quotes them as
+    # code, while a real attribution footer never is.
+    # shellcheck disable=SC2016  # the backticks are markdown, not shell
+    body_prose=$(sed '/^[[:space:]]*```/,/^[[:space:]]*```/d' "$BODY" | sed 's/`[^`]*`//g')
+    scan_text "PR body" "$body_prose"
+fi
+
+if [ "$fail" -eq 0 ]; then
+    echo "AI-attribution gate passed"
+fi
+exit "$fail"

--- a/scripts/test-check-no-ai-attribution.sh
+++ b/scripts/test-check-no-ai-attribution.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Tests for check-no-ai-attribution.sh: a throwaway git repo with
+# deliberately-bad commits, so the identity checks are exercised
+# against real git metadata rather than synthetic text.
+set -u
+
+GATE="$(cd "$(dirname "$0")" && pwd)/check-no-ai-attribution.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+REPO="$TMP/repo"
+mkdir -p "$REPO"
+git init -q -b main "$REPO"
+git -C "$REPO" config user.name "Chris"
+git -C "$REPO" config user.email "chris@example.com"
+git -C "$REPO" config commit.gpgsign false
+
+failures=0
+
+# commit <subject-and-body> [author-name] [author-email]
+commit() {
+    local msg="$1" name="${2-Chris}" email="${3-chris@example.com}"
+    echo "$RANDOM" >> "$REPO/file.txt"
+    git -C "$REPO" add -A
+    GIT_AUTHOR_NAME="$name" GIT_AUTHOR_EMAIL="$email" \
+    GIT_COMMITTER_NAME="$name" GIT_COMMITTER_EMAIL="$email" \
+        git -C "$REPO" commit -q -m "$msg"
+}
+
+check() {
+    local name="$1" want_exit="$2"
+    shift 2
+    (cd "$REPO" && bash "$GATE" "$@") > "$TMP/out" 2>&1
+    local got=$?
+    if [ "$got" -eq "$want_exit" ]; then
+        echo "PASS: $name"
+    else
+        echo "FAIL: $name (want exit $want_exit, got $got)"
+        sed 's/^/    /' "$TMP/out"
+        failures=$((failures + 1))
+    fi
+}
+
+commit "feat: the baseline commit"
+BASE=$(git -C "$REPO" rev-parse HEAD)
+
+commit "fix: an ordinary change
+
+Explains itself over several lines, mentions no assistant."
+check "clean history passes" 0 "$BASE..HEAD"
+
+# 1. co-author trailer
+commit "fix: something
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+check "co-author trailer fails" 1 "$BASE..HEAD"
+grep -q 'co-author trailer' "$TMP/out" || { echo "FAIL: missing trailer diagnostic"; failures=$((failures+1)); }
+git -C "$REPO" reset -q --hard "$BASE"
+
+# 2. session trailer
+commit "fix: something
+
+Claude-Session: https://example.invalid/session_0123"
+check "session trailer fails" 1 "$BASE..HEAD"
+git -C "$REPO" reset -q --hard "$BASE"
+
+# 3. generated-with line
+commit "fix: something
+
+Generated with Claude Code"
+check "generated-with line fails" 1 "$BASE..HEAD"
+git -C "$REPO" reset -q --hard "$BASE"
+
+# 4. the one that got missed: clean message, assistant IDENTITY.
+commit "fix: a perfectly clean message" "Claude" "noreply@anthropic.com"
+check "assistant author identity fails despite clean message" 1 "$BASE..HEAD"
+grep -q 'identity' "$TMP/out" || { echo "FAIL: missing identity diagnostic"; failures=$((failures+1)); }
+git -C "$REPO" reset -q --hard "$BASE"
+
+# Legitimate non-maintainer authors must NOT trip the gate: external
+# contributors and dependabot commit here too.
+commit "build(deps): bump something" "dependabot[bot]" "49699333+dependabot[bot]@users.noreply.github.com"
+commit "fix: an outside contribution" "Jane Contributor" "jane@example.org"
+check "external and bot authors pass" 0 "$BASE..HEAD"
+git -C "$REPO" reset -q --hard "$BASE"
+
+# Prose that merely discusses the tools is not attribution.
+commit "docs: note which assistants the project does not credit
+
+The rule is that no AI assistant, Claude or otherwise, may be credited
+in commits. This message discusses that policy and must stay legal."
+check "prose mentioning assistants passes" 0 "$BASE..HEAD"
+git -C "$REPO" reset -q --hard "$BASE"
+
+# PR body scanning.
+commit "fix: clean commit for body tests"
+
+printf 'Ordinary description.\n\nNothing to see here.\n' > "$TMP/body-clean.md"
+check "clean PR body passes" 0 "$BASE..HEAD" "$TMP/body-clean.md"
+
+printf 'Some description.\n\n🤖 Generated with Claude Code\n' > "$TMP/body-bad.md"
+check "PR body attribution fails" 1 "$BASE..HEAD" "$TMP/body-bad.md"
+grep -q 'PR body' "$TMP/out" || { echo "FAIL: missing PR-body diagnostic"; failures=$((failures+1)); }
+
+printf 'Session footer.\n\nhttps://claude.ai/code/session_01ABC\n' > "$TMP/body-session.md"
+check "PR body session link fails" 1 "$BASE..HEAD" "$TMP/body-session.md"
+
+# A PR that DOCUMENTS the patterns quotes them as code — including this
+# gate's own PR. Fenced blocks and inline spans are stripped first.
+cat > "$TMP/body-doc.md" <<'EOF'
+This gate rejects the following in commit messages:
+
+```
+Co-Authored-By: Claude <noreply@anthropic.com>
+Generated with Claude Code
+```
+
+It also rejects `Claude-Session:` trailers and `claude.ai/code/session` links.
+EOF
+check "PR body documenting the patterns in code spans passes" 0 "$BASE..HEAD" "$TMP/body-doc.md"
+
+# Harness errors are distinguishable from findings.
+check "unresolvable range exits 2" 2 "no-such-ref..HEAD"
+check "missing body file exits 2" 2 "$BASE..HEAD" "$TMP/does-not-exist.md"
+(cd "$REPO" && bash "$GATE") >/dev/null 2>&1
+if [ $? -eq 2 ]; then
+    echo "PASS: usage error exits 2"
+else
+    echo "FAIL: usage error should exit 2"
+    failures=$((failures + 1))
+fi
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures attribution-gate test(s) failed"
+    exit 1
+fi
+echo "All AI-attribution-gate tests passed"


### PR DESCRIPTION
## What this changes

Turns the no-AI-attribution rule from something remembered into something enforced, in the established gate style: `scripts/check-no-ai-attribution.sh` + `scripts/test-check-no-ai-attribution.sh` + a `pull_request`-only job in `test.yaml`.

The rule is documented and predates this repo's CI, and it has still reached a public branch twice — most recently on the branch behind #330, where three commits carried assistant trailers **and** were authored by an assistant identity.

The identity half is why this is worth automating. Stripping trailers is not sufficient: `git cherry-pick` and `git rebase` preserve authorship, so a trailer-only cleanup keeps the bad author while a reviewer scanning commit *messages* sees nothing wrong. That is exactly how it survived one cleanup pass on #330.

## Four surfaces checked

1. Assistant co-author trailers
2. Assistant session-link trailers
3. `Generated with …` lines, including the robot-emoji variant
4. The commit **author and committer identity** itself

## Design notes

- **Identity is matched by pattern, not against an allowlist** of the maintainer — dependabot and outside contributors author commits here legitimately and must keep passing. There is a test for exactly that.
- **Vendor-agnostic**: the rule is "no AI assistant credit", not "no one product". Adding a vendor to the list is cheaper than discovering the gap after a leak.
- **Prose stays legal**: patterns target attribution artifacts, not any mention of these tools, so a commit may discuss them without tripping.
- **The PR body is scanned with fenced blocks and inline code spans stripped first** — so a PR that documents the patterns (this one) does not trip its own gate. Tested.
- **Exit 2 = cannot check** (bad usage, unresolvable range), distinct from **exit 1 = found attribution**, matching the sibling gates.
- The PR description reaches the script through `env:`, never interpolated into `run:` — it is attacker-controlled text.

## Verification

- 14 self-test cases against a throwaway git repo, so identities are real git metadata rather than synthetic strings — including the clean-message/bad-author case, bot and outside-contributor authors passing, prose passing, and a documenting PR body passing.
- **Live fixture**: run against the real pre-cleanup commits of #330 (kept locally) and its original description. All four surfaces flagged across all three commits; the cleaned branch and rewritten body pass. This gate would have failed that PR on day one instead of four days later.
- `actionlint` clean on the edited workflow; `shellcheck` clean on both scripts; the full gate-script sweep still passes.

## Follow-up for the maintainer

Making `attribution` a **required check** on `dev` and `main` is a repo-settings change, deliberately not part of this PR.

## Related issue

Closes #335.

## Checklist

- [x] Branched off and targets `dev` (not `main`)
- [x] Tests added/updated for the change (the coverage ratchet is enforced at release) — 14 cases, added to the gate-script self-test sweep
- [x] Unit tests, `staticcheck`, and the integration suite pass — no Go code changed; `actionlint`, `shellcheck`, and all nine gate self-tests pass locally
- [x] Docs (README / `docs/`) updated if behaviour or options changed — no operator-visible behaviour; the script documents its own contract and exit codes
- [x] No secrets, credentials, or internal host details in the diff
