### PR TITLE
DO NOT MERGE: control run for #330's concurrent-renew test (runtime-dir isolation reverted)

### DIFF
--- a/cmd/net-dhcp/main.go
+++ b/cmd/net-dhcp/main.go
@@ -69,7 +69,13 @@ func main() {
 		logFileMu.Lock()
 		old := currentLogFd
 		currentLogFd = f
-		log.StandardLogger().Out = f
+		// SetOutput (not a bare `.Out =`) takes logrus's own mutex, which
+		// every write also holds: the swap can't race a concurrent log
+		// write, and once it returns no writer can still be mid-write on
+		// the old fd — making the Close below safe. A direct field
+		// assignment had both problems (data race on Out; a SIGHUP close
+		// could yank the fd out from under an in-flight write).
+		log.StandardLogger().SetOutput(f)
 		logFileMu.Unlock()
 		if old != nil {
 			_ = old.Close()

--- a/pkg/dhcp/client.go
+++ b/pkg/dhcp/client.go
@@ -92,11 +92,9 @@ const (
 func mountPrep() string {
 	return fmt.Sprintf(
 		"mount -t tmpfs tmpfs %s 2>/dev/null; "+
-			"mkdir -p %s 2>/dev/null; "+
-			"mount -t tmpfs tmpfs %s 2>/dev/null; "+
 			"mount -o remount,bind,rw %s 2>/dev/null; "+
 			"exec \"$0\" \"$@\"",
-		dhcpcdStateDir, dhcpcdRunDir, dhcpcdRunDir, procSysPath)
+		dhcpcdStateDir, procSysPath)
 }
 
 // tailWriter retains the last up-to-max bytes written to it. dhcpcd's

--- a/pkg/dhcp/client.go
+++ b/pkg/dhcp/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net"
 	"os"
 	"os/exec"
@@ -15,6 +16,7 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netns"
@@ -170,10 +172,11 @@ type DHCPClientOptions struct {
 type DHCPClient struct {
 	Opts *DHCPClientOptions
 
-	cmd     *exec.Cmd
-	workDir string      // per-client temp dir: generated config + event FIFO
-	fifo    *os.File    // read+keep-alive (O_RDWR) end of the event FIFO
-	stderr  *tailWriter // last bytes of dhcpcd stderr, for the exit error
+	cmd      *exec.Cmd
+	workDir  string      // per-client temp dir: generated config + event FIFO
+	fifoRead *os.File    // read end of the event FIFO (scanner side)
+	fifoKeep *os.File    // write keep-alive (O_RDWR) end of the event FIFO
+	stderr   *tailWriter // last bytes of dhcpcd stderr, for the exit error
 
 	waitErr  error
 	waitDone chan struct{} // closed when cmd.Wait() returns
@@ -236,12 +239,25 @@ func NewDHCPClient(iface string, opts *DHCPClientOptions) (*DHCPClient, error) {
 		return cleanup(fmt.Errorf("failed to write dhcpcd config: %w", err))
 	}
 
-	// Open the read end now (and keep it open with O_RDWR so the FIFO
-	// never reports EOF between the short-lived hook processes that write
-	// to it). The reaper closes it on process exit to end the scanner.
-	fifo, err := os.OpenFile(fifoPath, os.O_RDWR, 0)
+	// The FIFO is opened twice, and the order matters. fifoKeep (O_RDWR,
+	// opened first so neither open can block) acts as a permanently-open
+	// writer: it keeps the FIFO from reporting EOF between the
+	// short-lived hook processes that write to it. fifoRead is the
+	// scanner's dedicated read end. On process exit the reaper closes
+	// ONLY fifoKeep — the scanner then drains whatever is still buffered
+	// in the FIFO and terminates on natural EOF. Closing the read end
+	// directly instead would discard any not-yet-scanned event, losing
+	// the final `bound` under scheduler contention: dhcpcd -1 exits
+	// right after the hook writes it, so the reaper's close raced the
+	// scanner's read and CreateEndpoint failed with ErrNoLease (#325).
+	fifoKeep, err := os.OpenFile(fifoPath, os.O_RDWR, 0)
 	if err != nil {
 		return cleanup(fmt.Errorf("failed to open event FIFO: %w", err))
+	}
+	fifoRead, err := os.OpenFile(fifoPath, os.O_RDONLY, 0)
+	if err != nil {
+		_ = fifoKeep.Close()
+		return cleanup(fmt.Errorf("failed to open event FIFO read end: %w", err))
 	}
 
 	// dhcpcd has no runtime state-dir override, so isolate per client in
@@ -253,11 +269,12 @@ func NewDHCPClient(iface string, opts *DHCPClientOptions) (*DHCPClient, error) {
 	wrapped := append([]string{"unshare", "-m", "/bin/sh", "-c", mountPrep()}, dargs...)
 
 	c := &DHCPClient{
-		Opts:    opts,
-		cmd:     exec.Command(wrapped[0], wrapped[1:]...),
-		workDir: workDir,
-		fifo:    fifo,
-		stderr:  &tailWriter{max: stderrTailMax},
+		Opts:     opts,
+		cmd:      exec.Command(wrapped[0], wrapped[1:]...),
+		workDir:  workDir,
+		fifoRead: fifoRead,
+		fifoKeep: fifoKeep,
+		stderr:   &tailWriter{max: stderrTailMax},
 	}
 	// dhcpcd's own logs (stdout/stderr) go to logrus at debug level; the
 	// structured events come over the FIFO, not these streams. stderr is
@@ -323,7 +340,8 @@ func (c *DHCPClient) Start() (chan Event, error) {
 	}
 
 	if err := c.cmd.Start(); err != nil {
-		c.fifo.Close()
+		c.fifoRead.Close()
+		c.fifoKeep.Close()
 		_ = os.RemoveAll(c.workDir)
 		return nil, err
 	}
@@ -332,12 +350,15 @@ func (c *DHCPClient) Start() (chan Event, error) {
 	events := make(chan Event, 16)
 
 	// Scanner: read newline-delimited JSON events off the FIFO and hand
-	// them downstream. Owns the events channel: closes it when the FIFO
-	// read ends (the reaper closes the FIFO once dhcpcd exits). A full
-	// channel drops events rather than blocking the DHCP exchange.
+	// them downstream. Owns the events channel (and the FIFO read end):
+	// once the reaper closes the keep-alive writer after dhcpcd exits,
+	// the scanner drains any still-buffered events, hits EOF, and closes
+	// both. A full channel drops events rather than blocking the DHCP
+	// exchange.
 	go func() {
 		defer close(events)
-		scanner := bufio.NewScanner(c.fifo)
+		defer c.fifoRead.Close()
+		scanner := bufio.NewScanner(c.fifoRead)
 		for scanner.Scan() {
 			log.WithField("line", string(scanner.Bytes())).Trace("dhcpcd handler line")
 			var event Event
@@ -354,8 +375,10 @@ func (c *DHCPClient) Start() (chan Event, error) {
 	}()
 
 	// Reaper: the single owner of cmd.Wait(). When dhcpcd exits it closes
-	// the FIFO (ending the scanner, which closes events) and records the
-	// exit status for Finish/Wait.
+	// the FIFO's keep-alive writer — NOT the read end — so the scanner
+	// drains any events still buffered in the FIFO before ending on EOF
+	// (#325: closing the read end here raced the scanner and could drop
+	// the final bound event), and records the exit status for Finish/Wait.
 	go func() {
 		werr := c.cmd.Wait()
 		// Wait has joined the stderr-copy goroutine, so the tail buffer is
@@ -367,7 +390,7 @@ func (c *DHCPClient) Start() (chan Event, error) {
 			}
 		}
 		c.waitErr = werr
-		c.fifo.Close()
+		c.fifoKeep.Close()
 		close(c.waitDone)
 	}()
 
@@ -420,16 +443,14 @@ func (c *DHCPClient) await(ctx context.Context) error {
 	}
 }
 
-// GetIP runs dhcpcd once and returns the lease info obtained. The
-// caller's opts is not mutated — we work on a local copy so a caller
-// that reuses the options struct between persistent and one-shot calls
-// doesn't get its Once flag flipped on.
-func GetIP(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, error) {
+// attemptGetIP runs dhcpcd once (opts must already carry Once=true)
+// and returns the lease info obtained. GetIP wraps it in a retry loop;
+// the indirection through attemptGetIPFunc lets unit tests exercise
+// that loop without running a real dhcpcd.
+func attemptGetIP(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, error) {
 	dummy := Info{}
 
-	optsCopy := *opts
-	optsCopy.Once = true
-	client, err := NewDHCPClient(iface, &optsCopy)
+	client, err := NewDHCPClient(iface, opts)
 	if err != nil {
 		return dummy, fmt.Errorf("failed to create DHCP client: %w", err)
 	}
@@ -469,5 +490,81 @@ func GetIP(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, er
 		return info, nil
 	case <-ctx.Done():
 		return dummy, ctx.Err()
+	}
+}
+
+var attemptGetIPFunc = attemptGetIP
+
+// Retry pacing for GetIP. The base delay keeps a failing endpoint from
+// hammering the DHCP server; the jitter de-synchronises the many
+// one-shot clients a `docker-compose up` starts at once, so their
+// retries don't land in lockstep.
+const (
+	leaseRetryDelay  = 500 * time.Millisecond
+	leaseRetryJitter = 250 * time.Millisecond
+)
+
+// isRetryableLeaseErr reports whether an attemptGetIP failure is worth
+// retrying: dhcpcd ran and the exchange failed (exited zero with no
+// lease event, or exited non-zero — e.g. its own internal timeout).
+// Everything else — client construction, exec, netns entry, the
+// caller's context firing — is deterministic or terminal, and
+// retrying it would only convert a fast, well-diagnosed failure into
+// a slow one (#247 diagnostics must surface immediately).
+func isRetryableLeaseErr(err error) bool {
+	var exitErr *exec.ExitError
+	return errors.Is(err, util.ErrNoLease) || errors.As(err, &exitErr)
+}
+
+// GetIP obtains a lease via one-shot dhcpcd runs, retrying transient
+// acquisition failures until the passed context's deadline. Retries
+// exist because a failed exchange is often momentary (#325: lost
+// server response under boot-time load, slow upstream) while the
+// price of giving up — Docker refusing to start the container — is
+// high. Permanent failures are returned immediately, unwrapped, so
+// errors.Is/As classification (and the #247 stderr diagnostics) keep
+// working; on deadline the last attempt's error is chained with %w
+// for the same reason (ErrToStatus's 502, the probe's ErrNoLease
+// branch).
+//
+// The caller's opts is not mutated — we work on a local copy so a
+// caller that reuses the options struct between persistent and
+// one-shot calls doesn't get its Once flag flipped on.
+func GetIP(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, error) {
+	dummy := Info{}
+
+	optsCopy := *opts
+	optsCopy.Once = true
+
+	var lastErr error
+	for {
+		if err := ctx.Err(); err != nil {
+			if lastErr != nil {
+				return dummy, fmt.Errorf("%w (last attempt error: %w)", err, lastErr)
+			}
+			return dummy, err
+		}
+
+		info, err := attemptGetIPFunc(ctx, iface, &optsCopy)
+		if err == nil {
+			return info, nil
+		}
+		if !isRetryableLeaseErr(err) {
+			// A context error mid-attempt is the deadline, not a new
+			// failure — report what we were retrying when it hit.
+			if lastErr != nil && ctx.Err() != nil {
+				return dummy, fmt.Errorf("%w (last attempt error: %w)", err, lastErr)
+			}
+			return dummy, err
+		}
+
+		lastErr = err
+		log.WithError(err).WithField("iface", iface).Warn("DHCP lease acquisition attempt failed; retrying")
+
+		select {
+		case <-time.After(leaseRetryDelay + rand.N(leaseRetryJitter)):
+		case <-ctx.Done():
+			return dummy, fmt.Errorf("%w (last attempt error: %w)", ctx.Err(), lastErr)
+		}
 	}
 }

--- a/pkg/dhcp/client.go
+++ b/pkg/dhcp/client.go
@@ -177,6 +177,7 @@ type DHCPClient struct {
 	fifoRead *os.File    // read end of the event FIFO (scanner side)
 	fifoKeep *os.File    // write keep-alive (O_RDWR) end of the event FIFO
 	stderr   *tailWriter // last bytes of dhcpcd stderr, for the exit error
+	logPipes []io.Closer // logrus WriterLevel pipe writers; closed by the reaper
 
 	waitErr  error
 	waitDone chan struct{} // closed when cmd.Wait() returns
@@ -280,8 +281,17 @@ func NewDHCPClient(iface string, opts *DHCPClientOptions) (*DHCPClient, error) {
 	// structured events come over the FIFO, not these streams. stderr is
 	// additionally tee'd into a bounded tail buffer so a non-zero exit
 	// can report dhcpcd's real diagnostic, not just "exit status 1" (#247).
-	c.cmd.Stdout = log.StandardLogger().WriterLevel(log.DebugLevel)
-	c.cmd.Stderr = io.MultiWriter(log.StandardLogger().WriterLevel(log.DebugLevel), c.stderr)
+	// WriterLevel spawns a goroutine reading an io.Pipe that only exits
+	// when the writer is closed — and exec never closes cmd.Stdout/Stderr
+	// writers — so the pipes are retained and closed by the reaper (after
+	// Wait has joined exec's copy goroutines, so nothing writes to them
+	// anymore). Without that close every dhcpcd run leaked two goroutines
+	// and pipe pairs for the daemon's lifetime.
+	outPipe := log.StandardLogger().WriterLevel(log.DebugLevel)
+	errPipe := log.StandardLogger().WriterLevel(log.DebugLevel)
+	c.cmd.Stdout = outPipe
+	c.cmd.Stderr = io.MultiWriter(errPipe, c.stderr)
+	c.logPipes = []io.Closer{outPipe, errPipe}
 
 	log.WithField("cmd", c.cmd.Args).Trace("new dhcpcd client")
 	return c, nil
@@ -342,6 +352,7 @@ func (c *DHCPClient) Start() (chan Event, error) {
 	if err := c.cmd.Start(); err != nil {
 		c.fifoRead.Close()
 		c.fifoKeep.Close()
+		c.closeLogPipes()
 		_ = os.RemoveAll(c.workDir)
 		return nil, err
 	}
@@ -391,10 +402,20 @@ func (c *DHCPClient) Start() (chan Event, error) {
 		}
 		c.waitErr = werr
 		c.fifoKeep.Close()
+		c.closeLogPipes()
 		close(c.waitDone)
 	}()
 
 	return events, nil
+}
+
+// closeLogPipes closes the logrus WriterLevel pipe writers so their
+// reader goroutines exit. Called once nothing can write to them anymore:
+// by the reaper after cmd.Wait, or on a failed Start.
+func (c *DHCPClient) closeLogPipes() {
+	for _, p := range c.logPipes {
+		_ = p.Close()
+	}
 }
 
 // Finish stops the client and waits for it to exit. For the persistent

--- a/pkg/dhcp/client.go
+++ b/pkg/dhcp/client.go
@@ -50,6 +50,26 @@ const (
 	// invisible to the host and to other containers.
 	procSysPath = "/proc/sys"
 
+	// dhcpcdRunDir is dhcpcd's compile-time runtime directory: the
+	// per-interface pidfile (<iface>-4.pid) and control sockets
+	// (<iface>-4.sock etc.). Like the state dir these are keyed by
+	// interface name with NO netns component, and /run is shared across
+	// the plugin's mount view — but unlike the state dir the collision
+	// here is not merely stale data. dhcpcd's startup first tries the
+	// per-interface control socket, and if a live instance answers it
+	// FORWARDS its argv to that instance and exits 0 without doing any
+	// DHCP work. Two containers whose container-side link is the default
+	// `eth0` therefore collide deterministically: the second container's
+	// persistent client becomes a no-op (lease never renewed or
+	// released) and the first container's dhcpcd is reconfigured with
+	// the second's config (verified against dhcpcd 10.x: "sending
+	// commands to dhcpcd process"). dhcpcd has no flag to suppress the
+	// pidfile/control socket, so this dir gets the same private-tmpfs
+	// treatment as the state dir (see mountPrep). Alpine's /var/run is a
+	// symlink to /run, so this canonical path covers either compile-time
+	// spelling.
+	dhcpcdRunDir = "/run/dhcpcd"
+
 	// stderrTailMax caps the dhcpcd stderr retained to fold into a
 	// non-zero exit error — enough for the operative diagnostic line(s)
 	// without unbounded growth from a chatty trace.
@@ -58,19 +78,25 @@ const (
 
 // mountPrep is the shell run inside the `unshare -m` mount namespace
 // before exec'ing dhcpcd. It (1) shadows the host-shared dhcpcd state
-// dir with a private tmpfs (see dhcpcdStateDir) and (2) flips /proc/sys
-// read-write so dhcpcd's interface-setup sysctl writes succeed (see
-// procSysPath, #247). Both mounts are local to this client's mount
-// namespace. Their stderr is swallowed: each can legitimately be a
-// no-op (state dir already private, /proc/sys already rw) or refused
-// (userns-locked mount) — a genuinely blocked sysctl write still
-// surfaces via dhcpcd's own stderr, captured into the exit error.
+// dir with a private tmpfs (see dhcpcdStateDir), (2) shadows dhcpcd's
+// runtime dir the same way so per-interface pidfiles/control sockets
+// can't collide across containers (see dhcpcdRunDir — without this the
+// second same-named-interface client forwards its argv into the first
+// container's dhcpcd and exits without acquiring anything), and
+// (3) flips /proc/sys read-write so dhcpcd's interface-setup sysctl
+// writes succeed (see procSysPath, #247). All mounts are local to this
+// client's mount namespace. Their stderr is swallowed: each can
+// legitimately be a no-op (dir already private, /proc/sys already rw)
+// or refused (userns-locked mount) — a genuinely blocked sysctl write
+// still surfaces via dhcpcd's own stderr, captured into the exit error.
 func mountPrep() string {
 	return fmt.Sprintf(
 		"mount -t tmpfs tmpfs %s 2>/dev/null; "+
+			"mkdir -p %s 2>/dev/null; "+
+			"mount -t tmpfs tmpfs %s 2>/dev/null; "+
 			"mount -o remount,bind,rw %s 2>/dev/null; "+
 			"exec \"$0\" \"$@\"",
-		dhcpcdStateDir, procSysPath)
+		dhcpcdStateDir, dhcpcdRunDir, dhcpcdRunDir, procSysPath)
 }
 
 // tailWriter retains the last up-to-max bytes written to it. dhcpcd's
@@ -422,6 +448,14 @@ func (c *DHCPClient) closeLogPipes() {
 // client it sends SIGTERM (dhcpcd releases its lease and exits); the
 // one-shot client exits on its own (-1), so Finish only awaits it.
 func (c *DHCPClient) Finish(ctx context.Context) error {
+	if c.cmd.Process == nil {
+		// Start was never called (or its cmd.Start failed): nothing to
+		// signal. await handles the not-started case; without this
+		// guard the Signal below would nil-panic for persistent
+		// clients. No production path hits this today — it hardens the
+		// contract await already advertises.
+		return c.await(ctx)
+	}
 	if !c.Opts.Once {
 		if err := c.cmd.Process.Signal(syscall.SIGTERM); err != nil {
 			// The process can self-exit between Start and here (lease
@@ -532,9 +566,19 @@ const (
 // caller's context firing — is deterministic or terminal, and
 // retrying it would only convert a fast, well-diagnosed failure into
 // a slow one (#247 diagnostics must surface immediately).
+//
+// One dhcpcd exit IS terminal: "interface not found" means the link
+// was deleted out from under us (DeleteEndpoint racing a slow
+// CreateEndpoint). Retrying would spawn dhcpcd against a nonexistent
+// interface every cycle until the lease timeout, then blame the DHCP
+// server. Matched best-effort on the stderr tail #247 folds into the
+// exit error — a miss merely retries as before.
 func isRetryableLeaseErr(err error) bool {
 	var exitErr *exec.ExitError
-	return errors.Is(err, util.ErrNoLease) || errors.As(err, &exitErr)
+	if !errors.Is(err, util.ErrNoLease) && !errors.As(err, &exitErr) {
+		return false
+	}
+	return !strings.Contains(err.Error(), "interface not found")
 }
 
 // GetIP obtains a lease via one-shot dhcpcd runs, retrying transient

--- a/pkg/dhcp/client_test.go
+++ b/pkg/dhcp/client_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -442,5 +443,44 @@ func TestGetIP_ContextCancelledStopsRetries(t *testing.T) {
 	}
 	if attempts != 2 {
 		t.Errorf("attempts: got %d, want 2 (must stop on cancellation)", attempts)
+	}
+}
+
+// TestStart_NoGoroutineLeakPerClient pins the log-pipe lifecycle: each
+// client wires dhcpcd's stdout/stderr into logrus via WriterLevel, whose
+// pipe-reader goroutines only exit when the writers are closed. The
+// reaper must close them after Wait, or every dhcpcd run (including each
+// GetIP retry) permanently leaks two goroutines and pipe pairs in the
+// long-running plugin daemon.
+func TestStart_NoGoroutineLeakPerClient(t *testing.T) {
+	const cycles = 50
+
+	baseline := runtime.NumGoroutine()
+	for i := 0; i < cycles; i++ {
+		c := newTestClient(t, "eth0", &DHCPClientOptions{Once: true, MAC: mustMAC(t, "de:ad:be:ef:00:01")})
+		swapCmd(c, "exit 0")
+		events, err := c.Start()
+		if err != nil {
+			t.Fatalf("cycle %d: Start: %v", i, err)
+		}
+		for range events {
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		_ = c.Wait(ctx)
+		cancel()
+	}
+
+	// The WriterLevel reader goroutines exit asynchronously after the
+	// reaper closes their writers; poll briefly for the count to settle.
+	// Pre-fix this leaked 2*cycles goroutines, far above the slack.
+	const slack = 10
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if growth := runtime.NumGoroutine() - baseline; growth <= slack {
+			return
+		} else if time.Now().After(deadline) {
+			t.Fatalf("goroutines grew by %d after %d client cycles (want <= %d): log pipes not closed?", growth, cycles, slack)
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 }

--- a/pkg/dhcp/client_test.go
+++ b/pkg/dhcp/client_test.go
@@ -1,10 +1,18 @@
 package dhcp
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/pkg/util"
 )
 
 // hasArg returns whether args contains exactly target.
@@ -27,8 +35,11 @@ func newTestClient(t *testing.T, iface string, opts *DHCPClientOptions) *DHCPCli
 		t.Fatalf("NewDHCPClient: %v", err)
 	}
 	t.Cleanup(func() {
-		if c.fifo != nil {
-			_ = c.fifo.Close()
+		if c.fifoRead != nil {
+			_ = c.fifoRead.Close()
+		}
+		if c.fifoKeep != nil {
+			_ = c.fifoKeep.Close()
 		}
 		_ = os.RemoveAll(c.workDir)
 	})
@@ -72,8 +83,11 @@ func TestNewDHCPClient_RejectsInvalidIface(t *testing.T) {
 			t.Errorf("NewDHCPClient(%q) rejected a valid interface name: %v", name, err)
 			continue
 		}
-		if c.fifo != nil {
-			_ = c.fifo.Close()
+		if c.fifoRead != nil {
+			_ = c.fifoRead.Close()
+		}
+		if c.fifoKeep != nil {
+			_ = c.fifoKeep.Close()
 		}
 		_ = os.RemoveAll(c.workDir)
 	}
@@ -238,5 +252,195 @@ func TestTailWriter_CapsAndCondenses(t *testing.T) {
 	}
 	if (&tailWriter{max: stderrTailMax}).condense() != "" {
 		t.Errorf("empty tail should condense to empty string")
+	}
+}
+
+// swapCmd replaces the client's dhcpcd command with an arbitrary shell
+// script standing in for the real process, so Start/scanner/reaper can
+// be exercised without dhcpcd.
+func swapCmd(c *DHCPClient, script string) {
+	c.cmd = exec.Command("/bin/sh", "-c", script)
+}
+
+// TestStart_BoundEventSurvivesFastExit is the regression test for the
+// reaper/scanner FIFO race (#325): a one-shot dhcpcd exits immediately
+// after its hook writes the bound event, and the reaper's FIFO close
+// could discard the event before the scanner read it, surfacing as a
+// spurious ErrNoLease under scheduler load. With the keep-alive-only
+// close the bound event must survive every time; repeated trials keep
+// the race window exercised.
+func TestStart_BoundEventSurvivesFastExit(t *testing.T) {
+	for i := 0; i < 300; i++ {
+		c := newTestClient(t, "eth0", &DHCPClientOptions{Once: true, MAC: mustMAC(t, "de:ad:be:ef:00:01")})
+		// Stand-in for dhcpcd -1: write the bound event to the FIFO
+		// (as the hook does) and exit immediately.
+		swapCmd(c, `printf '{"Type":"bound","Data":{"IP":"10.99.0.2/24","Gateway":"10.99.0.1"}}\n' > `+filepath.Join(c.workDir, "events"))
+
+		events, err := c.Start()
+		if err != nil {
+			t.Fatalf("trial %d: Start: %v", i, err)
+		}
+
+		bound := false
+		consumed := make(chan struct{})
+		go func() {
+			defer close(consumed)
+			for event := range events {
+				if event.Type == "bound" {
+					bound = true
+				}
+			}
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		if err := c.Wait(ctx); err != nil {
+			cancel()
+			t.Fatalf("trial %d: Wait: %v", i, err)
+		}
+		cancel()
+		<-consumed
+
+		if !bound {
+			t.Fatalf("trial %d: bound event lost between hook write and process exit", i)
+		}
+	}
+}
+
+// stubAttemptGetIP swaps attemptGetIPFunc for the test's duration.
+func stubAttemptGetIP(t *testing.T, fn func(context.Context, string, *DHCPClientOptions) (Info, error)) {
+	t.Helper()
+	prev := attemptGetIPFunc
+	attemptGetIPFunc = fn
+	t.Cleanup(func() { attemptGetIPFunc = prev })
+}
+
+func TestGetIP_RetriesTransientAndSucceeds(t *testing.T) {
+	attempts := 0
+	stubAttemptGetIP(t, func(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, error) {
+		attempts++
+		if !opts.Once {
+			t.Errorf("attempt %d: opts.Once not set", attempts)
+		}
+		if attempts < 3 {
+			return Info{}, util.ErrNoLease
+		}
+		return Info{IP: "192.168.1.100/24", Gateway: "192.168.1.1"}, nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	opts := &DHCPClientOptions{MAC: mustMAC(t, "de:ad:be:ef:00:01")}
+	info, err := GetIP(ctx, "eth0", opts)
+	if err != nil {
+		t.Fatalf("GetIP: %v", err)
+	}
+	if attempts != 3 {
+		t.Errorf("attempts: got %d, want 3", attempts)
+	}
+	if info.IP != "192.168.1.100/24" || info.Gateway != "192.168.1.1" {
+		t.Errorf("lease: got %+v", info)
+	}
+	if opts.Once {
+		t.Errorf("caller's opts.Once was mutated")
+	}
+}
+
+func TestGetIP_PermanentErrorFailsFast(t *testing.T) {
+	attempts := 0
+	permanent := errors.New("failed to create DHCP client: invalid interface name")
+	stubAttemptGetIP(t, func(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, error) {
+		attempts++
+		return Info{}, permanent
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err := GetIP(ctx, "eth0", &DHCPClientOptions{MAC: mustMAC(t, "de:ad:be:ef:00:01")})
+	if !errors.Is(err, permanent) {
+		t.Fatalf("error: got %v, want the permanent error unwrapped", err)
+	}
+	if attempts != 1 {
+		t.Errorf("attempts: got %d, want 1 (no retries on permanent errors)", attempts)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("permanent failure took %v; must fail fast", elapsed)
+	}
+}
+
+// A non-zero dhcpcd exit (wrapped with its stderr tail, as the reaper
+// does) is transient from the caller's perspective and must be retried;
+// client-construction errors must not be.
+func TestIsRetryableLeaseErr(t *testing.T) {
+	exitErr := exec.Command("/bin/sh", "-c", "exit 1").Run()
+	if exitErr == nil {
+		t.Skip("cannot produce an ExitError on this system")
+	}
+	wrapped := fmt.Errorf("%w: dhcpcd: timed out", exitErr)
+
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"no lease", util.ErrNoLease, true},
+		{"wrapped no lease", fmt.Errorf("x: %w", util.ErrNoLease), true},
+		{"dhcpcd exit + stderr tail", wrapped, true},
+		{"client setup", errors.New("failed to create DHCP client: x"), false},
+		{"context deadline", context.DeadlineExceeded, false},
+	} {
+		if got := isRetryableLeaseErr(tc.err); got != tc.want {
+			t.Errorf("%s: isRetryableLeaseErr = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// On deadline the error must keep BOTH sentinels intact: the context
+// error (probe's "no DHCP OFFER" classification) and the last attempt's
+// error (ErrToStatus's 502 mapping for ErrNoLease).
+func TestGetIP_DeadlinePreservesErrorChain(t *testing.T) {
+	stubAttemptGetIP(t, func(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, error) {
+		return Info{}, util.ErrNoLease
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	_, err := GetIP(ctx, "eth0", &DHCPClientOptions{MAC: mustMAC(t, "de:ad:be:ef:00:01")})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error lost context.DeadlineExceeded: %v", err)
+	}
+	if !errors.Is(err, util.ErrNoLease) {
+		t.Errorf("error lost util.ErrNoLease sentinel: %v", err)
+	}
+	if got := util.ErrToStatus(err); got != http.StatusBadGateway {
+		t.Errorf("ErrToStatus: got %d, want 502 (ErrNoLease must survive the retry loop)", got)
+	}
+}
+
+func TestGetIP_ContextCancelledStopsRetries(t *testing.T) {
+	attempts := 0
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stubAttemptGetIP(t, func(ctx context.Context, iface string, opts *DHCPClientOptions) (Info, error) {
+		attempts++
+		if attempts == 2 {
+			cancel()
+		}
+		return Info{}, util.ErrNoLease
+	})
+
+	_, err := GetIP(ctx, "eth0", &DHCPClientOptions{MAC: mustMAC(t, "de:ad:be:ef:00:01")})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error: got %v, want context.Canceled", err)
+	}
+	if attempts != 2 {
+		t.Errorf("attempts: got %d, want 2 (must stop on cancellation)", attempts)
 	}
 }

--- a/pkg/dhcp/client_test.go
+++ b/pkg/dhcp/client_test.go
@@ -210,6 +210,12 @@ func TestMountPrep_RemountsProcSysRW(t *testing.T) {
 	// per-client tmpfs state dir and exec dhcpcd via $0/$@.
 	for _, want := range []string{
 		"mount -t tmpfs tmpfs " + dhcpcdStateDir,
+		// dhcpcd's runtime dir (pidfile + control sockets, keyed by
+		// interface name only) must be private per client, or the
+		// second same-named-interface client forwards its argv into
+		// the first container's dhcpcd and exits without doing DHCP.
+		"mkdir -p " + dhcpcdRunDir,
+		"mount -t tmpfs tmpfs " + dhcpcdRunDir,
 		"mount -o remount,bind,rw " + procSysPath,
 		`exec "$0" "$@"`,
 	} {
@@ -482,5 +488,30 @@ func TestStart_NoGoroutineLeakPerClient(t *testing.T) {
 			t.Fatalf("goroutines grew by %d after %d client cycles (want <= %d): log pipes not closed?", growth, cycles, slack)
 		}
 		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// A dhcpcd exit whose stderr tail says the interface is gone is
+// terminal (link deleted under us), not retryable.
+func TestIsRetryableLeaseErr_InterfaceVanished(t *testing.T) {
+	exitErr := exec.Command("/bin/sh", "-c", "exit 1").Run()
+	if exitErr == nil {
+		t.Skip("cannot produce an ExitError on this system")
+	}
+	vanished := fmt.Errorf("%w: eth0: interface not found or invalid", exitErr)
+	if isRetryableLeaseErr(vanished) {
+		t.Errorf("interface-not-found exit must be terminal, got retryable")
+	}
+}
+
+// Finish without Start must not panic (persistent clients would
+// otherwise nil-deref cmd.Process on the SIGTERM path) and must clean
+// up like await does.
+func TestFinish_WithoutStartIsSafe(t *testing.T) {
+	c := newTestClient(t, "eth0", &DHCPClientOptions{Once: false, MAC: mustMAC(t, "de:ad:be:ef:00:01")})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := c.Finish(ctx); err != nil {
+		t.Fatalf("Finish without Start: %v", err)
 	}
 }

--- a/pkg/dhcp/client_test.go
+++ b/pkg/dhcp/client_test.go
@@ -214,8 +214,6 @@ func TestMountPrep_RemountsProcSysRW(t *testing.T) {
 		// interface name only) must be private per client, or the
 		// second same-named-interface client forwards its argv into
 		// the first container's dhcpcd and exits without doing DHCP.
-		"mkdir -p " + dhcpcdRunDir,
-		"mount -t tmpfs tmpfs " + dhcpcdRunDir,
 		"mount -o remount,bind,rw " + procSysPath,
 		`exec "$0" "$@"`,
 	} {

--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -889,6 +889,12 @@ func (m *dhcpManager) Start(ctx context.Context) (err error) {
 			}
 			if m.errChanV6, err = m.setupClient(true); err != nil {
 				close(m.stopChan)
+				// The v4 consumer goroutine is already live and may be
+				// mid-renew on m.netHandle; stopChan only signals it.
+				// Drain its exit ack so the outer cleanup can't close
+				// the netlink/netns handles out from under it (and so
+				// the v4 dhcpcd is reaped, not orphaned).
+				<-m.errChan
 				return err
 			}
 		}
@@ -928,33 +934,53 @@ func (m *dhcpManager) Stop() error {
 
 	close(m.stopChan)
 
+	// Drain BOTH consumer goroutines before doing anything else — in
+	// particular before this function can return and run the deferred
+	// handle closes. A v4 release failure must not leave the v6
+	// consumer live and mid-renew on m.netHandle while the deferred
+	// closeNetHandle nils the netlink socket out from under it (the
+	// netlink Handle's Close is unsynchronized against requests).
 	lastIP, lastIPv6 := m.lastIPs()
-	if err := <-m.errChan; err != nil {
-		// SIGTERM -> DHCPRELEASE -> exit didn't complete cleanly. The
-		// upstream server may now be holding a phantom lease against
-		// this MAC until its own expiry. Bump so operators can alert
-		// on a pattern of releases failing — typically points at
-		// upstream reachability problems mid-teardown. The ledger
-		// records release_failed rather than release so the audit
-		// trail never claims a release the server may not have seen.
+	errV4 := <-m.errChan
+	var errV6 error
+	if m.opts.IPv6 {
+		errV6 = <-m.errChanV6
+	}
+
+	// SIGTERM -> DHCPRELEASE -> exit didn't complete cleanly. The
+	// upstream server may now be holding a phantom lease against
+	// this MAC until its own expiry. Bump so operators can alert
+	// on a pattern of releases failing — typically points at
+	// upstream reachability problems mid-teardown. The ledger
+	// records release_failed rather than release so the audit
+	// trail never claims a release the server may not have seen.
+	// Both families are audited independently: a failed v4 release
+	// no longer hides the v6 outcome from the ledger.
+	if errV4 != nil {
 		if m.plugin != nil {
 			m.plugin.leaseReleaseFailures.Add(1)
 		}
 		m.audit("release_failed", auditIP(lastIP))
-		return fmt.Errorf("failed shut down DHCP client: %w", err)
+	} else {
+		m.audit("release", auditIP(lastIP))
 	}
-	m.audit("release", auditIP(lastIP))
 	if m.opts.IPv6 {
-		if err := <-m.errChanV6; err != nil {
+		if errV6 != nil {
 			if m.plugin != nil {
 				m.plugin.leaseReleaseFailures.Add(1)
 			}
 			m.audit("release_failed", auditIP(lastIPv6))
-			return fmt.Errorf("failed shut down DHCPv6 client: %w", err)
+		} else {
+			m.audit("release", auditIP(lastIPv6))
 		}
-		m.audit("release", auditIP(lastIPv6))
 	}
 
+	if errV4 != nil {
+		return fmt.Errorf("failed shut down DHCP client: %w", errV4)
+	}
+	if errV6 != nil {
+		return fmt.Errorf("failed shut down DHCPv6 client: %w", errV6)
+	}
 	return nil
 }
 

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -738,6 +739,21 @@ func (p *Plugin) DeleteEndpoint(ctx context.Context, r DeleteEndpointRequest) er
 	hostName, _ := vethPairNames(r.EndpointID)
 	link, err := netlink.LinkByName(hostName)
 	if err != nil {
+		// A veth pair dies whole when the container-side end's netns is
+		// destroyed (OOM-kill, `docker rm -f`, host reboot race), so a
+		// missing host-side link means the cleanup already happened —
+		// the same happy-path treatment the macvlan/ipvlan delete path
+		// gives it. Hard-failing here 500s the DeleteEndpoint and can
+		// wedge `docker network rm`. Anything other than not-found is
+		// still a real error.
+		var lnf netlink.LinkNotFoundError
+		if errors.As(err, &lnf) {
+			log.WithFields(log.Fields{
+				"network":  shortID(r.NetworkID),
+				"endpoint": shortID(r.EndpointID),
+			}).Debug("Host veth already gone (expected on forced teardown)")
+			return nil
+		}
 		return fmt.Errorf("failed to lookup host veth interface %v: %w", hostName, err)
 	}
 
@@ -1032,7 +1048,22 @@ func (p *Plugin) Join(ctx context.Context, r JoinRequest) (JoinResponse, error) 
 	m.setLastIP(false, hint.IPv4)
 	m.setLastIP(true, hint.IPv6)
 	m.MacAddress = hint.MacAddress
-	p.registerDHCPManager(r.EndpointID, m)
+	if displaced := p.registerDHCPManager(r.EndpointID, m); displaced != nil {
+		// A recovery-registered manager for this endpoint was still in
+		// the registry (Join with no preceding Leave to this plugin
+		// instance — plugin restart racing a container restart). Stop
+		// it so its dhcpcd doesn't run untracked forever and collide
+		// with the new client on the same interface. Asynchronously:
+		// Stop blocks on the dhcpcd release cycle and Join shouldn't.
+		go func() {
+			if err := displaced.Stop(); err != nil {
+				log.WithError(err).WithFields(log.Fields{
+					"network":  shortID(r.NetworkID),
+					"endpoint": shortID(r.EndpointID),
+				}).Warn("Failed to stop displaced DHCP manager")
+			}
+		}()
+	}
 
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), p.awaitTimeout)
@@ -1048,8 +1079,11 @@ func (p *Plugin) Join(ctx context.Context, r JoinRequest) (JoinResponse, error) 
 			// If Start failed, take ourselves out of the registry so a
 			// later Leave doesn't try to Stop() us. Stop() is safe to
 			// call against a failed-Start manager (it returns the start
-			// error), but de-registering keeps the map tidy.
-			p.takeDHCPManager(r.EndpointID)
+			// error), but de-registering keeps the map tidy. Identity-
+			// checked: a fast Leave+Join can already have installed a
+			// new healthy manager under this key, which we must not
+			// evict.
+			p.removeDHCPManagerIfSame(r.EndpointID, m)
 		}
 	}()
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -432,10 +432,35 @@ func (p *Plugin) takeJoinHint(endpointID string) (joinHint, bool) {
 // can find it. Caller registers the manager *before* spawning the
 // goroutine that runs dhcpManager.Start; dhcpManager.Stop is safe to
 // call against a manager whose Start is still in flight.
-func (p *Plugin) registerDHCPManager(endpointID string, m *dhcpManager) {
+//
+// Returns the manager this registration displaced, or nil. A displaced
+// manager happens when Join lands on an endpoint the recovery path
+// already registered (plugin restart while the container restarts:
+// Docker sends Join with no preceding Leave to this plugin instance).
+// Silently dropping it from the map would leak its running dhcpcd —
+// unstoppable forever, and colliding with the new client on the same
+// interface — so the caller must Stop it.
+func (p *Plugin) registerDHCPManager(endpointID string, m *dhcpManager) *dhcpManager {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	old := p.persistentDHCP[endpointID]
 	p.persistentDHCP[endpointID] = m
+	return old
+}
+
+// removeDHCPManagerIfSame deletes the registry entry for endpointID only
+// if it still holds m. The failed-Start goroutines use this instead of
+// takeDHCPManager: between Start failing (which unblocks a pending
+// Leave) and the goroutine reaching its deregistration, a fast
+// Leave+Join cycle can install a NEW healthy manager under the same
+// key — deleting by key alone would evict that successor, leaking its
+// running dhcpcd.
+func (p *Plugin) removeDHCPManagerIfSame(endpointID string, m *dhcpManager) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.persistentDHCP[endpointID] == m {
+		delete(p.persistentDHCP, endpointID)
+	}
 }
 
 // takeDHCPManager atomically retrieves and deletes the DHCP manager for
@@ -796,7 +821,9 @@ func (p *Plugin) recoverOneEndpoint(ctx context.Context, networkID, endpointID, 
 				"network":  shortID(networkID),
 				"endpoint": shortID(endpointID),
 			}).Error("recovery: persistent DHCP client Start failed; lease will not renew until container restart")
-			p.takeDHCPManager(endpointID)
+			// Identity-checked: a Join for this endpoint may already
+			// have displaced us with a fresh manager we must not evict.
+			p.removeDHCPManagerIfSame(endpointID, m)
 			return
 		}
 		p.recoveredOK.Add(1)
@@ -996,24 +1023,35 @@ func (p *Plugin) Listen(bindSock string) error {
 // a typical dhcpcd release-and-exit cycle completes well within it.
 const pluginShutdownTimeout = 5 * time.Second
 
-// Close stops the plugin server. Persistent DHCP clients are stopped
-// first so they get a chance to send DHCPRELEASE for their leases —
-// otherwise plugin upgrade or `docker plugin disable` would orphan
-// every active lease at the upstream DHCP server, defeating the
-// release-on-stop contract Leave normally honors.
+// Close stops the plugin. The HTTP server is closed FIRST so no new
+// Join can register a manager while (or after) we stop the existing
+// ones — with the old ordering a Join dispatched during the up-to-5s
+// stop fan-out installed a manager into the fresh registry that nobody
+// ever stopped, orphaning its lease (no DHCPRELEASE) and its dhcpcd.
+// Persistent DHCP clients are then stopped before process exit so they
+// get a chance to send DHCPRELEASE for their leases — otherwise plugin
+// upgrade or `docker plugin disable` would orphan every active lease at
+// the upstream DHCP server, defeating the release-on-stop contract
+// Leave normally honors.
 func (p *Plugin) Close() error {
-	// Snapshot the live managers under the lock, then drop the lock
-	// before calling Stop on each (Stop blocks on dhcpcd Wait and we
-	// don't want to hold p.mu across that).
-	p.mu.Lock()
-	managers := make([]*dhcpManager, 0, len(p.persistentDHCP))
-	for _, m := range p.persistentDHCP {
-		managers = append(managers, m)
-	}
-	p.persistentDHCP = make(map[string]*dhcpManager)
-	p.mu.Unlock()
+	serverErr := p.server.Close()
 
-	if len(managers) > 0 {
+	// stopSnapshot drains the current registry once: snapshot under the
+	// lock, then Stop each manager in parallel outside it (Stop blocks
+	// on dhcpcd Wait and we don't want to hold p.mu across that).
+	// Returns how many managers it stopped.
+	stopSnapshot := func() int {
+		p.mu.Lock()
+		managers := make([]*dhcpManager, 0, len(p.persistentDHCP))
+		for _, m := range p.persistentDHCP {
+			managers = append(managers, m)
+		}
+		p.persistentDHCP = make(map[string]*dhcpManager)
+		p.mu.Unlock()
+
+		if len(managers) == 0 {
+			return 0
+		}
 		log.WithField("count", len(managers)).Info("Stopping persistent DHCP clients before shutdown")
 		// Stop in parallel — each dhcpcd release is independent and
 		// we don't want N×timeout wall time.
@@ -1044,14 +1082,27 @@ func (p *Plugin) Close() error {
 		case <-time.After(pluginShutdownTimeout):
 			log.Warn("Timeout waiting for persistent DHCP clients to stop; continuing shutdown")
 		}
+		return len(managers)
+	}
+
+	// Two passes: server.Close doesn't wait for in-flight handlers, so
+	// a Join already past the listener when we closed it can register a
+	// manager after the first snapshot. Those handlers finish in
+	// milliseconds while the first fan-out runs; a second sweep catches
+	// them. (A handler still running after BOTH passes would need to
+	// outlast an entire release fan-out — at that point we're at the
+	// same process-exit backstop as W-8.)
+	stopSnapshot()
+	if n := stopSnapshot(); n > 0 {
+		log.WithField("count", n).Info("Stopped late-registered DHCP clients in shutdown sweep")
 	}
 
 	if err := p.docker.Close(); err != nil {
 		return fmt.Errorf("failed to close docker client: %w", err)
 	}
 
-	if err := p.server.Close(); err != nil {
-		return fmt.Errorf("failed to close http server: %w", err)
+	if serverErr != nil {
+		return fmt.Errorf("failed to close http server: %w", serverErr)
 	}
 
 	return nil

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -306,3 +306,50 @@ func TestListen_RemovesStaleSocket(t *testing.T) {
 	_ = l.Close()
 	_ = os.Remove(sockPath)
 }
+
+// TestRegisterDHCPManager_ReturnsDisplaced pins the displacement
+// contract: registering over an existing entry (Join landing on a
+// recovery-registered endpoint) must hand the old manager back so the
+// caller can Stop it instead of silently leaking its running dhcpcd.
+func TestRegisterDHCPManager_ReturnsDisplaced(t *testing.T) {
+	p := &Plugin{persistentDHCP: make(map[string]*dhcpManager)}
+	m1 := &dhcpManager{}
+	m2 := &dhcpManager{}
+
+	if got := p.registerDHCPManager("ep1", m1); got != nil {
+		t.Errorf("first registration displaced %v, want nil", got)
+	}
+	if got := p.registerDHCPManager("ep1", m2); got != m1 {
+		t.Errorf("second registration displaced %v, want the first manager", got)
+	}
+	if got, ok := p.takeDHCPManager("ep1"); !ok || got != m2 {
+		t.Errorf("registry holds %v (ok=%v), want the second manager", got, ok)
+	}
+}
+
+// TestRemoveDHCPManagerIfSame pins the identity-checked deregistration
+// used by the failed-Start goroutines: between a Start failure and its
+// late cleanup, a fast Leave+Join can install a NEW manager under the
+// same endpoint key — the cleanup must not evict that successor.
+func TestRemoveDHCPManagerIfSame(t *testing.T) {
+	p := &Plugin{persistentDHCP: make(map[string]*dhcpManager)}
+	failed := &dhcpManager{}
+	successor := &dhcpManager{}
+
+	// Normal case: entry still ours -> removed.
+	p.registerDHCPManager("ep1", failed)
+	p.removeDHCPManagerIfSame("ep1", failed)
+	if _, ok := p.takeDHCPManager("ep1"); ok {
+		t.Errorf("entry not removed when identity matches")
+	}
+
+	// Race case: successor already installed -> must survive.
+	p.registerDHCPManager("ep1", successor)
+	p.removeDHCPManagerIfSame("ep1", failed)
+	if got, ok := p.takeDHCPManager("ep1"); !ok || got != successor {
+		t.Errorf("successor manager evicted by stale cleanup (got %v, ok=%v)", got, ok)
+	}
+
+	// Missing entry: no-op, no panic.
+	p.removeDHCPManagerIfSame("ep-gone", failed)
+}

--- a/test/integration/concurrent_renew_test.go
+++ b/test/integration/concurrent_renew_test.go
@@ -1,0 +1,150 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
+	docker "github.com/docker/docker/client"
+)
+
+// TestConcurrentRenew_SameInterfaceNameBothRenew verifies that two
+// containers on the same network — both with the default container-side
+// interface name `eth0` — each keep a persistent DHCP client that
+// actually renews its own lease.
+//
+// This closes a structural blind spot rather than a hypothetical one.
+// dhcpcd keys its pidfile and control sockets by interface name alone,
+// in a runtime dir shared across the plugin's mount view. When only the
+// *state* dir was shadowed per client, the second container's dhcpcd
+// found the first container's live control socket, forwarded its argv
+// to it, and exited 0 — so the second container held an IP that no
+// client was renewing or releasing, while the first container's dhcpcd
+// was reconfigured with the second's settings.
+//
+// Nothing in the suite could see that. TestConcurrency_DistinctLeases
+// is the only concurrent multi-container test and asserts only the
+// *initial* IP/MAC, which comes from the one-shot client at
+// CreateEndpoint — it never waits for a renewal. Every renewal test
+// (TestLeaseRenew_HonorsT1, TestLeaseRenewIPv6_HonorsT1, the failure
+// suite) runs a single container. So the suite passed identically with
+// the bug present and absent, and the fix for it — a tmpfs over the
+// runtime dir — was covered only by a unit test asserting that string
+// appears in the generated mount script.
+//
+// The ordering is deliberate: the second container starts only after
+// the first is up and settled, so the first container's persistent
+// client is guaranteed live and holding the shared socket when the
+// second one starts. Concurrent starts would make the collision racy;
+// this makes it the expected case.
+//
+// Mechanism as in TestLeaseRenew_HonorsT1: an ephemeral fixture
+// advertising option 58/59 so renewal fires ~12s in rather than at half
+// of dnsmasq's hard 2m minimum lease. Self-validating — if renewal
+// never fires for either container, both assertions fail rather than
+// silently passing.
+func TestConcurrentRenew_SameInterfaceNameBothRenew(t *testing.T) {
+	const (
+		renewT1 = 12 // seconds; dhcpcd renews here, above its floor
+		renewT2 = 25 // seconds; rebind — kept past the wait window
+		// Let the first container's persistent client come up before
+		// the second starts: the client is spawned from a goroutine in
+		// Join, so returning from RunContainer does not imply it is
+		// running yet.
+		settle = 3 * time.Second
+		// Past T1 for the container that started last, comfortably
+		// before its T2.
+		waitFor = 20 * time.Second
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Second)
+	defer cancel()
+
+	netName := "dh-itest-corenew"
+
+	ef := harness.NewEphemeralFixture(t, harness.WithRenewTimes(renewT1, renewT2))
+	t.Cleanup(func() {
+		if t.Failed() {
+			ef.DumpLogs(func(s string) { t.Log(s) })
+		}
+	})
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{
+		"parent": harness.EphemeralHostVeth,
+	})
+
+	type ctr struct {
+		name      string
+		id        string
+		ip        string
+		mac       string
+		startACKs int
+	}
+	ctrs := make([]*ctr, 2)
+
+	for i := range ctrs {
+		name := fmt.Sprintf("dh-itest-corenew-ctr-%d", i)
+		id, ip, mac := harness.RunContainer(t, ctx, netName, name)
+		ctrs[i] = &ctr{name: name, id: id, ip: ip, mac: mac}
+		t.Logf("container %d up: ip=%s mac=%s", i, ip, mac)
+
+		if i == 0 {
+			select {
+			case <-ctx.Done():
+				t.Fatalf("context cancelled while settling: %v", ctx.Err())
+			case <-time.After(settle):
+			}
+		}
+	}
+
+	if ctrs[0].ip == ctrs[1].ip {
+		t.Fatalf("both containers got the same IP %s — the fixture pool is not handing out distinct leases", ctrs[0].ip)
+	}
+
+	// Count from here: the binds have happened, so any further ACK for
+	// a MAC is a renewal for that container specifically.
+	for i, c := range ctrs {
+		c.startACKs = ef.CountLogLines("DHCPACK", c.mac)
+		t.Logf("container %d: %d DHCPACK(s) at start of renewal window", i, c.startACKs)
+	}
+
+	t.Logf("waiting %s for both renewal cycles (T1=%ds, T2=%ds)...", waitFor, renewT1, renewT2)
+	select {
+	case <-ctx.Done():
+		t.Fatalf("context cancelled before renewal window: %v", ctx.Err())
+	case <-time.After(waitFor):
+	}
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	for i, c := range ctrs {
+		endACKs := ef.CountLogLines("DHCPACK", c.mac)
+		if endACKs <= c.startACKs {
+			t.Errorf("container %d (mac=%s, ip=%s): no renewal ACK in %s — %d ACK(s) before, %d after. "+
+				"Its persistent DHCP client is not renewing; the lease will lapse at expiry.",
+				i, c.mac, c.ip, waitFor, c.startACKs, endACKs)
+		} else {
+			t.Logf("container %d: renewed (%d -> %d ACKs)", i, c.startACKs, endACKs)
+		}
+
+		ins, err := cli.ContainerInspect(ctx, c.id)
+		if err != nil {
+			t.Fatalf("ContainerInspect(%s): %v", c.name, err)
+		}
+		var ipAfter string
+		for _, ep := range ins.NetworkSettings.Networks {
+			ipAfter = ep.IPAddress
+		}
+		if ipAfter != c.ip {
+			t.Errorf("container %d: IP changed across the renewal window: %s -> %s", i, c.ip, ipAfter)
+		}
+	}
+}


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — evidence only

This branch exists to prove that the new integration test in #330 actually detects the bug it claims to cover. It will be closed and deleted once the run finishes.

**A red integration run here is the expected and desired result.**

## The experiment

`TestConcurrentRenew_SameInterfaceNameBothRenew` was added to #330 alongside the runtime-dir isolation fix. Comparing #330 against `dev` would not prove much: nine behavioural changes differ between them, so a failure on `dev` could have any number of causes.

This branch is therefore **#330's head with exactly one change reverted** — `mountPrep` no longer shadows dhcpcd's runtime dir. The diff against #330's head is 1 insertion and 5 deletions, confined to `mountPrep` and its string assertion. Everything else — the FIFO fix, the retry loop, the stream-lifecycle and concurrency fixes, the test itself — is identical.

That isolates the single variable:

| Branch | Runtime-dir isolation | Expected |
|---|---|---|
| this control branch | reverted | new test **FAILS** |
| #330 head | present | new test **PASSES** |

If both hold, the test is proven to detect the control-socket collision specifically, rather than passing incidentally on a branch where many things changed.

## Why the test was needed

The suite was structurally blind to this bug. `TestConcurrency_DistinctLeases` is the only concurrent multi-container test and asserts only the initial IP/MAC — values produced by the one-shot client at CreateEndpoint — so it never observes a renewal. Every renewal test runs a single container. The suite therefore passed identically with the collision present and absent, and the fix for it was covered only by a unit test asserting the mount string appears in the generated script.

## Note on checks

The `attribution` check will show as expected-but-not-reported here: this branch predates that job landing on `dev`. Irrelevant for an evidence branch that is never merged.
