### PR TITLE
release: prepare v1.3.4 (version pins, release notes, docs review)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ like any other machine. Bridge, macvlan, and ipvlan attachment modes.
 Install the plugin:
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.3
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.4
 ```
 
 It requests `host` networking, the host PID namespace, the Docker
@@ -43,7 +43,7 @@ already have a host bridge `my-bridge` on your LAN — see
 [bridge mode](docs/bridge-mode.md) for that one-time setup):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.4 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 
 docker run --rm -ti --network my-dhcp-net alpine ip address show
@@ -137,9 +137,21 @@ Contributions are welcome.
     files must pass `shellcheck`/`actionlint`. These are enforced in CI.
   - **Tests:** new functionality is expected to ship with tests; a coverage
     ratchet enforces this at release time.
+  - **Authorship:** commits and pull request descriptions must not carry
+    AI-assistant attribution — no `Co-authored-by:` trailer naming an
+    assistant or an assistant's no-reply address, no "Generated with …"
+    line, no assistant session trailer or link — and the commit author must
+    be a person. Using an assistant to help write a change is fine and needs
+    no disclosure; what the project asks is that you sign the work as its
+    author and stand behind it. This is enforced by the `attribution` check,
+    which reads every commit in your PR — message *and* author identity,
+    since a rebase preserves authorship — plus the PR description. In the
+    description, code blocks and inline code are stripped before scanning,
+    so you can quote a trailer to discuss one, as here; commit messages are
+    scanned in full and have no such escape.
   - **Green CI:** every PR must pass the required checks — unit tests,
-    `staticcheck`, the live integration suite, `govulncheck`, and `actionlint` —
-    before it can be merged. (Docs-only PRs — diffs touching nothing but
+    `staticcheck`, the live integration suite, `govulncheck`, `actionlint`,
+    and `attribution` — before it can be merged. (Docs-only PRs — diffs touching nothing but
     `*.md` — satisfy the integration check via a fast in-job skip; any code,
     script, or workflow change runs the full suite.)
   - **Hosted cross-check:** a separate, *non-required* workflow runs the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -53,6 +53,90 @@ symlink-swap empty-file race, also daemon-side) are accepted with
 justification in `.github/vuln-allowlist.txt` (#291, #292) until a
 fixed release ships on the module path we depend on.
 
+As of v1.3.4 (#333), GO-2026-5746 is no longer reported by
+`govulncheck` and its allowlist entry has been removed — the
+assessment above is retained here as the audit trail. If it becomes
+reachable again the gate fails loudly rather than silently
+re-accepting it.
+
+## v1.3.4
+
+A patch release fixing three lease-lifecycle defects, one of which
+broke DHCP renewal outright whenever two containers shared an
+interface name — the ordinary case for anything using the default
+`eth0`. No new options, no manifest changes; existing networks keep
+working unchanged.
+
+What changed:
+
+- **Lease events could be lost between the client and the plugin**
+  (#332). The one-shot `dhcpcd` reports each lease over a FIFO. The
+  goroutine that reaped the exited client closed that FIFO
+  immediately, racing the goroutine still reading a `bound` event
+  sitting in the kernel pipe buffer. Under CPU load — a multi-service
+  `docker compose up` is the realistic trigger — the event was lost
+  about 4% of the time per acquisition (0% on an idle host), and the
+  container failed to start with `dhcpcd did not output a lease` even
+  though the server had granted one. The FIFO now has a dedicated
+  keep-alive writer: the reaper closes only the writer, and the reader
+  drains to a natural EOF, so the event cannot be dropped.
+- **`lease_timeout` is now a retry budget** (#332). Transient
+  acquisition failures are retried within it (500 ms plus jitter
+  between attempts) instead of aborting the container start on the
+  first one. Permanent failures — a missing interface, a malformed
+  option — still fail immediately rather than burning the whole
+  budget, and the error chain is preserved, so the existing 502
+  mapping, probe diagnostics, and stderr tails are unchanged. Reaching
+  the timeout now means the exchange genuinely never succeeded.
+- **Two containers on the same interface name broke each other's
+  renewals** (#332). `dhcpcd` keys both its state directory *and* its
+  runtime directory (pidfile, control socket) by interface name, with
+  no runtime override for either. The plugin isolated only the state
+  directory, so with two containers both on `eth0` the second client
+  found the first's control socket, forwarded its arguments to that
+  process and exited 0 — silently, with status 0 — without ever
+  running a client of its own. Its lease was then never renewed and
+  never released, while the first client reloaded the wrong
+  configuration. Both directories are now shadowed by a private
+  `tmpfs` in each client's own mount namespace. A new integration test
+  runs two containers past their renewal deadline and asserts each
+  gets its own ACKs; it fails on the pre-fix code.
+- **Concurrency and shutdown audit** (#332). Also fixed in the same
+  pass: two drain races where a `Start`/`Stop` error path closed the
+  netns and netlink handles while an event consumer was still live;
+  a failed start's late cleanup that could evict a newer healthy
+  manager from the registry (removal is now identity-checked); a
+  displaced manager left running when `Join` arrived over a recovered
+  endpoint; `Plugin.Close` now closes the HTTP server before draining
+  managers, so a `Join` arriving during shutdown cannot leak an
+  unstopped client; bridge-mode `DeleteEndpoint` tolerates an
+  already-vanished veth, matching macvlan; `interface not found` exits
+  are treated as terminal instead of retried; and `Finish` without a
+  preceding `Start` no longer panics.
+- **Goroutine and file-descriptor leak per DHCP client** (#332). The
+  logrus writer pipes wired to the client's stdout and stderr were
+  never closed, leaking two goroutines and a pipe pair per run. The
+  `SIGHUP` log-reopen path also swapped the logger's output without
+  logrus's mutex — a data race that could close the writer under an
+  active write; it uses `SetOutput` now.
+- Documentation: `docs/internals.md` now describes both directories
+  the private mount namespace shadows and why the runtime one matters,
+  and the `lease_timeout` entries in the reference and macvlan/ipvlan
+  docs describe the retry semantics. The contribution requirements in
+  the README now state the project's authorship rule, which has been a
+  required CI check since #335/#336 but was documented nowhere (#335).
+- CI and dependencies: the `govulncheck` gate now rejects an
+  inconclusive scan instead of passing on a verdict-less report, and
+  the stale `GO-2026-5746` allowlist entry is dropped now that it is
+  no longer reported (#333); dependency bumps for the Go toolchain
+  image, `golang.org/x/sys`, and eight pinned GitHub Actions (#326,
+  #327, #331).
+
+Thanks to **@jridgewell** for reporting the `dhcpcd did not output a
+lease` failures (#325) and for the initial retry patch — the retry
+behaviour above is that idea, reworked to keep permanent failures
+fast and the error chain intact.
+
 ## v1.3.3
 
 A patch release fixing a bug as old as the fork: containers running as

--- a/docs/bridge-mode.md
+++ b/docs/bridge-mode.md
@@ -37,7 +37,7 @@ sudo dhcpcd my-bridge
 ## 2. Create the network
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.4 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 ```
 
@@ -45,7 +45,7 @@ With IPv6 as well (the `docker network create --ipv6` flag does **not**
 work with the null IPAM driver; use the `ipv6` driver option instead):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.4 \
   --ipam-driver null -o bridge=my-bridge -o ipv6=true my-dhcp-net
 ```
 
@@ -100,7 +100,7 @@ services:
       - dhcp
 networks:
   dhcp:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.3
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.4
     driver_opts:
       bridge: my-bridge
       ipv6: 'true'

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ like any other machine. Bridge, macvlan, and ipvlan attachment modes.
 Install the plugin:
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.3
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.4
 ```
 
 It requests `host` networking, the host PID namespace, the Docker
@@ -35,7 +35,7 @@ already have a host bridge `my-bridge` on your LAN — see
 [Bridge mode](bridge-mode.md) for that one-time setup):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.4 \
   --ipam-driver null -o bridge=my-bridge my-dhcp-net
 
 docker run --rm -ti --network my-dhcp-net alpine ip address show

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -41,11 +41,17 @@ Two architectural notes about how the plugin drives `dhcpcd`:
   through a pipe the plugin opened — which is why the plugin ships a
   small handler binary rather than parsing client output. The plugin
   applies the resulting address/routes via netlink itself.
-- **Each client runs in a private mount namespace.** `dhcpcd` keys its
-  on-disk state by interface name and has no runtime override for that
-  location, so two containers whose link is the default `eth0` would
-  otherwise collide on the host's shared state directory. Isolating each
-  client in its own mount namespace keeps them independent.
+- **Each client runs in a private mount namespace.** `dhcpcd` keys *two*
+  on-disk locations by interface name, with no runtime override for
+  either: its **state** directory (lease files, DUID) and its **runtime**
+  directory (pidfile and control socket). Two containers whose link is
+  the default `eth0` would otherwise collide on both. The state collision
+  corrupts lease bookkeeping; the runtime collision is worse and silent —
+  the second client finds the first one's control socket, forwards its
+  arguments to that process and exits 0, so it never runs a client of its
+  own and its lease is never renewed or released (#332). The plugin
+  shadows both directories with a private `tmpfs` in each client's own
+  mount namespace, which keeps them fully independent.
 
 ## See also
 

--- a/docs/parent-attached-modes.md
+++ b/docs/parent-attached-modes.md
@@ -92,7 +92,7 @@ The host's NIC config (IP, routes, netplan/`systemd-networkd`,
 | `bridge`            | bridge           | yes      | Existing Linux bridge to plug veths into.                     |
 | `gateway`           | all              | no       | Override the IPv4 gateway returned by DHCP (e.g. when egress should go through a VPN router instead of the LAN's default gateway). |
 | `ipv6`              | all              | no       | Also run stateful DHCPv6 (a second `dhcpcd` with `-6`) in addition to DHCPv4 — see "DHCPv6" below for semantics and DUID/IAID identity. |
-| `lease_timeout`     | both      | no       | Initial-lease timeout for the up-front DHCP exchange (default `10s`). |
+| `lease_timeout`     | both      | no       | Budget for the up-front DHCP exchange (default `10s`). Since v1.3.4 this is a *retry* budget: transient failures are retried within it, so a hard timeout means the exchange never succeeded, not that one attempt was unlucky. |
 | `ignore_conflicts`  | bridge    | no       | Skip the bridge-already-in-use check. No-op in macvlan mode.  |
 | `skip_routes`       | all       | no       | Don't copy non-default static routes from the parent (bridge / macvlan parent NIC / ipvlan parent NIC) into the container. v0.9.0 extended this from bridge-only to all modes for parity (#102) — set `true` to restore pre-v0.9.0 macvlan/ipvlan no-copy behaviour. Since v1.3.0 it also suppresses DHCP-supplied classless static routes (option 121, #260 — see `reference.md`). |
 | `propagate_dns`     | all       | no       | (v0.9.0+) Write DHCP option 6 / 23 (DNS server list) into the container's `/etc/resolv.conf` on bind/renew. Off by default; turning it on overrides Docker's embedded resolver for this network. The `search` line uses option 119 (Domain Search List) when supplied, falling back to option 15 (`Domain`) otherwise. |
@@ -314,7 +314,7 @@ exact create incantation (note: the Docker-level `--ipv6` flag does
 NOT work with the null IPAM driver and is not what you want):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.4 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 -o ipv6=true \
     lan-dhcp6
@@ -583,7 +583,7 @@ endpoint operation everything is back to disk-served.
 Override the location via the `STATE_DIR` env var on the plugin:
 
 ```bash
-docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.3.3 STATE_DIR=/some/other/path
+docker plugin set ghcr.io/<your-namespace>/docker-net-dhcp:v1.3.4 STATE_DIR=/some/other/path
 ```
 
 ## Plugin env vars

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,7 +27,7 @@ The plugin publishes to two registries; GHCR is primary:
 for unattended):
 
 ```bash
-docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.3
+docker plugin install ghcr.io/claymore666/docker-net-dhcp:v1.3.4
 ```
 
 Privileges requested: `network: host`, host PID namespace, the Docker
@@ -96,7 +96,7 @@ You bring an existing Linux bridge that is L2-connected to the LAN
 (see [`bridge-mode.md`](bridge-mode.md) for the bridge setup itself):
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.4 \
     --ipam-driver null \
     -o bridge=my-bridge \
     my-dhcp-net
@@ -108,7 +108,7 @@ No host changes — containers get per-container kernel-generated MACs
 as macvlan children of a host NIC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.4 \
     --ipam-driver null \
     -o mode=macvlan -o parent=eth0 \
     lan-dhcp
@@ -122,7 +122,7 @@ security, hostile vSwitches, some Wi-Fi APs). The DHCP server must
 key reservations on DHCP option 61 (client identifier), not MAC:
 
 ```bash
-docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.3 \
+docker network create -d ghcr.io/claymore666/docker-net-dhcp:v1.3.4 \
     --ipam-driver null \
     -o mode=ipvlan -o parent=eth0 \
     lan-dhcp
@@ -147,7 +147,7 @@ Passed as `-o key=value` on `docker network create`, or under
 | `parent` | macvlan, ipvlan | *(required)* | v0.2.0 | Host NIC to attach children to (e.g. `eth0`, `ens18`). Must exist and be administratively `UP`. |
 | `gateway` | all | from DHCP | v0.3.0 | Override the IPv4 default gateway returned by the DHCP server — for split-horizon LANs where containers should egress via a different router (e.g. a VPN gateway). |
 | `ipv6` | all | `false` | upstream; functional again in v1.0.0 | Also run stateful DHCPv6 (a second `dhcpcd` with `-6`) alongside DHCPv4 — see the [DHCPv6 section](parent-attached-modes.md#dhcpv6-ipv6true) for semantics and DUID/IAID identity. The Docker-visible v6 address is renewed as of v1.2.0 (#152). |
-| `lease_timeout` | all | `10s` | upstream | Budget for the up-front DHCP exchange at container creation. Raise on slow/relayed networks (`-o lease_timeout=60s`). |
+| `lease_timeout` | all | `10s` | upstream | Budget for the up-front DHCP exchange at container creation. Since v1.3.4 it is a *retry* budget (#332): transient failures are retried inside it (500 ms plus jitter between attempts) until it expires, while permanent ones — a missing interface, a malformed option — still fail immediately. Raise on slow/relayed networks (`-o lease_timeout=60s`). |
 | `ignore_conflicts` | bridge | `false` | upstream | Skip the bridge-already-in-use check against other Docker networks. No-op in macvlan/ipvlan. |
 | `skip_routes` | all | `false` | upstream; all modes since v0.9.0 | Don't copy non-default static routes from the parent (bridge or NIC) into containers, **and** don't apply DHCP-supplied classless static routes (option 121, see below). v0.9.0 extended parent route-copying from bridge-only to all modes (#102); set `true` to restore the old macvlan/ipvlan no-copy behaviour. The default gateway is unaffected either way. |
 | `propagate_dns` | all | `false` | v0.9.0 | Write the DHCP-supplied DNS server list (option 6 / v6 option 23) into the container's `/etc/resolv.conf` on every bind/renew. Overrides Docker's embedded resolver for this network; the `search` line uses option 119 with fallback to option 15. |
@@ -242,7 +242,7 @@ Set with `docker plugin set <plugin> NAME=value`; take effect after
 JSON liveness + counters on the plugin's UNIX socket:
 
 ```bash
-PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.3.3)
+PLUGIN_ID=$(docker plugin inspect -f '{{.Id}}' ghcr.io/claymore666/docker-net-dhcp:v1.3.4)
 curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
     http://localhost/Plugin.Health | jq .
 ```
@@ -314,7 +314,7 @@ Compose-managed alternative (network lifecycle tied to the project):
 ```yaml
 networks:
   lan:
-    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.3
+    driver: ghcr.io/claymore666/docker-net-dhcp:v1.3.4
     driver_opts:
       mode: macvlan
       parent: eth0
@@ -335,7 +335,7 @@ above and issue #125).
 
 | symptom | likely cause | fix |
 | ------- | ------------ | --- |
-| `docker run` hangs then fails with a lease timeout | No DHCP reply on the parent L2 (isolated NIC, firewall on UDP 67/68, wrong VLAN) | Verify with `-o validate_dhcp=true` at create time; check the parent's connectivity; raise `-o lease_timeout` for slow/relayed networks |
+| `docker run` hangs then fails with a lease timeout | No DHCP reply on the parent L2 (isolated NIC, firewall on UDP 67/68, wrong VLAN). Since v1.3.4 transient failures are retried within `lease_timeout`, so reaching the timeout points at a persistent problem, not a one-off blip | Verify with `-o validate_dhcp=true` at create time; check the parent's connectivity; raise `-o lease_timeout` for slow/relayed networks |
 | `invalid rootfs in image configuration` at install | Old Docker engine | Upgrade Docker |
 | Network create fails `Bridge already in use` | Another Docker network owns the bridge | Use a dedicated bridge, or `-o ignore_conflicts=true` if the detection is wrong |
 | Container has an IP but `docker inspect` shows a different one | Mid-life re-acquisition after NAK/lease change | Expected degraded mode; watch `lease_changed` on `/Plugin.Health`; restart the container to resync Docker's view |


### PR DESCRIPTION
## What this changes

The v1.3.4 release preparation commit, landing on `dev` ahead of the release PR into `main`.

- **Version pins** bumped to `v1.3.4` across `README.md` and `docs/` via `scripts/bump-version.sh` (`check-version-pins.sh` passes).
- **`RELEASE_NOTES.md`** gains the `## v1.3.4` section, written from the merged commits: the lease-event FIFO race, `lease_timeout` becoming a retry budget, the `dhcpcd` runtime-directory collision that silently killed renewals for any second container on the same interface name, the concurrency/shutdown audit, and the per-client goroutine/fd leak — plus the CI and dependency work. Credit to @jridgewell for the report and the original retry idea.
- **Documentation review** (runbook step 3), all of it driven by what the release actually contains rather than by version-pin bumps:
  - `docs/internals.md` — the private-mount-namespace note explained the isolation purely in terms of `dhcpcd`'s on-disk *state* directory. The collision that broke renewals was the *runtime* directory (pidfile and control socket), which is the silent one. Both are now described, with the failure mode spelled out.
  - `docs/reference.md` and `docs/parent-attached-modes.md` — `lease_timeout` is a retry budget as of this release, not a single-attempt timeout. Both option tables say so, and the troubleshooting row notes that reaching the timeout now implies a persistent fault rather than a blip.
  - `README.md` — the contribution requirements gained an **Authorship** bullet, and `attribution` joins the required-checks list. That check has gated every PR since #336 but was documented nowhere, so an outside contributor could fail it with no way to find out why. Closes #335.
  - `RELEASE_NOTES.md` — the standing govulncheck-findings section records that `GO-2026-5746`'s allowlist entry is dropped in this release, so the assessment survives even though the entry does not.

## Related issue

Closes #335.

## Checklist

- [x] Branched off and targets `dev` (not `main`)
- [x] Tests added/updated for the change (the coverage ratchet is enforced at release) — documentation and version pins only; no code changes
- [x] Unit tests, `staticcheck`, and the integration suite pass
- [x] Docs (README / `docs/`) updated if behaviour or options changed — this PR *is* the documentation update
- [x] No secrets, credentials, or internal host details in the diff
