### PR TITLE
build(deps): bump pymdown-extensions from 10.21.3 to 11.0 in /docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -283,7 +283,7 @@ mergedeep==1.3.4 \
 mike==2.2.0 \
     --hash=sha256:1e3858e32c0f125aac14432fc7848434358f9ae0962c5c5cde387ad47f6ad25e \
     --hash=sha256:e1f4981c1152eec7c2490a3401142292cc47d686194188416db2648fdfe1d040
-    # via -r docs/requirements.in
+    # via -r requirements.in
 mkdocs==1.6.1 \
     --hash=sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2 \
     --hash=sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e
@@ -297,7 +297,7 @@ mkdocs-get-deps==0.2.2 \
 mkdocs-material==9.7.6 \
     --hash=sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69 \
     --hash=sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba
-    # via -r docs/requirements.in
+    # via -r requirements.in
 mkdocs-material-extensions==1.3.1 \
     --hash=sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443 \
     --hash=sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31
@@ -322,9 +322,9 @@ pygments==2.20.0 \
     --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
     --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
     # via mkdocs-material
-pymdown-extensions==10.21.3 \
-    --hash=sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354 \
-    --hash=sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6
+pymdown-extensions==11.0 \
+    --hash=sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589 \
+    --hash=sha256:fbc4acb641814fa9d17521bbd21a5240ef739a662f11c06330c4b78c93e954d6
     # via mkdocs-material
 pyparsing==3.3.2 \
     --hash=sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d \


### PR DESCRIPTION
## What this changes

`pymdown-extensions` **10.21.3 → 11.0** in `docs/requirements.txt`, the pinned toolchain for the documentation site. Dependabot's commit, cherry-picked onto current `dev` with authorship preserved — the original PR (#342) branched before the `attribution` gate landed and could not merge.

A major bump into a hash-pinned build deserves more than a green checkmark, so this was verified rather than assumed.

## Why 11.0 is safe here

The 11.0 breaking changes are:

- **`pymdownx.b64`** now restricts relative links to `base_path` by default (new `restrict_path` / `root_path` options). **We do not use `b64`.**
- **Python 3.9 support dropped.** The Pages workflow pins `python-version: "3.13"`, so this is a no-op.

The five extensions this project actually enables — `pymdownx.highlight`, `inlinehilite`, `snippets`, `superfences`, `tabbed` — carry only bug fixes in 11.0, including a `tabbed` fix for empty titles raising an exception.

## Verification

Built the site twice from the same source tree, once with each pin, in clean virtualenvs installed with `--require-hashes` exactly as CI does:

| | result |
| --- | --- |
| `mkdocs build --strict` @ 10.21.3 | exit 0, 55 files |
| `mkdocs build --strict` @ 11.0 | exit 0, 55 files |
| `diff -rq` between the two site trees | **exit 0 — byte-identical** |

The rendered output does not change at all: same file count, no differing bytes anywhere including the asset tree. Spot-checked that the extensions are genuinely exercised in the output rather than silently inert — the reference page alone renders 11 highlighted code blocks, 17 TOC permalinks, and 5 tables.

One thing worth naming so it isn't mistaken for fallout: the strict build prints a loud red `mkdocs-material` notice about a future MkDocs 2.0 being backward-incompatible. **It appears identically on the 10.21.3 baseline**, is emitted by `mkdocs-material` rather than this dependency, and is unrelated to this change.

## Related

Supersedes #342 (same commit, rebased so the `attribution` check can run).

## Checklist

- [x] Branched off and targets `dev` (not `main`)
- [x] Tests added/updated for the change (the coverage ratchet is enforced at release) — dependency pin only; verified by building the site with both pins and diffing the output
- [x] Unit tests, `staticcheck`, and the integration suite pass — no Go code changed
- [x] Docs (README / `docs/`) updated if behaviour or options changed — no content or behaviour change
- [x] No secrets, credentials, or internal host details in the diff
