### PR TITLE
ci(trivy): scan main on push so the default branch stops showing fixed CVEs

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -35,9 +35,18 @@ on:
       - 'Dockerfile'
       - '.trivyignore.yaml'
       - '.github/workflows/trivy.yml'
+  # `main` is here for a reason that is easy to miss: the Security tab
+  # and the alert list show the **default branch**. Scanning only `dev`
+  # meant a release merge never refreshed main's alerts, so findings
+  # already fixed on dev stayed visible on main until the Monday cron —
+  # up to a week of stale HIGH/MEDIUM alerts, and the week right after a
+  # release is exactly when someone looks. v1.3.4 shipped the Go 1.26.5
+  # base image that fixed CVE-2026-39822 and CVE-2026-42505; dev went
+  # clean immediately while main kept reporting both.
   push:
     branches:
       - dev
+      - main
     paths:
       - 'Dockerfile'
       - '.trivyignore.yaml'


### PR DESCRIPTION
## What this changes

Adds `main` to Trivy's push trigger. One line, plus the comment explaining why it matters.

## Why

The Security tab and the code-scanning alert list show the **default branch**. Trivy's push trigger covered only `dev`, so a release merge never refreshed `main`'s alerts — findings already fixed on `dev` stayed visible on `main` until the Monday cron happened to run.

This was found while triaging the open alerts, and it is not hypothetical:

- v1.3.4 shipped the `golang` base-image bump from **1.26.4 → 1.26.5** (in the deps batch, #339), which fixes **CVE-2026-39822** (HIGH — `os.Root` symlink traversal) and **CVE-2026-42505** (MEDIUM — `crypto/tls` ECH information disclosure).
- `dev` has had **zero** open code-scanning alerts since that merge.
- `main` still listed **four** instances of those two CVEs, every one pinned to the pre-release commit, because nothing rescanned it after the release.

So the repository was advertising two fixed vulnerabilities — one of them HIGH — for up to a week after shipping the fix, in exactly the week someone is most likely to look.

## Verification

Confirmed against the registry rather than inferred from the changelog:

| base-image pin | resolves to |
| --- | --- |
| `sha256:3ad5730…` (before #339) | `GOLANG_VERSION=1.26.4` — the flagged version |
| `sha256:0178a64…` (shipped in v1.3.4) | `GOLANG_VERSION=1.26.5` — the fixed version |

Alert state by ref: `refs/heads/dev` → none open; `refs/heads/main` → both CVEs, newest instance at the pre-v1.3.4 commit.

Neither CVE is reachable from this codebase — there is no `os.Root` and no `crypto/tls` use outside tests. That is why the `govulncheck` gate stayed green throughout: it matches on reachability, while Trivy matches on version and so flags the shipped binaries regardless. Both views are worth having, and neither is wrong.

The `paths` filter is deliberately the same as `dev`'s. The image builds from a pinned digest, so only a `Dockerfile`, `.trivyignore.yaml`, or workflow change can alter the result; scanning on every push to `main` would add runs that cannot report anything new.

I have separately dispatched a manual Trivy run on `main` to clear the currently stale alerts, since this change only takes effect from the next release merge onward.

## Checklist

- [x] Branched off and targets `dev` (not `main`)
- [x] Tests added/updated for the change (the coverage ratchet is enforced at release) — workflow trigger only; `actionlint` covers the file and passes
- [x] Unit tests, `staticcheck`, and the integration suite pass — no Go code changed
- [x] Docs (README / `docs/`) updated if behaviour or options changed — no user-visible change
- [x] No secrets, credentials, or internal host details in the diff
