### PR TITLE
chore(v1.3.5): runbook check list, util coverage floor, rc docs retirement, DeleteEndpoint tests

### DIFF
--- a/.github/coverage-baseline.txt
+++ b/.github/coverage-baseline.txt
@@ -69,7 +69,26 @@
 #   coverage dispatch; all other packages identical to the decimal
 #   across four runs now, so the +0.3 is attributable, not variance.
 #   Floor 0.3 under measured, same margin as the prior two decisions.
-github.com/devplayer0/docker-net-dhcp/pkg/util 88.0
+# v1.3.5 (#338, PR #349): pkg/util 88.0 -> 95.0. RAISED, but NOT earned
+#   by this cycle — the gap was already there and went unclaimed. Dev
+#   measured 88.7 on 2026-07-05 (coverage run 28738787076) and 95.5 the
+#   same day (run 28753476811); the jump came with the #317 ptrace fix
+#   (d652519), which let the plugin enter non-root netns and so made
+#   util's Await* poll paths actually execute. Stable at 95.5 across
+#   every run since, including v1.3.4's release measurement. Deferred
+#   from the v1.3.4 release PR to avoid another serialized coverage run
+#   on an otherwise-ready release. Floor set 0.5 under measured, the
+#   same margin as the decisions above.
+#
+#   pkg/plugin deliberately NOT raised: it measured 83.4 against a floor
+#   of 83.8 at v1.3.4, holding only via the 0.5 ratchet epsilon. The
+#   DeleteEndpoint tests in this PR are the first repayment (that
+#   handler went 0% -> 72.7% unit, and its not-found arm is unreachable
+#   from the integration suite, so it should move the merged number too
+#   — unlike the v1.3.4 lifecycle tests, which duplicated paths
+#   integration already covered and moved it 83.3 -> 83.4). Re-measure
+#   at the release PR and raise only what the number supports.
+github.com/devplayer0/docker-net-dhcp/pkg/util 95.0
 github.com/devplayer0/docker-net-dhcp/pkg/plugin 83.8
 github.com/devplayer0/docker-net-dhcp/pkg/dhcp 89.5
 github.com/devplayer0/docker-net-dhcp/cmd/net-dhcp 75.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -136,6 +136,21 @@ jobs:
             # Real release: publish this version and move latest + default.
             mike deploy --push --update-aliases "${REF}" latest
             mike set-default --push latest
+            # An rc's docs exist to be read during its dry-run window and
+            # are superseded the moment the real tag ships — but nothing
+            # used to remove them, so every rc since v1.2.0-rc1 stayed in
+            # the version selector forever, inviting someone to read (and
+            # pin) a build that was thrown away. Retire this release's own
+            # rcs; other versions are untouched.
+            # `mike list` prints "<version> [aliases]"; field 1 is the
+            # version. Anchored to this release's own rcs so an unrelated
+            # version can never match.
+            rcs=$(mike list 2>/dev/null | awk '{print $1}' \
+                    | grep -E "^${REF}-rc[0-9]+$" || true)
+            for rc in ${rcs}; do
+              echo "Retiring superseded pre-release docs: ${rc}"
+              mike delete --push "${rc}"
+            done
           elif [[ "${REF}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             # Pre-release (vX.Y.Z-rcN): preview only — no alias, no default move.
             mike deploy --push "${REF}"

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -199,9 +199,17 @@ the `vX.Y.Z` milestone (the workflow leans on this for the
    commit messages. Include any **operator-visible compatibility
    notes** (e.g. v0.8.0 narrowed the `IsDHCPPlugin` regex — that
    needed a callout).
-5. **PR `release/vX.Y.Z` → `dev`.** Required checks: `test`,
-   `staticcheck`, `integration` (every PR builds and exercises its
-   own plugin on the integration runner). Merge when green.
+5. **PR `release/vX.Y.Z` → `dev`.** Required checks on `dev` are
+   `test`, `staticcheck`, `integration` (every PR builds and exercises
+   its own plugin on the integration runner), `actionlint`,
+   `govulncheck`, `attribution`, and CodeQL's `Analyze (go)` +
+   `Analyze (actions)` — eight in total. Merge when green.
+
+   `main` requires those eight **plus `coverage`**, which is why the
+   ratchet first bites at the release PR in the next step and not
+   before. Branch protection is the authority here; if this list and
+   the settings disagree, the settings win and this list is the thing
+   to fix.
 6. **Open the release PR `dev` → `main`** with title
    `Release vX.Y.Z` and a `Closes #N` line for **every issue** in
    the milestone. The list is what auto-closes them when the PR

--- a/pkg/plugin/delete_endpoint_test.go
+++ b/pkg/plugin/delete_endpoint_test.go
@@ -1,0 +1,129 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// DeleteEndpoint had no unit coverage at all before #338: the
+// integration suite only ever exercises the path where the host veth
+// still exists, so the not-found arm — the one that keeps a forced
+// teardown from wedging `docker network rm` — was carried entirely by
+// code review. These tests cover it without root, since LinkByName on
+// a name that was never created fails the same way for any user.
+
+// deleteEndpointPlugin builds a plugin whose network options resolve
+// from disk, so DeleteEndpoint never reaches for the Docker API. The
+// fakeDocker errors on every call to prove that.
+func deleteEndpointPlugin(t *testing.T, networkID string, opts DHCPNetworkOptions) *Plugin {
+	t.Helper()
+
+	p := newTestPlugin(t)
+	p.docker = &fakeDocker{inspectErr: errors.New("DeleteEndpoint must not call docker")}
+	if err := saveOptions(networkID, opts); err != nil {
+		t.Fatalf("saveOptions: %v", err)
+	}
+	return p
+}
+
+func TestDeleteEndpoint_MissingHostVethIsNotAnError(t *testing.T) {
+	// A veth pair dies whole when the container side's netns goes away
+	// (`docker rm -f`, OOM-kill, a host reboot racing teardown), so by
+	// the time libnetwork calls DeleteEndpoint the host side is often
+	// already gone. Returning an error there 500s the RPC and can wedge
+	// `docker network rm` — the network keeps an endpoint it can never
+	// delete.
+	p := deleteEndpointPlugin(t, "net-missing", DHCPNetworkOptions{Bridge: "br-test"})
+
+	// An endpoint ID that was never created: vethPairNames derives
+	// "dh-<first 12 chars>", which cannot exist on the host.
+	err := p.DeleteEndpoint(context.Background(), DeleteEndpointRequest{
+		NetworkID:  "net-missing",
+		EndpointID: "e7a1c0ffee00deadbeef0000000000000000000000000000000000000000abcd",
+	})
+	if err != nil {
+		t.Fatalf("DeleteEndpoint with an absent host veth must succeed, got: %v", err)
+	}
+}
+
+func TestDeleteEndpoint_WritesTombstoneForBridgeMode(t *testing.T) {
+	// The tombstone is what carries MAC/IP across a container restart.
+	// It has to be laid down even when the link is already gone, or a
+	// forced teardown silently costs the container its address on the
+	// way back up.
+	const netID, epID, hostname = "net-tomb", "abcdef0123456789aaaa", "app-1"
+
+	p := deleteEndpointPlugin(t, netID, DHCPNetworkOptions{Bridge: "br-test"})
+	p.rememberEndpoint(epID, endpointFingerprint{
+		MAC:      "02:42:ac:11:00:01",
+		IPv4:     "192.168.0.166",
+		IPv6:     "2001:db8::1",
+		Hostname: hostname,
+	})
+
+	if err := p.DeleteEndpoint(context.Background(), DeleteEndpointRequest{
+		NetworkID: netID, EndpointID: epID,
+	}); err != nil {
+		t.Fatalf("DeleteEndpoint: %v", err)
+	}
+
+	mac, ipv4, ipv6, ok := p.consumeTombstone(netID, hostname)
+	if !ok {
+		t.Fatal("expected a tombstone for the deleted endpoint, found none")
+	}
+	if mac != "02:42:ac:11:00:01" || ipv4 != "192.168.0.166" || ipv6 != "2001:db8::1" {
+		t.Errorf("tombstone: got (%q, %q, %q), want the fingerprint's MAC/IPv4/IPv6", mac, ipv4, ipv6)
+	}
+
+	// The fingerprint is consumed, not merely copied — a second delete
+	// must not resurrect it.
+	if _, ok := p.takeEndpoint(epID); ok {
+		t.Error("fingerprint should have been taken by DeleteEndpoint")
+	}
+}
+
+func TestDeleteEndpoint_IPvlanSkipsTombstone(t *testing.T) {
+	// ipvlan children share the parent's MAC, so a tombstone would only
+	// hand back a MAC the kernel assigns anyway — recording one implies
+	// a per-container identity that does not exist in this mode.
+	const netID, epID, hostname = "net-ipvlan", "bbbbcccc11112222", "app-2"
+
+	p := deleteEndpointPlugin(t, netID, DHCPNetworkOptions{
+		Mode:   ModeIPvlan,
+		Parent: "eth-absent",
+	})
+	p.rememberEndpoint(epID, endpointFingerprint{
+		MAC:      "02:42:ac:11:00:02",
+		IPv4:     "192.168.0.167",
+		Hostname: hostname,
+	})
+
+	// The parent-attached delete path is best-effort about an absent
+	// link for the same reason the bridge path is.
+	if err := p.DeleteEndpoint(context.Background(), DeleteEndpointRequest{
+		NetworkID: netID, EndpointID: epID,
+	}); err != nil {
+		t.Fatalf("DeleteEndpoint (ipvlan, link absent): %v", err)
+	}
+
+	if _, _, _, ok := p.consumeTombstone(netID, hostname); ok {
+		t.Error("ipvlan must not leave a tombstone — the MAC is the parent's, not the container's")
+	}
+}
+
+func TestDeleteEndpoint_NetworkOptionsFailurePropagates(t *testing.T) {
+	// Disk miss plus a failing Docker inspect means the mode is unknown,
+	// so the handler cannot tell which teardown to run. That has to
+	// surface rather than be guessed at.
+	p := newTestPlugin(t)
+	p.docker = &fakeDocker{inspectErr: errors.New("inspect boom")}
+
+	err := p.DeleteEndpoint(context.Background(), DeleteEndpointRequest{
+		NetworkID:  "net-unknown",
+		EndpointID: "ffff0000ffff0000",
+	})
+	if err == nil {
+		t.Fatal("expected an error when the network options cannot be resolved")
+	}
+}


### PR DESCRIPTION
## What this changes

Four small v1.3.5 items, batched so they cost **one** integration slot on the serialized runner instead of four.

### 1. The runbook's required-checks list was wrong (#343)

Step 5 named three checks — `test`, `staticcheck`, `integration`. Branch protection actually requires **eight** on `dev` (those plus `actionlint`, `govulncheck`, `attribution`, and CodeQL's `Analyze (go)` / `Analyze (actions)`) and **nine** on `main`, the extra being `coverage`.

Under-reporting the gates by five, in the document that is meant to be the release procedure's single source of truth, is how a release-day surprise happens. The corrected text also records that branch protection is the authority, so a future divergence gets fixed here rather than argued about.

### 2. `pkg/util` coverage floor 88.0 → 95.0 (#338)

Deferred from the v1.3.4 release PR to avoid another serialized coverage run on an otherwise-ready release.

Worth being precise about *why* the gap exists, because it was never earned by a cycle: `dev` measured **88.7** and then **95.5** on the same day in July (coverage runs `28738787076` and `28753476811`). The jump arrived with the #317 ptrace fix — the plugin could suddenly enter non-root netns, so `pkg/util`'s `Await*` poll paths actually executed. It has been 95.5 on every run since, including v1.3.4's release measurement.

Floor set 0.5 under measured, the same margin as every decision above it in the file. **Replayed v1.3.4's measured numbers against the new baseline — still passes on every package.**

`pkg/plugin` is deliberately **not** raised: it measured 83.4 against a floor of 83.8 and holds only via the ratchet epsilon.

### 3. Retire superseded rc docs versions (#343)

An rc's documentation exists to be read during its dry-run window and is superseded the moment the real tag ships — but nothing ever removed it. Every rc since `v1.2.0-rc1` is still in the published version selector: **eight of them**, sitting next to seven real releases, inviting a reader to browse and pin a build that was deliberately thrown away.

A real release now deletes **its own** rcs and only its own — the pattern is anchored to the release being published, so an unrelated version can't match.

Correcting something I got wrong when filing #343: publishing rc docs at all is *not* a defect. `pages.yml` documents it as deliberate — an rc publishes a preview while `latest` and the site default stay put, mirroring the zero-impact dry-run guarantee `release.yml` gives images. The gap was only the missing retirement.

**Pre-existing rc versions are untouched by this PR** — that is a one-off `mike delete` against the live site, which I'd rather do as a separate, explicit step. Any of them can be republished from its tag with `gh workflow run pages.yml -f tag=vX.Y.Z-rcN`, so it is reversible.

### 4. `DeleteEndpoint` unit tests (#338)

The handler had **no unit coverage at all**. The integration suite only exercises the path where the host veth still exists, so the not-found arm — the one that stops a forced teardown (`docker rm -f`, OOM-kill, a reboot racing cleanup) from 500ing the RPC and wedging `docker network rm` — was carried by code review alone.

Four cases now cover it and the tombstone behaviour either side:

- an absent host veth is not an error;
- bridge mode records the tombstone that carries MAC/IP across a restart, and consumes the fingerprint;
- **ipvlan records none**, because its children share the parent MAC and a tombstone would imply a per-container identity that does not exist;
- an unresolvable network-options lookup propagates instead of guessing the teardown path.

No root required: `LinkByName` on a name that was never created fails identically for any user.

## Coverage impact

| | before | after |
| --- | --- | --- |
| `DeleteEndpoint` | 0% | **72.7%** |
| `deleteParentAttachedEndpoint` | — | **100%** |
| `pkg/plugin` unit total | 45.7% | 46.8% |

Unlike the v1.3.4 lifecycle tests — which duplicated paths integration already walked and moved the merged number only 83.3 → 83.4 — the not-found arm is unreachable from the integration suite, so this should show up in the merged measurement. I'd still re-measure at the release PR before raising that floor rather than predicting it.

## Verification

- `go build`, `go vet`, full unit suite, and `go test ./pkg/plugin/ -race -count=2`: pass.
- All **11** gate self-tests pass, including the coverage ratchet's own.
- `check-docs-drift.sh`, `check-option-docs.sh`, `check-version-pins.sh`, `check-manifest-parity.sh`: pass.
- `actionlint` clean on the modified `pages.yml` (the first draft embedded a Python heredoc that broke YAML parsing — rewritten in plain shell and re-linted).

## Related issues

Contributes to #343 and #338. Neither is fully closed: #343 still has nothing outstanding beyond the one-off rc cleanup noted above, and #338 keeps its two items that need real design work — `Close`'s late-`Join` window and the unbounded `go displaced.Stop()`.

## Checklist

- [x] Branched off and targets `dev` (not `main`)
- [x] Tests added/updated for the change (the coverage ratchet is enforced at release) — four new `DeleteEndpoint` cases; the ratchet change is replayed against v1.3.4's real numbers
- [x] Unit tests, `staticcheck`, and the integration suite pass
- [x] Docs (README / `docs/`) updated if behaviour or options changed — runbook corrected; no user-facing behaviour change
- [x] No secrets, credentials, or internal host details in the diff
