### PR TITLE
test(integration): make the failure suite prove the failure it injects (#278)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,10 +53,13 @@ permissions:
 jobs:
   integration:
     runs-on: [self-hosted, dhcp-ci]
-    # 35 = main suite (~10 min here, 558s measured on runner-class
-    # hardware, #146) + failure-injection suite (~10 min of mostly
-    # deliberate DHCP-timing waits, #128) + plugin build + margin.
-    timeout-minutes: 35
+    # 40 = main suite (~18 min measured) + failure-injection suite
+    # (~9 min of deliberate DHCP-timing waits, #128) + plugin build
+    # (~46s) + margin. Raised from 35 in #278: the failure tests now
+    # establish a BOUND lease before injecting the outage, so each one
+    # waits out a real 2m expiry instead of catching a client that was
+    # still acquiring — correct, and ~2 min slower across the suite.
+    timeout-minutes: 40
     env:
       INTEGRATION_PLUGIN_REF: ghcr.io/claymore666/docker-net-dhcp:integration
     steps:

--- a/Makefile
+++ b/Makefile
@@ -109,12 +109,18 @@ integration-test:
 # (lease expiry, NAK at T1) against per-test ephemeral DHCP servers —
 # ~9 serial minutes of mostly deliberate waiting, so it runs as its
 # own step instead of inflating the main suite's feedback loop.
+#
+# 20m, not 15m (#278): each test now waits for the persistent client's
+# own bind BEFORE killing the server, so the outage it injects has to
+# be detected the slow way — a bound 2m lease lapsing, plus up to one
+# 30s watchdog period. Three tests at a ~300s worst case each sat
+# exactly on the old 15m ceiling.
 integration-test-failure:
 	@if [ "$$(id -u)" -ne 0 ]; then \
 		echo "integration-test-failure must run as root. Re-run with sudo."; \
 		exit 1; \
 	fi
-	go test -v -tags integration -count=1 -timeout 15m -run 'TestFailure_' ./test/integration/...
+	go test -v -tags integration -count=1 -timeout 20m -run 'TestFailure_' ./test/integration/...
 
 # Manual orphan cleanup for when an integration test panics mid-setup
 # and leaves dh-itest-* interfaces / containers / networks behind.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -524,6 +524,13 @@ sudo curl -s --unix-socket /run/docker/plugins/$PLUGIN_ID/net-dhcp.sock \
 A plain `GET` is correct; no request body or method override is needed.
 Anything that can reach the socket can poll this as a liveness check.
 
+Every counter below is a **plugin-wide total**, not a per-endpoint one.
+A rise tells you *some* client on this host saw the event, never which
+one — so when a counter moves, the plugin log is what attributes it:
+each bump is emitted alongside a line carrying that endpoint's
+`endpoint=<short id>` field. Alerting on the counters is right;
+diagnosing a specific container from them alone is not.
+
 | field | healthy-affecting | meaning |
 | ----- | ----------------- | ------- |
 | `healthy` | — | `false` when `recovery_failed`, `join_start_failures`, or `tombstone_write_failures` is non-zero — an operator should look. The plugin keeps serving fresh attaches either way. |

--- a/test/integration/failure_test.go
+++ b/test/integration/failure_test.go
@@ -25,6 +25,27 @@
 //   - at expiry the plugin DELIBERATELY does NOT tear down the address
 //     on EXPIRE (would wipe copied routes, see dhcp_manager.go) — the
 //     container keeps its address through an outage.
+//
+// TWO RULES THIS FILE LEARNED THE HARD WAY (#278). Both cost almost
+// nothing to keep, and dropping either one silently guts these tests:
+//
+//  1. Establish that the persistent client is BOUND before injecting
+//     the failure. RunContainer returns as soon as docker reports an
+//     address, and that address comes from CreateEndpoint's one-shot
+//     lease — the long-lived client Join starts may not have confirmed
+//     its own lease yet. Kill the server inside that window and the
+//     client never leaves the "acquiring" state it starts in; the
+//     watchdog then fires within ~30s and the test goes green having
+//     never crossed the expiry it claims to exercise. Measured: both
+//     outage tests used to finish in ~77s, which is less than the one
+//     120s lease they were supposedly waiting out.
+//  2. Assert endpoint-scoped, not plugin-wide. Every health counter is
+//     a plugin-level total, so "dhcp_timeouts went up" is satisfied by
+//     ANY manager in the plugin, including an orphan left by an earlier
+//     test. Pair each counter assertion with the plugin's own
+//     endpoint=<short id> log line for the same event
+//     (harness.CountPluginLogLines), and assert it as a delta across
+//     the window so start-up churn cannot stand in for the real event.
 package integration
 
 import (
@@ -38,6 +59,17 @@ import (
 
 	"github.com/devplayer0/docker-net-dhcp/test/integration/harness"
 	docker "github.com/docker/docker/client"
+)
+
+// Plugin log messages that record a DHCP outage against ONE endpoint.
+// These sit next to the counter bumps in pkg/plugin — handleEvent's
+// "leasefail" and "renew"-with-changed-IP arms, and the outage
+// watchdog — and carry the manager's endpoint field, which the
+// counters themselves do not.
+const (
+	logLeaseFail = "dhcp failed to get a lease"
+	logWatchdog  = "DHCP server still unreachable"
+	logIPChanged = "dhcp renew with changed IP"
 )
 
 // failureHealth polls /Plugin.Health until cond is true or the budget
@@ -63,6 +95,30 @@ func failureHealth(t *testing.T, ctx context.Context, cli *docker.Client, budget
 	return last, false
 }
 
+// awaitBoundPersistentClient blocks until the plugin records a bind
+// beyond the pre-test baseline — i.e. the long-lived client started in
+// Join holds its OWN lease and the lease clock these tests wait out is
+// actually running. Rule 1 in this file's header.
+func awaitBoundPersistentClient(t *testing.T, ctx context.Context, cli *docker.Client, pre *harness.HealthResponse) {
+	t.Helper()
+	if _, ok := failureHealth(t, ctx, cli, 45*time.Second, func(h *harness.HealthResponse) bool {
+		return h.LeasesObtained > pre.LeasesObtained
+	}); !ok {
+		t.Fatal("persistent client never confirmed its own bind; the failure below would land on an acquiring client, not a bound one (#278)")
+	}
+}
+
+// outageLines counts, for one endpoint, the plugin-log records of the
+// two events that bump dhcp_timeouts: a leasefail (dhcpcd EXPIRE or
+// TIMEOUT) and an outage-watchdog tick. Returned separately because
+// which of the two fires is the diagnostic — a leasefail means dhcpcd
+// spoke, a watchdog line means the plugin synthesised the signal.
+func outageLines(t *testing.T, ctx context.Context, endpoint string) (leasefail, watchdog int) {
+	t.Helper()
+	return harness.CountPluginLogLines(t, ctx, endpoint, logLeaseFail),
+		harness.CountPluginLogLines(t, ctx, endpoint, logWatchdog)
+}
+
 // containerHasIP reports whether `ip -4 addr` inside the container
 // still shows the given address.
 func containerHasIP(t *testing.T, ctx context.Context, ctrID, ip string) bool {
@@ -86,13 +142,19 @@ func inRange(ip, start, end string) bool {
 // scenario. Intended behaviour asserted:
 //   - while the server is gone, the container KEEPS its address (the
 //     EXPIRE no-op), the plugin stays Healthy, and dhcp_timeouts
-//     records the failure;
+//     records the failure — for THIS endpoint, proven from the
+//     plugin's own log rather than from the plugin-wide counter alone;
 //   - when the server returns with its lease DB intact, the client
 //     re-binds to the SAME address (lease_changed stays flat) without
 //     operator intervention.
 func TestFailure_ServerLossDuringRenewal(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	// 8m, not 6m: the outage is only detectable after a bound lease
+	// lapses (~120s) plus up to one watchdog period, and the re-bind
+	// poll after the server returns adds up to 90s on top of that.
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
+
+	const netName = "dh-itest-floss"
 
 	ef := harness.NewEphemeralFixture(t)
 	t.Cleanup(func() {
@@ -108,27 +170,50 @@ func TestFailure_ServerLossDuringRenewal(t *testing.T) {
 	}
 	defer cli.Close()
 
-	harness.CreateNetwork(t, ctx, "dh-itest-floss", "macvlan", map[string]string{
+	pre, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("Plugin.Health (pre): %v", err)
+	}
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{
 		"parent": harness.EphemeralHostVeth,
 	})
-	id, ip, mac := harness.RunContainer(t, ctx, "dh-itest-floss", "dh-itest-floss-ctr")
+	id, ip, mac := harness.RunContainer(t, ctx, netName, "dh-itest-floss-ctr")
 	t.Logf("bound: ip=%s mac=%s", ip, mac)
+
+	awaitBoundPersistentClient(t, ctx, cli, pre)
+	ep := harness.EndpointShortID(t, ctx, cli, id, netName)
 
 	base, err := harness.PluginHealth(ctx, cli)
 	if err != nil {
 		t.Fatalf("Plugin.Health (baseline): %v", err)
 	}
+	baseFail, baseWatch := outageLines(t, ctx, ep)
+	if baseFail+baseWatch > 0 {
+		// Not fatal: one dhcpcd TIMEOUT during initial acquisition on a
+		// loaded runner is plausible and harmless. Asserting the delta
+		// below keeps the proof intact either way.
+		t.Logf("endpoint %s carried %d leasefail / %d watchdog line(s) from start-up; asserting on the delta", ep, baseFail, baseWatch)
+	}
 
-	// Kill the server uncleanly. The persistent client now faces
-	// silent T1/T2 retries, expiry, and a failing re-DISCOVER.
+	// Kill the server uncleanly. The persistent client — now provably
+	// holding its own lease — faces silent T1/T2 retries, expiry, and
+	// a failing re-DISCOVER.
+	killed := time.Now()
 	ef.Stop()
-	t.Log("server killed; waiting for the post-expiry leasefail (~130s)...")
+	t.Logf("server killed; a BOUND lease (fixture lease %s) has to lapse before the plugin can report a timeout", harness.LeaseTime)
 
-	h, ok := failureHealth(t, ctx, cli, 170*time.Second, func(h *harness.HealthResponse) bool {
+	h, ok := failureHealth(t, ctx, cli, 200*time.Second, func(h *harness.HealthResponse) bool {
 		return h.DHCPTimeouts > base.DHCPTimeouts
 	})
 	if !ok {
-		t.Fatalf("dhcp_timeouts never rose above %d during server outage (last: %+v)", base.DHCPTimeouts, h)
+		t.Fatalf("dhcp_timeouts never rose above %d within 200s of the server dying (last: %+v)", base.DHCPTimeouts, h)
+	}
+	nowFail, nowWatch := outageLines(t, ctx, ep)
+	t.Logf("dhcp_timeouts %d -> %d at t+%.0fs after the kill; endpoint %s logged +%d leasefail / +%d watchdog line(s)",
+		base.DHCPTimeouts, h.DHCPTimeouts, time.Since(killed).Seconds(), ep, nowFail-baseFail, nowWatch-baseWatch)
+	if (nowFail-baseFail)+(nowWatch-baseWatch) == 0 {
+		t.Errorf("dhcp_timeouts rose but the plugin logged no outage line for endpoint %s: the counter is plugin-wide, so this rise belongs to some other client and says nothing about the endpoint under test (#278)", ep)
 	}
 	if !h.Healthy {
 		t.Error("plugin went unhealthy during a server outage; a dead DHCP server is a degraded mode, not a plugin failure")
@@ -140,6 +225,7 @@ func TestFailure_ServerLossDuringRenewal(t *testing.T) {
 	// Server returns, lease DB intact: the dhcpcd retry loop must
 	// re-bind to the same address within ~30s (poll 90s for margin).
 	acksBefore := ef.CountLogLines("DHCPACK", mac)
+	restarted := time.Now()
 	ef.StartAgain()
 	t.Log("server restarted with preserved lease DB; awaiting re-bind...")
 
@@ -157,6 +243,7 @@ func TestFailure_ServerLossDuringRenewal(t *testing.T) {
 	if !recovered {
 		t.Fatal("no DHCPACK for the container's MAC within 90s of the server returning")
 	}
+	t.Logf("re-bound at t+%.0fs after the server came back", time.Since(restarted).Seconds())
 	if !containerHasIP(t, ctx, id, ip) {
 		t.Errorf("container's address changed across the outage; with a preserved lease DB it must re-bind to %s", ip)
 	}
@@ -188,8 +275,10 @@ func TestFailure_ServerLossDuringRenewal(t *testing.T) {
 // (TestHandleEvent_Counters) — when a server does NAK, that's the
 // path that counts it; any NAK observed here is logged for interest.
 func TestFailure_LeaseRefusedOnRenewal(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
+
+	const netName = "dh-itest-fref"
 
 	ef := harness.NewEphemeralFixture(t)
 	t.Cleanup(func() {
@@ -210,30 +299,30 @@ func TestFailure_LeaseRefusedOnRenewal(t *testing.T) {
 		t.Fatalf("Plugin.Health (pre): %v", err)
 	}
 
-	harness.CreateNetwork(t, ctx, "dh-itest-fref", "macvlan", map[string]string{
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{
 		"parent": harness.EphemeralHostVeth,
 	})
-	id, inspectIP, mac := harness.RunContainer(t, ctx, "dh-itest-fref", "dh-itest-fref-ctr")
+	id, inspectIP, mac := harness.RunContainer(t, ctx, netName, "dh-itest-fref-ctr")
 	t.Logf("bound: inspect ip=%s mac=%s", inspectIP, mac)
 
 	// Settle: wait for the persistent client's own bound (it can
 	// differ from CreateEndpoint's one-shot lease) so the baseline
 	// isn't polluted by start-up churn.
-	if _, ok := failureHealth(t, ctx, cli, 30*time.Second, func(h *harness.HealthResponse) bool {
-		return h.LeasesObtained > pre.LeasesObtained
-	}); !ok {
-		t.Fatal("persistent client never bound")
-	}
+	awaitBoundPersistentClient(t, ctx, cli, pre)
+	ep := harness.EndpointShortID(t, ctx, cli, id, netName)
+
 	base, err := harness.PluginHealth(ctx, cli)
 	if err != nil {
 		t.Fatalf("Plugin.Health (baseline): %v", err)
 	}
+	baseChanged := harness.CountPluginLogLines(t, ctx, ep, logIPChanged)
 
 	// Renumber the site: new server address, new pool, wiped DB. The
 	// unicast T1 renewal dies (the old server address is gone); the
 	// T2 broadcast rebind carries a foreign address; re-acquisition
 	// follows somewhere between T2 (105s) and expiry+rediscover
 	// (~135s).
+	renumbered := time.Now()
 	ef.RestartOnSubnet(harness.EphemeralAltServerAddr, harness.EphemeralAltPoolStart, harness.EphemeralAltPoolEnd)
 	t.Log("server renumbered; awaiting re-acquisition (T2 ~105s, expiry ~135s)...")
 
@@ -263,13 +352,20 @@ func TestFailure_LeaseRefusedOnRenewal(t *testing.T) {
 			harness.EphemeralAltPoolStart, harness.EphemeralAltPoolEnd,
 			harness.ExecOutput(t, ctx, id, "ip", "-4", "addr"))
 	}
-	t.Logf("re-acquired: live ip=%s", liveIP)
+	t.Logf("re-acquired: live ip=%s at t+%.0fs after the renumbering", liveIP, time.Since(renumbered).Seconds())
 
 	h, ok := failureHealth(t, ctx, cli, 30*time.Second, func(h *harness.HealthResponse) bool {
 		return h.LeaseChanged > base.LeaseChanged
 	})
 	if !ok {
 		t.Errorf("lease_changed never recorded the re-acquisition (last: %+v)", h)
+	}
+	// lease_changed is plugin-wide like every other counter. The
+	// address observed inside THIS container above is already
+	// endpoint-scoped evidence; the plugin's own log line for this
+	// endpoint is what ties the counter to it (#278).
+	if nowChanged := harness.CountPluginLogLines(t, ctx, ep, logIPChanged); nowChanged == baseChanged {
+		t.Errorf("endpoint %s re-addressed to %s but the plugin logged no lease-change line for it (%d before, %d after)", ep, liveIP, baseChanged, nowChanged)
 	}
 	if h != nil && !h.Healthy {
 		t.Error("plugin went unhealthy over a lease re-acquisition; this is a defined, healthy flow")
@@ -287,8 +383,8 @@ func TestFailure_LeaseRefusedOnRenewal(t *testing.T) {
 		t.Fatalf("ContainerInspect: %v", err)
 	}
 	var nowInspect string
-	for _, ep := range ins.NetworkSettings.Networks {
-		nowInspect = ep.IPAddress
+	for _, epView := range ins.NetworkSettings.Networks {
+		nowInspect = epView.IPAddress
 	}
 	if nowInspect != inspectIP {
 		t.Errorf("docker inspect reports %s; expected the stale original %s (documented degraded mode, #104)", nowInspect, inspectIP)
@@ -301,9 +397,15 @@ func TestFailure_LeaseRefusedOnRenewal(t *testing.T) {
 // the stale address, dhcp_timeouts keeps climbing as the retry loop
 // spins, and the plugin reports Healthy — "server gone" is a defined
 // degraded mode, not undefined behaviour.
+//
+// This is the test that leans hardest on rule 1 in the file header: a
+// lease that was never held cannot expire, so the bind wait below is
+// not hygiene, it is the entire premise.
 func TestFailure_LeaseExpiry(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
+
+	const netName = "dh-itest-fexp"
 
 	ef := harness.NewEphemeralFixture(t)
 	t.Cleanup(func() {
@@ -319,33 +421,60 @@ func TestFailure_LeaseExpiry(t *testing.T) {
 	}
 	defer cli.Close()
 
-	harness.CreateNetwork(t, ctx, "dh-itest-fexp", "macvlan", map[string]string{
+	pre, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("Plugin.Health (pre): %v", err)
+	}
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{
 		"parent": harness.EphemeralHostVeth,
 	})
-	id, ip, mac := harness.RunContainer(t, ctx, "dh-itest-fexp", "dh-itest-fexp-ctr")
+	id, ip, mac := harness.RunContainer(t, ctx, netName, "dh-itest-fexp-ctr")
 	t.Logf("bound: ip=%s mac=%s", ip, mac)
+
+	awaitBoundPersistentClient(t, ctx, cli, pre)
+	ep := harness.EndpointShortID(t, ctx, cli, id, netName)
 
 	base, err := harness.PluginHealth(ctx, cli)
 	if err != nil {
 		t.Fatalf("Plugin.Health (baseline): %v", err)
 	}
+	baseFail, baseWatch := outageLines(t, ctx, ep)
+	if baseFail+baseWatch > 0 {
+		t.Logf("endpoint %s carried %d leasefail / %d watchdog line(s) from start-up; asserting on the delta", ep, baseFail, baseWatch)
+	}
 
+	killed := time.Now()
 	ef.Stop()
-	t.Log("server killed permanently; crossing T2 and full expiry (~130s)...")
+	t.Logf("server killed permanently; a BOUND lease (fixture lease %s) now has to cross T2 and full expiry", harness.LeaseTime)
 
-	first, ok := failureHealth(t, ctx, cli, 170*time.Second, func(h *harness.HealthResponse) bool {
+	first, ok := failureHealth(t, ctx, cli, 200*time.Second, func(h *harness.HealthResponse) bool {
 		return h.DHCPTimeouts > base.DHCPTimeouts
 	})
 	if !ok {
-		t.Fatalf("dhcp_timeouts never rose above %d after lease expiry (last: %+v)", base.DHCPTimeouts, first)
+		t.Fatalf("dhcp_timeouts never rose above %d within 200s of the kill (last: %+v)", base.DHCPTimeouts, first)
+	}
+	firstFail, firstWatch := outageLines(t, ctx, ep)
+	t.Logf("first dhcp_timeouts rise %d -> %d at t+%.0fs after the kill; endpoint %s logged +%d leasefail / +%d watchdog line(s)",
+		base.DHCPTimeouts, first.DHCPTimeouts, time.Since(killed).Seconds(), ep, firstFail-baseFail, firstWatch-baseWatch)
+	if (firstFail-baseFail)+(firstWatch-baseWatch) == 0 {
+		t.Errorf("dhcp_timeouts rose but the plugin logged no outage line for endpoint %s: the counter is plugin-wide, so this rise belongs to some other client (#278)", ep)
 	}
 
-	// The retry loop must keep recording failures (~30s period).
+	// The retry loop must keep recording failures (~30s period), and
+	// keep recording them AGAINST THIS ENDPOINT — a watchdog that
+	// stalled on our client is invisible in the plugin-wide total.
 	second, ok := failureHealth(t, ctx, cli, 80*time.Second, func(h *harness.HealthResponse) bool {
 		return h.DHCPTimeouts > first.DHCPTimeouts
 	})
 	if !ok {
 		t.Errorf("dhcp_timeouts stalled at %d; the re-DISCOVER loop should keep recording failures (last: %+v)", first.DHCPTimeouts, second)
+	}
+	secondFail, secondWatch := outageLines(t, ctx, ep)
+	t.Logf("second dhcp_timeouts rise at t+%.0fs after the kill; endpoint %s now +%d leasefail / +%d watchdog line(s) since baseline",
+		time.Since(killed).Seconds(), ep, secondFail-baseFail, secondWatch-baseWatch)
+	if (secondFail-firstFail)+(secondWatch-firstWatch) == 0 {
+		t.Errorf("endpoint %s logged no further outage line while the server stayed down; the recurring signal is not recurring for this client (#278)", ep)
 	}
 	if second != nil && !second.Healthy {
 		t.Error("plugin went unhealthy on a permanent server loss; this is a defined degraded mode")

--- a/test/integration/failure_test.go
+++ b/test/integration/failure_test.go
@@ -13,18 +13,25 @@
 // `make integration-test-failure` (second CI step).
 //
 // dhcpcd timing facts the asserts below lean on (see pkg/dhcp):
-//   - a dead server produces NO event at T1/T2 (dhcpcd retries silently
-//     while re-discovering); the first internal "leasefail" comes from
-//     dhcpcd's EXPIRE when the bound lease finally lapses (at expiry),
-//     and the plugin's outage watchdog then increments dhcp_timeouts on
-//     a recurring ~30s period (dhcpOutageTick/Grace) while still
-//     acquiring. dhcp_timeouts therefore moves around expiry, not at T1.
+//   - a dead server produces NO event at T1/T2, and — the part this
+//     file originally got wrong, see #353 — no usable event at expiry
+//     either. Under `--noconfigure` dhcpcd reports a lapsed lease as
+//     RELEASE, which is indistinguishable from the one a graceful stop
+//     emits and so can never be counted as a loss. From the kill
+//     onward dhcpcd may say nothing at all.
+//   - dhcp_timeouts therefore moves on the plugin's OWN reckoning: the
+//     outage watchdog knows the granted lease lifetime
+//     (dhcp.Info.LeaseSeconds) and calls the outage once
+//     lastAffirmed + lease + grace has passed, re-checking on a ~30s
+//     tick (dhcpOutageTick/Grace). On the fixture's 120s lease that is
+//     145s after the last bind/renew, and up to ~175s because the tick
+//     phase is arbitrary. The budgets below are sized from that.
 //   - dhcpcd keeps re-DISCOVERing forever, so recovery after the server
 //     returns lands within ~30s, and while it's gone dhcp_timeouts keeps
 //     climbing on the watchdog's ~30s period.
-//   - at expiry the plugin DELIBERATELY does NOT tear down the address
-//     on EXPIRE (would wipe copied routes, see dhcp_manager.go) — the
-//     container keeps its address through an outage.
+//   - the plugin DELIBERATELY does NOT tear down the address when the
+//     lease lapses (would wipe copied routes, see dhcp_manager.go) —
+//     the container keeps its address through an outage.
 //
 // TWO RULES THIS FILE LEARNED THE HARD WAY (#278). Both cost almost
 // nothing to keep, and dropping either one silently guts these tests:
@@ -68,8 +75,21 @@ import (
 // counters themselves do not.
 const (
 	logLeaseFail = "dhcp failed to get a lease"
+	// The watchdog has two wordings and a bound client hits the second
+	// one FIRST: a lease that lapses unheard is reported as the
+	// deadline line, and only the repeat ticks after it say "still
+	// unreachable". Matching just one of the two would make these
+	// tests race the wording (#353).
 	logWatchdog  = "DHCP server still unreachable"
+	logLapse     = "passed its renewal deadline"
 	logIPChanged = "dhcp renew with changed IP"
+
+	// outageRiseBudget bounds the wait for the first dhcp_timeouts rise
+	// after a BOUND client's server dies. The plugin calls the outage at
+	// lastAffirmed + lease + grace (120s + 25s on the fixture) and only
+	// notices on its next ~30s tick, so the true worst case is ~175s;
+	// the rest is runner-load headroom.
+	outageRiseBudget = 240 * time.Second
 )
 
 // failureHealth polls /Plugin.Health until cond is true or the budget
@@ -109,14 +129,18 @@ func awaitBoundPersistentClient(t *testing.T, ctx context.Context, cli *docker.C
 }
 
 // outageLines counts, for one endpoint, the plugin-log records of the
-// two events that bump dhcp_timeouts: a leasefail (dhcpcd EXPIRE or
-// TIMEOUT) and an outage-watchdog tick. Returned separately because
-// which of the two fires is the diagnostic — a leasefail means dhcpcd
-// spoke, a watchdog line means the plugin synthesised the signal.
+// two events that bump dhcp_timeouts: a leasefail (a dhcpcd TIMEOUT
+// while acquiring) and an outage-watchdog tick. Returned separately
+// because which of the two fires is the diagnostic — a leasefail means
+// dhcpcd spoke, a watchdog line means the plugin synthesised the
+// signal from the lease deadline. For a client that was BOUND before
+// the server died, expect the watchdog: dhcpcd's lapse report is a
+// RELEASE and is deliberately dropped (#353).
 func outageLines(t *testing.T, ctx context.Context, endpoint string) (leasefail, watchdog int) {
 	t.Helper()
 	return harness.CountPluginLogLines(t, ctx, endpoint, logLeaseFail),
-		harness.CountPluginLogLines(t, ctx, endpoint, logWatchdog)
+		harness.CountPluginLogLines(t, ctx, endpoint, logWatchdog) +
+			harness.CountPluginLogLines(t, ctx, endpoint, logLapse)
 }
 
 // containerHasIP reports whether `ip -4 addr` inside the container
@@ -141,7 +165,7 @@ func inRange(ip, start, end string) bool {
 // TestFailure_ServerLossDuringRenewal: the "router rebooted at 3am"
 // scenario. Intended behaviour asserted:
 //   - while the server is gone, the container KEEPS its address (the
-//     EXPIRE no-op), the plugin stays Healthy, and dhcp_timeouts
+//     lapse no-op), the plugin stays Healthy, and dhcp_timeouts
 //     records the failure — for THIS endpoint, proven from the
 //     plugin's own log rather than from the plugin-wide counter alone;
 //   - when the server returns with its lease DB intact, the client
@@ -203,11 +227,11 @@ func TestFailure_ServerLossDuringRenewal(t *testing.T) {
 	ef.Stop()
 	t.Logf("server killed; a BOUND lease (fixture lease %s) has to lapse before the plugin can report a timeout", harness.LeaseTime)
 
-	h, ok := failureHealth(t, ctx, cli, 200*time.Second, func(h *harness.HealthResponse) bool {
+	h, ok := failureHealth(t, ctx, cli, outageRiseBudget, func(h *harness.HealthResponse) bool {
 		return h.DHCPTimeouts > base.DHCPTimeouts
 	})
 	if !ok {
-		t.Fatalf("dhcp_timeouts never rose above %d within 200s of the server dying (last: %+v)", base.DHCPTimeouts, h)
+		t.Fatalf("dhcp_timeouts never rose above %d within %s of the server dying (last: %+v)", base.DHCPTimeouts, outageRiseBudget, h)
 	}
 	nowFail, nowWatch := outageLines(t, ctx, ep)
 	t.Logf("dhcp_timeouts %d -> %d at t+%.0fs after the kill; endpoint %s logged +%d leasefail / +%d watchdog line(s)",
@@ -219,7 +243,7 @@ func TestFailure_ServerLossDuringRenewal(t *testing.T) {
 		t.Error("plugin went unhealthy during a server outage; a dead DHCP server is a degraded mode, not a plugin failure")
 	}
 	if !containerHasIP(t, ctx, id, ip) {
-		t.Errorf("container lost %s during the outage; the EXPIRE no-op should retain the address", ip)
+		t.Errorf("container lost %s during the outage; a lapsed lease is deliberately a no-op and should retain the address", ip)
 	}
 
 	// Server returns, lease DB intact: the dhcpcd retry loop must
@@ -448,11 +472,11 @@ func TestFailure_LeaseExpiry(t *testing.T) {
 	ef.Stop()
 	t.Logf("server killed permanently; a BOUND lease (fixture lease %s) now has to cross T2 and full expiry", harness.LeaseTime)
 
-	first, ok := failureHealth(t, ctx, cli, 200*time.Second, func(h *harness.HealthResponse) bool {
+	first, ok := failureHealth(t, ctx, cli, outageRiseBudget, func(h *harness.HealthResponse) bool {
 		return h.DHCPTimeouts > base.DHCPTimeouts
 	})
 	if !ok {
-		t.Fatalf("dhcp_timeouts never rose above %d within 200s of the kill (last: %+v)", base.DHCPTimeouts, first)
+		t.Fatalf("dhcp_timeouts never rose above %d within %s of the kill (last: %+v)", base.DHCPTimeouts, outageRiseBudget, first)
 	}
 	firstFail, firstWatch := outageLines(t, ctx, ep)
 	t.Logf("first dhcp_timeouts rise %d -> %d at t+%.0fs after the kill; endpoint %s logged +%d leasefail / +%d watchdog line(s)",

--- a/test/integration/failure_test.go
+++ b/test/integration/failure_test.go
@@ -8,7 +8,7 @@
 // are decided here rather than discovered in production.
 //
 // These tests cross real DHCP timing boundaries (the fixture lease
-// floor is 2m, so T1=60s, T2=105s, expiry=120s) and add ~9 serial
+// floor is 2m, so T1=60s, T2=105s, expiry=120s) and add ~11 serial
 // minutes — they are split out of the main suite into
 // `make integration-test-failure` (second CI step).
 //
@@ -143,6 +143,22 @@ func outageLines(t *testing.T, ctx context.Context, endpoint string) (leasefail,
 			harness.CountPluginLogLines(t, ctx, endpoint, logLapse)
 }
 
+// containerIPv4 returns the container's first non-loopback IPv4
+// address as seen inside its own netns, or "" if it has none.
+func containerIPv4(t *testing.T, ctx context.Context, ctrID string) string {
+	t.Helper()
+	for _, f := range strings.Fields(harness.ExecOutput(t, ctx, ctrID, "ip", "-4", "addr")) {
+		if !strings.Contains(f, "/") {
+			continue
+		}
+		bare := strings.SplitN(f, "/", 2)[0]
+		if ip := net.ParseIP(bare); ip != nil && ip.To4() != nil && !ip.IsLoopback() {
+			return bare
+		}
+	}
+	return ""
+}
+
 // containerHasIP reports whether `ip -4 addr` inside the container
 // still shows the given address.
 func containerHasIP(t *testing.T, ctx context.Context, ctrID, ip string) bool {
@@ -163,14 +179,30 @@ func inRange(ip, start, end string) bool {
 }
 
 // TestFailure_ServerLossDuringRenewal: the "router rebooted at 3am"
-// scenario. Intended behaviour asserted:
+// scenario, for an outage LONGER than the lease. Intended behaviour
+// asserted:
 //   - while the server is gone, the container KEEPS its address (the
 //     lapse no-op), the plugin stays Healthy, and dhcp_timeouts
 //     records the failure — for THIS endpoint, proven from the
 //     plugin's own log rather than from the plugin-wide counter alone;
-//   - when the server returns with its lease DB intact, the client
-//     re-binds to the SAME address (lease_changed stays flat) without
-//     operator intervention.
+//   - when the server returns, the client re-binds without operator
+//     intervention.
+//
+// It does NOT assert that the address survives, and cannot: the
+// outage is only detectable once the lease has lapsed (rise at
+// lease+grace = 145s, expiry at 120s), so by the time this test has
+// proven an outage the server's lease DB no longer holds the client's
+// address. Worse, the plugin's own retain-through-outage behaviour
+// makes the old address look occupied: the container is still
+// answering on it, dnsmasq pings before offering a freshly allocated
+// address, and hands out a different one. Observed exactly that —
+// DISCOVER requesting .21, OFFER .22.
+//
+// The same-address contract is real, but it belongs to an outage the
+// lease OUTLIVES; TestFailure_ServerReturnsBeforeExpiry owns it.
+// Asserting it here is what made the pre-#278 version of this test
+// green for the wrong reason: it finished in ~77s, inside the 120s
+// lease, so the server still held the entry and re-ACKed it.
 func TestFailure_ServerLossDuringRenewal(t *testing.T) {
 	// 8m, not 6m: the outage is only detectable after a bound lease
 	// lapses (~120s) plus up to one watchdog period, and the re-bind
@@ -268,15 +300,141 @@ func TestFailure_ServerLossDuringRenewal(t *testing.T) {
 		t.Fatal("no DHCPACK for the container's MAC within 90s of the server returning")
 	}
 	t.Logf("re-bound at t+%.0fs after the server came back", time.Since(restarted).Seconds())
-	if !containerHasIP(t, ctx, id, ip) {
-		t.Errorf("container's address changed across the outage; with a preserved lease DB it must re-bind to %s", ip)
+
+	// The address may or may not be the original one (see this test's
+	// header) — but whichever it is, the container and the server must
+	// agree on it. A re-bind that leaves the container holding an
+	// address the server has since given away is the failure mode worth
+	// catching here, and it is what the dropped same-address assertion
+	// was accidentally standing in for.
+	live := containerIPv4(t, ctx, id)
+	if live == "" {
+		t.Fatal("container has no IPv4 address after the server returned; the client did not recover")
 	}
+	if live != ip {
+		t.Logf("address changed across the outage: %s -> %s (expected when the outage outlives the lease)", ip, live)
+	}
+	if acked := ef.LastACKAddress(mac); acked != "" && acked != live {
+		t.Errorf("container holds %s but the server's last DHCPACK for %s was %s; the two have diverged", live, mac, acked)
+	}
+
+	after, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("Plugin.Health (after): %v", err)
+	}
+	if !after.Healthy {
+		t.Error("plugin still unhealthy after the server returned and the client re-bound")
+	}
+}
+
+// TestFailure_ServerReturnsBeforeExpiry: the same outage, but SHORT —
+// the server is back while the lease is still live. This is where the
+// address-stability contract belongs, and it is the common real case
+// (a router reboot takes well under a lease). Intended behaviour:
+//   - the client re-binds to the SAME address, because the server's
+//     lease DB still holds it;
+//   - lease_changed stays flat — no consumer sees a renumbering;
+//   - dhcp_timeouts stays flat for this endpoint: the outage never
+//     reached lease+grace, so there was nothing to report.
+//
+// Together with TestFailure_ServerLossDuringRenewal this pins both
+// sides of the boundary: inside the lease the address is guaranteed,
+// past it only recovery is.
+func TestFailure_ServerReturnsBeforeExpiry(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+
+	const netName = "dh-itest-fshort"
+
+	ef := harness.NewEphemeralFixture(t)
+	t.Cleanup(func() {
+		if t.Failed() {
+			ef.DumpLogs(func(s string) { t.Log(s) })
+			harness.DumpPluginLog(t)
+		}
+	})
+
+	cli, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer cli.Close()
+
+	pre, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("Plugin.Health (pre): %v", err)
+	}
+
+	harness.CreateNetwork(t, ctx, netName, "macvlan", map[string]string{
+		"parent": harness.EphemeralHostVeth,
+	})
+	id, ip, mac := harness.RunContainer(t, ctx, netName, "dh-itest-fshort-ctr")
+	t.Logf("bound: ip=%s mac=%s", ip, mac)
+
+	awaitBoundPersistentClient(t, ctx, cli, pre)
+	ep := harness.EndpointShortID(t, ctx, cli, id, netName)
+
+	base, err := harness.PluginHealth(ctx, cli)
+	if err != nil {
+		t.Fatalf("Plugin.Health (baseline): %v", err)
+	}
+	baseFail, baseWatch := outageLines(t, ctx, ep)
+
+	// Down and back up well inside the 120s lease. 60s is long enough
+	// to cross T1 (the renewal the client will fail) and short enough
+	// that the server's entry is still live when it returns.
+	acksBefore := ef.CountLogLines("DHCPACK", mac)
+	killed := time.Now()
+	ef.Stop()
+	t.Log("server stopped inside the lease; restarting in 60s (lease stays live throughout)")
+
+	select {
+	case <-time.After(60 * time.Second):
+	case <-ctx.Done():
+		t.Fatal("context expired during the short outage")
+	}
+	ef.StartAgain()
+	t.Logf("server back at t+%.0fs, still inside the lease; awaiting the renewal ACK...", time.Since(killed).Seconds())
+
+	deadline := time.Now().Add(90 * time.Second)
+	recovered := false
+	for time.Now().Before(deadline) {
+		if ef.CountLogLines("DHCPACK", mac) > acksBefore {
+			recovered = true
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	if !recovered {
+		t.Fatal("no DHCPACK for the container's MAC within 90s of the server returning inside the lease")
+	}
+	t.Logf("re-ACKed at t+%.0fs after the kill", time.Since(killed).Seconds())
+
+	// Both halves matter: the server must have handed the SAME address
+	// back (its own ACK is the authority), and the container must still
+	// be holding it. Checking only the container would pass on the
+	// plugin's retain-through-outage behaviour alone, without the
+	// server ever having agreed.
+	if acked := ef.LastACKAddress(mac); acked != ip {
+		t.Errorf("server's last DHCPACK for %s was %s, want %s; the lease was still live and must have been returned", mac, acked, ip)
+	}
+	if !containerHasIP(t, ctx, id, ip) {
+		t.Errorf("container's address changed across an outage the lease outlived; the server still held %s and must have returned it", ip)
+	}
+
 	after, err := harness.PluginHealth(ctx, cli)
 	if err != nil {
 		t.Fatalf("Plugin.Health (after): %v", err)
 	}
 	if after.LeaseChanged != base.LeaseChanged {
-		t.Errorf("lease_changed moved %d -> %d across an outage with a preserved lease DB; want flat", base.LeaseChanged, after.LeaseChanged)
+		t.Errorf("lease_changed moved %d -> %d across an outage shorter than the lease; want flat", base.LeaseChanged, after.LeaseChanged)
+	}
+	nowFail, nowWatch := outageLines(t, ctx, ep)
+	if d := (nowFail - baseFail) + (nowWatch - baseWatch); d != 0 {
+		t.Errorf("endpoint %s logged %d outage line(s) for an outage that never reached lease+grace; the watchdog fired early", ep, d)
+	}
+	if !after.Healthy {
+		t.Error("plugin unhealthy after an outage it should have ridden out silently")
 	}
 }
 

--- a/test/integration/harness/container.go
+++ b/test/integration/harness/container.go
@@ -155,6 +155,33 @@ func RunContainerUser(t *testing.T, ctx context.Context, networkName, containerN
 	return // unreachable
 }
 
+// EndpointShortID returns the first 12 characters of the container's
+// libnetwork endpoint id on networkName — the exact form the plugin
+// puts in its `endpoint=` log field (pkg/plugin.shortID).
+//
+// This is the join key between a test and the plugin's own record of
+// what it did to that endpoint, which is what makes an assertion
+// endpoint-scoped rather than plugin-wide (#278). See
+// CountPluginLogLines.
+func EndpointShortID(t *testing.T, ctx context.Context, cli *docker.Client, containerID, networkName string) string {
+	t.Helper()
+	ins, err := cli.ContainerInspect(ctx, containerID)
+	if err != nil {
+		t.Fatalf("ContainerInspect(%s): %v", containerID, err)
+	}
+	ep, ok := ins.NetworkSettings.Networks[networkName]
+	if !ok {
+		t.Fatalf("container %s is not attached to network %q", containerID, networkName)
+	}
+	if ep.EndpointID == "" {
+		t.Fatalf("container %s has no endpoint id on network %q", containerID, networkName)
+	}
+	if len(ep.EndpointID) < 12 {
+		return ep.EndpointID
+	}
+	return ep.EndpointID[:12]
+}
+
 // ExecOutput runs `docker exec` with the given args and returns
 // combined stdout+stderr as a string. Use for quick assertions like
 // `ip -4 addr show eth0` from inside a test container.

--- a/test/integration/harness/ephemeral.go
+++ b/test/integration/harness/ephemeral.go
@@ -4,6 +4,7 @@ package harness
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -396,6 +397,34 @@ func (ef *EphemeralFixture) CountLogLines(substrings ...string) int {
 		}
 	}
 	return count
+}
+
+// LastACKAddress returns the address in the most recent DHCPACK the
+// server logged for mac, or "" if it never ACKed one. dnsmasq writes
+// these as `DHCPACK(<iface>) <ip> <mac> [<hostname>]`, so the address
+// is the field after the DHCPACK token. Use it to check that the
+// container and the server agree on which address the container holds
+// — the container's own view alone cannot catch a divergence.
+func (ef *EphemeralFixture) LastACKAddress(mac string) string {
+	ef.t.Helper()
+	last := ""
+	for _, line := range strings.Split(ef.readLog(), "\n") {
+		l := strings.ToLower(line)
+		if !strings.Contains(l, "dhcpack") || !strings.Contains(l, strings.ToLower(mac)) {
+			continue
+		}
+		fields := strings.Fields(line)
+		for i, f := range fields {
+			if !strings.HasPrefix(f, "DHCPACK") || i+1 >= len(fields) {
+				continue
+			}
+			if ip := net.ParseIP(fields[i+1]); ip != nil && ip.To4() != nil {
+				last = fields[i+1]
+			}
+			break
+		}
+	}
+	return last
 }
 
 func (ef *EphemeralFixture) readLog() string {

--- a/test/integration/harness/health.go
+++ b/test/integration/harness/health.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -116,6 +117,40 @@ func ReadPluginLog(t *testing.T, ctx context.Context) string {
 		return ""
 	}
 	return string(data)
+}
+
+// CountPluginLogLines returns how many lines of the plugin log contain
+// every one of subs.
+//
+// The motivating use is attribution (#278). Health counters are
+// plugin-WIDE: `dhcp_timeouts` climbing proves that *some* client saw a
+// failure, not that the endpoint under test did. Every counter bump in
+// dhcpManager sits next to a log line carrying that manager's
+// `endpoint=<short id>` field, so passing an endpoint id plus the
+// message text turns a global observation into an endpoint-scoped one
+// without adding per-endpoint counters to the health surface.
+//
+// Counts, not booleans, so callers can assert on a DELTA across a
+// window and stay immune to start-up churn already in the log.
+func CountPluginLogLines(t *testing.T, ctx context.Context, subs ...string) int {
+	t.Helper()
+	if len(subs) == 0 {
+		return 0
+	}
+	n := 0
+	for _, line := range strings.Split(ReadPluginLog(t, ctx), "\n") {
+		matched := true
+		for _, sub := range subs {
+			if !strings.Contains(line, sub) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			n++
+		}
+	}
+	return n
 }
 
 // DumpPluginLog tails the plugin's /var/log/net-dhcp.log into t.Log.


### PR DESCRIPTION
Implements the re-scope agreed in #278 (see the re-evaluation comment there). The deferred watchdog-cadence knob is **not** in here — that decision stands.

## What was wrong

The timing table in #278 replicates exactly against a current run — 127.90s / 77.85s / 76.98s. What doesn't hold up is the story attached to it.

`TestFailure_LeaseExpiry` and `TestFailure_ServerLossDuringRenewal` **finish in less time than one lease lives**. The fixture lease is 120s and its clock starts at the *persistent* client's bind, ~15s into each test, so expiry cannot occur before t≈135s. `LeaseExpiry` passes at 77.85s having observed **two** `dhcp_timeouts` increments. Neither test can have been watching the post-expiry `EXPIRE` that its own output announces (*"crossing T2 and full expiry (~130s)"*).

Two independent causes, both fixed here:

**1. The precondition was never established.** `RunContainer` returns as soon as docker reports an address — and that address comes from `CreateEndpoint`'s one-shot lease, not from the long-lived client `Join` starts. Kill the server inside that window and the client never leaves the `acquiring` state it starts in; the outage watchdog fires ~30s later and the test goes green without the outage path it documents ever running. `LeaseRefusedOnRenewal` already had the settle wait for exactly this reason (*"it can differ from CreateEndpoint's one-shot lease"*); it is now generalised to all three.

**2. The assertions were plugin-wide.** Every health counter is a plugin-level total, so `dhcp_timeouts > base` is satisfied by *any* manager in the plugin — including an orphan left by an earlier test — while this endpoint's client sits perfectly idle. Each counter assertion is now paired with the plugin's own `endpoint=<short id>` log line for the same event, as a **delta** across the window so start-up churn can't substitute for the real event.

## What changed

- `harness.CountPluginLogLines(t, ctx, subs...)` — counts plugin-log lines matching all substrings; the join between a test and the plugin's record of what it did to *that* endpoint.
- `harness.EndpointShortID(...)` — the container's libnetwork endpoint id in the 12-char form `pkg/plugin.shortID` puts in the log field.
- All three tests: bind wait, endpoint-scoped delta assertions, and per-phase elapsed logging (`t+NNs after the kill`).
- `LeaseExpiry` additionally requires the *second* increment to also be attributable to this endpoint — a watchdog that stalled on our client is invisible in the total.
- `reference.md`: states that counters are plugin-wide totals and that the log is what attributes them. That's the trap that made this possible, and it applies to operators alerting on them, not just to tests.

## Cost, stated plainly

Waiting out a real expiry is the point, and it is **~2 minutes slower** across the failure suite: both outage tests go from ~77s to an expected ~200s. Package timeout 15m → 20m (three tests at a ~300s worst case sat exactly on the old ceiling); job timeout 35 → 40 min. Expected job wall-clock ~23 → ~27 min.

## Verified

`go build`, `go vet -tags integration ./...`, `gofmt -s`, `staticcheck`, unit suite, all 10 gate self-tests, `actionlint` on the changed workflow, docs-drift and option-docs gates — all pass locally.

**Not verified locally, by construction:** the integration suite itself. Everything above is a change to what the tests *assert*, so this PR's own `integration` run is the verification. Two outcomes are informative and neither is a flake:

- if the endpoint-scoped assertions pass, the elapsed logs tell us for the first time *when* and *why* `dhcp_timeouts` moves — which is the input the deferred cadence knob in #278 was estimated without;
- if they fail, the counter was being satisfied by another endpoint all along, which is the third hypothesis in the re-evaluation and a finding in its own right.
